### PR TITLE
Fix: Adjust z-index for edge panel

### DIFF
--- a/main.html
+++ b/main.html
@@ -340,7 +340,7 @@
         background-color: rgba(0, 0, 0, 0.5);
         border-radius: 10px 0 0 10px;
         transition: right 0.3s ease-in-out;
-        z-index: 1001;
+        z-index: 1002;
     }
     .edge-panel.visible {
         right: 0;


### PR DESCRIPTION
Increased the z-index of the edge panel to ensure it is displayed above the media player on mobile devices.