### PR TITLE
Fix music player opacity

### DIFF
--- a/style.css
+++ b/style.css
@@ -87,7 +87,7 @@ body {
 
 /* Music Player */
 .music-player {
-    background: rgba(34, 34, 34, 0.7);
+    background: rgba(34, 34, 34, 0.5);
     padding: 1rem;
     text-align: center;
     border-radius: 10px;


### PR DESCRIPTION
## Summary
- reduce `.music-player` background opacity for improved visual lightness

## Testing
- `python3 - <<'EOF'
...` etc. (no tests present)


------
https://chatgpt.com/codex/tasks/task_e_68797a816a5c8332bdd5cd7760fd68a8