### PR TITLE
Reduce font size for word search tiles

### DIFF
--- a/word-search.js
+++ b/word-search.js
@@ -102,6 +102,7 @@ function createBoard() {
             cell.style.width = `${cellSize}px`;
             cell.style.height = `${cellSize}px`;
             cell.style.lineHeight = `${cellSize}px`;
+            cell.style.fontSize = `${Math.floor(cellSize * 0.6)}px`;
             cell.dataset.row = i;
             cell.dataset.col = j;
             cell.addEventListener("pointerdown", handlePointerDown);
@@ -439,6 +440,7 @@ function resizeBoard() {
             cell.style.width = `${cellSize}px`;
             cell.style.height = `${cellSize}px`;
             cell.style.lineHeight = `${cellSize}px`;
+            cell.style.fontSize = `${Math.floor(cellSize * 0.6)}px`;
         }
     }
     const boardRect = gameBoard.getBoundingClientRect();


### PR DESCRIPTION
## Summary
- adjust cell font size based on cell size when creating the board
- update resizeBoard so font size scales correctly on resize

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687acce6f6408332a0fe3fef9bd8a999