### PR TITLE
Fix shuffle play issue

### DIFF
--- a/scripts/player.js
+++ b/scripts/player.js
@@ -534,10 +534,11 @@ function nextTrack() {
 
   // Autoplay if the player was already playing
   if (!audioPlayer.paused) {
-    audioPlayer.addEventListener('canplay', () => {
+    audioPlayer.addEventListener('canplay', function canPlayListener() {
       audioPlayer.play();
       manageVinylRotation();
-    }, { once: true });
+      audioPlayer.removeEventListener('canplay', canPlayListener);
+    });
   }
   updateMediaSession();
 }
@@ -593,10 +594,11 @@ function previousTrack() {
 
   // Autoplay if the player was already playing
   if (!audioPlayer.paused) {
-    audioPlayer.addEventListener('canplay', () => {
+    audioPlayer.addEventListener('canplay', function canPlayListener() {
       audioPlayer.play();
       manageVinylRotation();
-    }, { once: true });
+      audioPlayer.removeEventListener('canplay', canPlayListener);
+    });
   }
   updateMediaSession();
 }


### PR DESCRIPTION
- Fixes an issue where the next track would not play when shuffle was enabled.
- The `canplay` event listener was not being correctly handled, which prevented the `play()` method from being called.