### PR TITLE
Fix album cover overflow

### DIFF
--- a/style.css
+++ b/style.css
@@ -96,6 +96,7 @@ body {
     bottom: calc(1rem + env(safe-area-inset-bottom));
     width: 100%;
     max-width: 800px;
+    overflow: visible;
     left: 50%;
     transform: translateX(-50%);
     z-index: 100;
@@ -108,7 +109,7 @@ body {
     width: clamp(120px, 30vw, 200px);
     height: clamp(120px, 30vw, 200px);
     border-radius: 50%;
-    margin: 0.6rem auto;
+    margin: 1rem auto;
     display: block;
     box-shadow: 0px 4px 15px rgba(255,255,255,0.3);
     transition: transform 0.3s ease-in-out;


### PR DESCRIPTION
## Summary
- allow `.music-player` contents to overflow
- add more spacing around the album cover so the disc clears the title area

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68797a863ba0833290334b21cf6d9901