### PR TITLE
Improve mobile UI for puzzle and music player

### DIFF
--- a/picture-game.css
+++ b/picture-game.css
@@ -6,6 +6,7 @@
     color: #00bcd4;
     text-shadow: 2px 2px 4px #000000;
     margin-bottom: 20px;
+    text-align: center;
 }
 
 #game-title::before {
@@ -43,8 +44,11 @@
 #puzzle-grid {
     display: grid;
     border: 2px solid #333;
-    grid-template-columns: repeat(4, 100px);
-    grid-template-rows: repeat(3, 100px);
+    grid-template-columns: repeat(4, 1fr);
+    grid-template-rows: repeat(3, 1fr);
+    width: 80vw;
+    max-width: 400px;
+    aspect-ratio: 4 / 3;
 }
 
 .puzzle-tile {

--- a/picture-game.js
+++ b/picture-game.js
@@ -30,8 +30,12 @@ document.addEventListener('DOMContentLoaded', () => {
         puzzleGrid.innerHTML = '';
         const img = document.createElement('img');
         img.src = puzzleImage;
-        img.style.width = '400px';
-        img.style.height = '300px';
+        const boardWidth = Math.min(window.innerWidth * 0.8, 400);
+        const boardHeight = boardWidth * 0.75;
+        puzzleGrid.style.width = `${boardWidth}px`;
+        puzzleGrid.style.height = `${boardHeight}px`;
+        img.style.width = `${boardWidth}px`;
+        img.style.height = `${boardHeight}px`;
         puzzleGrid.appendChild(img);
     }
 
@@ -39,12 +43,14 @@ document.addEventListener('DOMContentLoaded', () => {
         puzzleGrid.innerHTML = '';
         tiles = [];
         const gridSize = Math.sqrt(tileCount);
-        const tileWidth = 400 / gridSize;
-        const tileHeight = 300 / gridSize;
+        const boardWidth = Math.min(window.innerWidth * 0.8, 400);
+        const boardHeight = boardWidth * 0.75;
+        const tileWidth = boardWidth / gridSize;
+        const tileHeight = boardHeight / gridSize;
         puzzleGrid.style.gridTemplateColumns = `repeat(${gridSize}, ${tileWidth}px)`;
         puzzleGrid.style.gridTemplateRows = `repeat(${gridSize}, ${tileHeight}px)`;
-        puzzleGrid.style.width = '400px';
-        puzzleGrid.style.height = '300px';
+        puzzleGrid.style.width = `${boardWidth}px`;
+        puzzleGrid.style.height = `${boardHeight}px`;
 
         let tileNumbers = Array.from({ length: tileCount - 1 }, (_, i) => i);
 
@@ -82,7 +88,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 tile.classList.add('empty-tile');
             } else {
                 tile.style.backgroundImage = `url(${puzzleImage})`;
-                tile.style.backgroundSize = `400px 300px`;
+                tile.style.backgroundSize = `${boardWidth}px ${boardHeight}px`;
                 const x = (tileNumbers[i] % gridSize) * tileWidth;
                 const y = Math.floor(tileNumbers[i] / gridSize) * tileHeight;
                 tile.style.backgroundPosition = `-${x}px -${y}px`;
@@ -142,8 +148,8 @@ document.addEventListener('DOMContentLoaded', () => {
         tile2.dataset.index = dataIndex1;
 
         const gridSize = Math.sqrt(tileCount);
-        const tileWidth = 400 / gridSize;
-        const tileHeight = 300 / gridSize;
+        const tileWidth = puzzleGrid.clientWidth / gridSize;
+        const tileHeight = puzzleGrid.clientHeight / gridSize;
 
         const emptyTile = document.querySelector('.empty-tile');
         const nonEmptyTile = tile1 === emptyTile ? tile2 : tile1;

--- a/style.css
+++ b/style.css
@@ -106,11 +106,15 @@ body {
     align-items: center;
 }
 
+.music-player h3 {
+    margin: 0.3rem 0;
+}
+
 .album-cover {
     width: clamp(120px, 30vw, 200px);
     height: clamp(120px, 30vw, 200px);
     border-radius: 50%;
-    margin: 1rem auto;
+    margin: 0.5rem auto;
     display: block;
     box-shadow: 0px 4px 15px rgba(255,255,255,0.3);
     transition: transform 0.3s ease-in-out;
@@ -165,17 +169,17 @@ body {
 }
 
 .track-info {
-    margin-top: 0.6rem;
+    margin-top: 0.3rem;
     font-size: clamp(1rem, 3vw, 1.2rem);
 }
 
 .track-duration {
     font-size: clamp(0.8rem, 2vw, 0.9rem);
-    margin-top: 0.3rem;
+    margin-top: 0.2rem;
 }
 
 .track-details {
-    margin-top: 0.6rem;
+    margin-top: 0.2rem;
     font-size: clamp(0.8rem, 2vw, 0.9rem);
 }
 


### PR DESCRIPTION
## Summary
- center the Ara puzzle title and make puzzle grid responsive
- update puzzle script to size grid dynamically for small screens
- tighten vertical spacing in the music player to keep album art visible on mobile

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687a504e59d883329bca29cca9f9802a