### PR TITLE
Adjust word search layout

### DIFF
--- a/word-search.css
+++ b/word-search.css
@@ -87,17 +87,17 @@ body {
     list-style: none;
     padding: 0;
     margin-top: 1rem;
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.5rem;
-    justify-content: center;
+    display: grid;
+    grid-template-columns: repeat(2, max-content);
+    gap: 0.25rem 0.5rem;
+    align-content: start;
 }
 
 #word-list li {
-    padding: 0.25rem 0.5rem;
+    padding: 0.25rem 0.4rem;
     border: 1px solid #ccc;
     border-radius: 4px;
-    font-size: 0.7rem;
+    font-size: 0.6rem;
 }
 
 #word-list li.found {
@@ -125,10 +125,10 @@ body {
         max-width: 90vw;
     }
     #word-list {
-        font-size: 0.8rem;
+        grid-template-columns: repeat(2, max-content);
     }
     #word-list li {
-        font-size: 0.6rem;
+        font-size: 0.5rem;
     }
 }
 

--- a/word-search.js
+++ b/word-search.js
@@ -59,7 +59,7 @@ let gridSize = window.innerWidth <= 480 ? 10 : 15;
 const GRID_GAP = 2; // must match CSS gap value
 const BOARD_PADDING = 5; // must match CSS padding
 const BOARD_BORDER = 2; // must match CSS border width
-const BOARD_SCALE = 0.8; // percentage of viewport used for board sizing
+const BOARD_SCALE = 0.9; // percentage of viewport used for board sizing
 
 function updateGridSize() {
     gridSize = window.innerWidth <= 480 ? 10 : 15;


### PR DESCRIPTION
## Summary
- enlarge word search board slightly so the bottom row is visible
- show the word list beside the board in two columns with smaller text

## Testing
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_e_687adee637048332b145bf0cf8b29890