### PR TITLE
Enhance word search gameplay

### DIFF
--- a/word-search.css
+++ b/word-search.css
@@ -9,20 +9,27 @@ body {
     margin: 0.5rem 0;
 }
 
+#board-container {
+    position: relative;
+    margin-bottom: 1rem;
+    touch-action: none;
+}
+
 #game-board {
     display: grid;
     grid-gap: 2px;
     border: 2px solid #333;
     padding: 5px;
+    max-width: 95vw;
+    overflow: auto;
 }
 
 .cell {
-    width: 30px;
-    height: 30px;
     text-align: center;
-    line-height: 30px;
     border: 1px solid #ccc;
     cursor: pointer;
+    user-select: none;
+    touch-action: none;
 }
 
 .selected {
@@ -52,6 +59,15 @@ body {
 
 .found {
     background-color: lightgreen;
+}
+
+#line-canvas {
+    position: absolute;
+    top: 0;
+    left: 0;
+    pointer-events: none;
+    width: 100%;
+    height: 100%;
 }
 
 #win-message {

--- a/word-search.html
+++ b/word-search.html
@@ -8,7 +8,10 @@
     <h1>Word Search</h1>
     <label for="category-select">Choose a category:</label>
     <select id="category-select"></select>
-    <div id="game-board"></div>
+    <div id="board-container">
+        <div id="game-board"></div>
+        <canvas id="line-canvas"></canvas>
+    </div>
     <ul id="word-list"></ul>
     <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.9.3/dist/confetti.browser.min.js"></script>
     <script src="word-search.js"></script>


### PR DESCRIPTION
## Summary
- prevent touch scrolling on the board and grid cells
- switch selection handlers to pointer events
- size the overlay canvas to match the board

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6879bbfd78f08332b4b4c8478b3ce8cf