### PR TITLE
Fix: Improve edge panel discoverability and fix watermark animation

### DIFF
--- a/main.html
+++ b/main.html
@@ -451,26 +451,6 @@
       text-shadow: 1px 1px 3px rgba(0,0,0,0.5);
       white-space: nowrap;
     }
-    @keyframes drift1 {
-      0% { transform: translate(0, 0) rotate(0deg); }
-      100% { transform: translate(200vw, 200vh) rotate(360deg); }
-    }
-    @keyframes drift2 {
-      0% { transform: translate(0, 0) rotate(0deg); }
-      100% { transform: translate(-200vw, -200vh) rotate(-360deg); }
-    }
-    @keyframes drift3 {
-      0% { transform: translate(0, 0) rotate(0deg); }
-      100% { transform: translate(200vw, -200vh) rotate(360deg); }
-    }
-    @keyframes drift4 {
-      0% { transform: translate(0, 0) rotate(0deg); }
-      100% { transform: translate(-200vw, 200vh) rotate(-360deg); }
-    }
-    .drift1 { animation: drift1 30s linear infinite; }
-    .drift2 { animation: drift2 30s linear infinite; }
-    .drift3 { animation: drift3 30s linear infinite; }
-    .drift4 { animation: drift4 30s linear infinite; }
     .exploding-watermark span {
         display: inline-block;
         animation: letter-explode 2s ease-in-out infinite;

--- a/scripts/ui.js
+++ b/scripts/ui.js
@@ -247,7 +247,21 @@ function toggleSabiBible() {
     let autoPopOutInterval;
 
     function autoPopOutEdgePanel() {
-        updateEdgePanelBehavior();
+        if (chatbotWindowOpen || edgePanel.classList.contains('visible')) return;
+
+        // Automatically pop out the panel shortly after page load
+        setTimeout(() => {
+            edgePanel.style.right = '0';
+            edgePanel.classList.add('visible');
+
+            // And retract it after a few seconds
+            setTimeout(() => {
+                if (!chatbotWindowOpen) { // Check again in case a panel was opened
+                    edgePanel.style.right = '-70px';
+                    edgePanel.classList.remove('visible');
+                }
+            }, 4000);
+        }, 2000);
     }
 
 function showNowPlayingToast(trackTitle) {


### PR DESCRIPTION
- I modified the edge panel to pop out and retract on page load, making it more discoverable for new users.
- I removed the conflicting 'drift' animation from the watermarks, allowing the 'exploding' animation to work as intended.