### PR TITLE
Fix: Bring About Us forward and make it mobile friendly

### DIFF
--- a/about.html
+++ b/about.html
@@ -142,6 +142,9 @@
         width: 100px;
         height: 100px;
       }
+      .about {
+        flex-direction: column;
+      }
     }
   </style>
 </head>

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -124,8 +124,7 @@
           aboutButtonGlobal.textContent = '🎵 Back to Player';
           aboutButtonGlobal.onclick = navigateToHome;
         }
-        mainContent.style.position = 'relative';
-        mainContent.style.zIndex = '101';
+        mainContent.classList.add('about-us-active');
         mainContent.style.opacity = '1';
 
       } catch (error) {
@@ -161,8 +160,7 @@
         aboutButtonGlobal.onclick = originalAboutButtonOnClick;
       }
 
-      mainContent.style.zIndex = '';
-      mainContent.style.position = '';
+      mainContent.classList.remove('about-us-active');
       gsap.to(mainContent, { opacity: 1, duration: 0.5 });
     }
 

--- a/scripts/ui.js
+++ b/scripts/ui.js
@@ -1,4 +1,5 @@
 function openAlbumList() {
+      document.getElementById('main-content').classList.remove('about-us-active');
       const modal = document.getElementById('albumModal');
       const modalContent = modal.querySelector('.modal-content');
 
@@ -54,6 +55,7 @@ function openAlbumList() {
     }
 
     function openRadioList() {
+      document.getElementById('main-content').classList.remove('about-us-active');
       updateRadioListModal();
       const modal = document.getElementById('radioModal');
       const modalContent = modal.querySelector('.modal-content');

--- a/style.css
+++ b/style.css
@@ -106,6 +106,11 @@ body {
     align-items: center;
 }
 
+.about-us-active {
+    position: relative;
+    z-index: 1001;
+}
+
 .music-player h3 {
     margin: 0.3rem 0;
 }


### PR DESCRIPTION
- The About Us page was loading behind the media player. This was fixed by adding a new CSS class `about-us-active` that sets a higher z-index and applying it to the main content area when the About Us page is loaded.
- The About Us page was also not mobile-friendly. This was fixed by adding a media query to the CSS to adjust the layout for smaller screens.