### PR TITLE
Fix puzzle grid border

### DIFF
--- a/picture-game.css
+++ b/picture-game.css
@@ -48,10 +48,13 @@
     grid-template-rows: repeat(3, 1fr);
     width: min(90vmin, 400px);
     aspect-ratio: 4 / 3;
+    box-sizing: border-box;
+    gap: 1px;
 }
 
 .puzzle-tile {
     border: 1px solid #ccc;
+    box-sizing: border-box;
     background-size: 400px 300px;
     cursor: pointer;
 }


### PR DESCRIPTION
## Summary
- make puzzle grid borders visible

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687a7074f6208332b3aa4189ec1a28f6