### PR TITLE
Improve responsive game layouts

### DIFF
--- a/picture-game.css
+++ b/picture-game.css
@@ -46,9 +46,7 @@
     border: 2px solid #333;
     grid-template-columns: repeat(4, 1fr);
     grid-template-rows: repeat(3, 1fr);
-    width: 80vw;
     max-width: 400px;
-    aspect-ratio: 4 / 3;
 }
 
 .puzzle-tile {

--- a/word-search.css
+++ b/word-search.css
@@ -51,8 +51,6 @@ body {
     padding: 5px;
     max-width: 95vw;
     overflow: auto;
-    aspect-ratio: 1 / 1;
-    width: 80vw;
 }
 
 .cell {

--- a/word-search.js
+++ b/word-search.js
@@ -74,7 +74,11 @@ function createBoard() {
     lineCanvas = document.getElementById("line-canvas");
     gameBoard.innerHTML = "";
     const cellSize = getCellSize();
+    const boardSize = cellSize * gridSize;
     gameBoard.style.gridTemplateColumns = `repeat(${gridSize}, ${cellSize}px)`;
+    gameBoard.style.gridTemplateRows = `repeat(${gridSize}, ${cellSize}px)`;
+    gameBoard.style.width = `${boardSize}px`;
+    gameBoard.style.height = `${boardSize}px`;
     board.length = 0;
     for (let i = 0; i < gridSize; i++) {
         const row = [];
@@ -329,7 +333,11 @@ function resizeBoard() {
     }
     const gameBoard = document.getElementById("game-board");
     const cellSize = getCellSize();
+    const boardSize = cellSize * gridSize;
     gameBoard.style.gridTemplateColumns = `repeat(${gridSize}, ${cellSize}px)`;
+    gameBoard.style.gridTemplateRows = `repeat(${gridSize}, ${cellSize}px)`;
+    gameBoard.style.width = `${boardSize}px`;
+    gameBoard.style.height = `${boardSize}px`;
     for (let i = 0; i < gridSize; i++) {
         for (let j = 0; j < gridSize; j++) {
             const cell = board[i][j];


### PR DESCRIPTION
## Summary
- ensure word search board sets width and height via JS
- remove fixed width and aspect ratio from CSS for the word search board
- remove width constraint from picture puzzle grid

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687a5309d4fc83328bf536804577623c