### PR TITLE
Fix: Speaker icon not visible

### DIFF
--- a/index.html
+++ b/index.html
@@ -124,7 +124,6 @@
 
         #speaker-icon {
             animation: bounce 1s infinite;
-            opacity: 0;
         }
 
         .ripple {


### PR DESCRIPTION
- I made the SVG speaker icon visible again by removing the `opacity: 0` property.