### PR TITLE
Make word search mobile friendly

### DIFF
--- a/word-search.css
+++ b/word-search.css
@@ -1,3 +1,24 @@
+@import url('https://fonts.googleapis.com/css?family=Lobster&display=swap');
+
+#game-title {
+    font-family: 'Lobster', cursive;
+    font-size: 3rem;
+    color: #00bcd4;
+    text-shadow: 2px 2px 4px #000000;
+    margin-bottom: 20px;
+}
+
+#game-title::before {
+    content: '';
+    display: inline-block;
+    width: 40px;
+    height: 40px;
+    margin-right: 10px;
+    background-image: url('https://raw.githubusercontent.com/Omoluabi1003/Ariyo-AI/main/logo.jpg');
+    background-size: contain;
+    background-repeat: no-repeat;
+}
+
 body {
     font-family: sans-serif;
     display: flex;

--- a/word-search.html
+++ b/word-search.html
@@ -1,11 +1,13 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Ara Word Search</title>
     <link rel="stylesheet" type="text/css" href="word-search.css">
 </head>
 <body>
-    <h1>Ara Word Search</h1>
+    <h1 id="game-title">Ara Word Search</h1>
     <label for="category-select">Choose a category:</label>
     <select id="category-select"></select>
     <button id="new-game-btn">New Game</button>


### PR DESCRIPTION
## Summary
- add charset and viewport metadata in `word-search.html`
- style word search title similarly to picture puzzle
- import Lobster font and use `game-title` styling for the word search

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687a4aa17ee88332ba5014b11e095e22