### PR TITLE
I've addressed the shuffle play issue again. Here's what I did:

### DIFF
--- a/scripts/player.js
+++ b/scripts/player.js
@@ -193,7 +193,7 @@ function selectTrack(src, title, index) {
       cacheButton.style.display = 'block'; // Show cache button
       document.getElementById('progressBar').style.display = 'block';
       progressBar.style.width = '0%';
-      handleAudioLoad(src, title, true);
+      handleAudioLoad(src, title, false);
       updateMediaSession();
       showNowPlayingToast(title);
     }


### PR DESCRIPTION
- I fixed a problem where the next track wouldn't play when shuffle was on.
- It turns out the `selectTrack` function was calling `handleAudioLoad` with `isInitialLoad` set to `true`, which stopped the track from playing automatically.