### PR TITLE
Improve UI responsiveness

### DIFF
--- a/index.html
+++ b/index.html
@@ -118,12 +118,16 @@
             background-image: url('https://raw.githubusercontent.com/Omoluabi1003/Ariyo-AI/main/icons/speaker.png');
             background-size: contain;
             background-repeat: no-repeat;
-            width: 48px;
-            height: 48px;
+            width: 60px;
+            height: 60px;
         }
 
         #speaker-icon {
             animation: bounce 1s infinite;
+            width: 36px;
+            height: 36px;
+            fill: red;
+            stroke: red;
         }
 
         .ripple {
@@ -252,7 +256,7 @@
         </div>
         <div style="font-size: 0.8rem; margin-top: 1rem; font-weight: bold;">Click the speaker icon for sound</div>
         <div id="speaker-container" style="position: absolute; top: 1rem; right: 1rem; cursor: pointer;">
-            <svg id="speaker-icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="white" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon icon-tabler icons-tabler-outline icon-tabler-volume-off ripple shockwave"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M15 8a5 5 0 0 1 0 8" /><path d="M17.7 5a9 9 0 0 1 0 14" /><path d="M6 15h-2a1 1 0 0 1 -1 -1v-4a1 1 0 0 1 1 -1h2l3.5 -4.5a.8 .8 0 0 1 1.5 .5v14a.8 .8 0 0 1 -1.5 .5l-3.5 -4.5" /><path d="M12 12l0 .01" /></svg>
+            <svg id="speaker-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon icon-tabler icons-tabler-outline icon-tabler-volume-off ripple shockwave"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M15 8a5 5 0 0 1 0 8" /><path d="M17.7 5a9 9 0 0 1 0 14" /><path d="M6 15h-2a1 1 0 0 1 -1 -1v-4a1 1 0 0 1 1 -1h2l3.5 -4.5a.8 .8 0 0 1 1.5 .5v14a.8 .8 0 0 1 -1.5 .5l-3.5 -4.5" /><path d="M12 12l0 .01" /></svg>
         </div>
         <footer style="font-size: 0.7rem; margin-top: 2rem; color: #aaa;">
             <p>&copy; 2024 <a href="https://linkedin.com/in/paul-iyogun-7591a571" target="_blank" style="color: #00bcd4;">A Paul Iyogun (A.K.A. Omoluabi)</a> Project. All Rights Reserved.</p>

--- a/main.html
+++ b/main.html
@@ -168,6 +168,8 @@
       bottom: calc(1rem + env(safe-area-inset-bottom));
       width: 100%;
       max-width: 800px;
+      overflow-y: auto;
+      max-height: 90vh;
       left: 50%;
       transform: translateX(-50%);
       z-index: 100;

--- a/style.css
+++ b/style.css
@@ -96,7 +96,8 @@ body {
     bottom: calc(1rem + env(safe-area-inset-bottom));
     width: 100%;
     max-width: 800px;
-    overflow: visible;
+    overflow-y: auto;
+    max-height: 90vh;
     left: 50%;
     transform: translateX(-50%);
     z-index: 100;

--- a/word-search.css
+++ b/word-search.css
@@ -68,6 +68,15 @@ body {
     pointer-events: none;
 }
 
+@media (max-width: 480px) {
+    #game-board {
+        max-width: 90vw;
+    }
+    #word-list {
+        font-size: 0.8rem;
+    }
+}
+
 @keyframes blink {
     50% {
         opacity: 0;

--- a/word-search.js
+++ b/word-search.js
@@ -39,7 +39,11 @@ const categories = {
 
 let selectedCategory = Object.keys(categories)[0];
 let words = categories[selectedCategory];
-const gridSize = 15;
+let gridSize = window.innerWidth <= 480 ? 10 : 15;
+
+function updateGridSize() {
+    gridSize = window.innerWidth <= 480 ? 10 : 15;
+}
 
 function getCellSize() {
     const maxSize = 30;
@@ -298,6 +302,7 @@ function populateWordList() {
 }
 
 function startGame() {
+    updateGridSize();
     selectedCategory = document.getElementById("category-select").value;
     words = categories[selectedCategory];
     wordsInGame = pickWords(words, 10);
@@ -309,6 +314,12 @@ function startGame() {
 }
 
 function resizeBoard() {
+    const newSize = window.innerWidth <= 480 ? 10 : 15;
+    if (newSize !== gridSize) {
+        gridSize = newSize;
+        startGame();
+        return;
+    }
     const gameBoard = document.getElementById("game-board");
     const cellSize = getCellSize();
     gameBoard.style.gridTemplateColumns = `repeat(${gridSize}, ${cellSize}px)`;


### PR DESCRIPTION
## Summary
- enlarge and color welcome screen speaker icon
- constrain music player height to avoid clipping
- adjust board and word list for smaller screens
- adapt word search grid size on mobile

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687a3f9614988332ad3cd619d1c5e774