### PR TITLE
Fix word search grid layout

### DIFF
--- a/word-search.css
+++ b/word-search.css
@@ -49,7 +49,7 @@ body {
     grid-gap: 2px;
     border: 2px solid #333;
     padding: 5px;
-    width: min(95vmin, 95vw);
+    max-width: 95vw;
     overflow: auto;
     aspect-ratio: 1 / 1;
 }
@@ -104,6 +104,9 @@ body {
 }
 
 @media (max-width: 480px) {
+    #game-board {
+        max-width: 90vw;
+    }
     #word-list {
         font-size: 0.8rem;
     }


### PR DESCRIPTION
## Summary
- revert board width style to prevent vertical layout
- keep game board within viewport on mobile

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_687aa0df2f108332823f86ea1473f8ef