### PR TITLE
feat: Add picture puzzle game

### DIFF
--- a/picture-game.css
+++ b/picture-game.css
@@ -13,25 +13,6 @@
     align-items: center;
 }
 
-#start-overlay {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    background-color: rgba(0, 0, 0, 0.5);
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    z-index: 10;
-}
-
-#start-text {
-    color: white;
-    font-size: 2rem;
-    font-weight: bold;
-}
-
 #puzzle-grid {
     display: grid;
     grid-template-columns: repeat(4, 100px);

--- a/picture-game.html
+++ b/picture-game.html
@@ -10,9 +10,6 @@
     <div id="game-container">
         <div id="puzzle-container">
             <div id="puzzle-grid"></div>
-            <div id="start-overlay">
-                <div id="start-text">Press Play</div>
-            </div>
             <div id="puzzle-controls">
                 <label for="difficulty">Difficulty:</label>
                 <select id="difficulty">

--- a/picture-game.js
+++ b/picture-game.js
@@ -6,7 +6,6 @@ document.addEventListener('DOMContentLoaded', () => {
     const stopButton = document.getElementById('stop-button');
     const scoreDisplay = document.getElementById('score');
     const timerDisplay = document.getElementById('timer');
-    const startOverlay = document.getElementById('start-overlay');
 
     const puzzles = [
         "https://raw.githubusercontent.com/Omoluabi1003/Ariyo-AI/main/Abuja%20City%20Gate.jfif",
@@ -174,18 +173,16 @@ document.addEventListener('DOMContentLoaded', () => {
     });
 
     startButton.addEventListener('click', () => {
-        startOverlay.style.display = 'none';
-        puzzleImage = puzzles[Math.floor(Math.random() * puzzles.length)];
-        showOriginalImage();
-        setTimeout(() => {
-            scramblePuzzle();
-            startTimer();
-            updateScore();
-        }, 10000);
+        scramblePuzzle();
+        startTimer();
+        updateScore();
     });
 
     stopButton.addEventListener('click', () => {
         clearInterval(timer);
-        startOverlay.style.display = 'flex';
+        showOriginalImage();
     });
+
+    puzzleImage = puzzles[Math.floor(Math.random() * puzzles.length)];
+    showOriginalImage();
 });


### PR DESCRIPTION
This commit introduces a new picture puzzle game to the web application.

The game is accessible from the edge panel and is displayed in a non-modal window, allowing you to interact with other parts of the application while the game is open.

The game features three difficulty levels (easy, medium, and hard) and uses a drag-and-drop interface for rearranging the puzzle tiles.

The game's color scheme is integrated with the application's existing theme.