### PR TITLE
Fix word search sizing

### DIFF
--- a/main.html
+++ b/main.html
@@ -280,20 +280,23 @@
     }
     .track-list a:hover, .album-list a:hover, .radio-list a:hover { background-color: #00bcd4; }
     .chatbot-container, .sabi-bible-container {
-      position: fixed;
-      bottom: calc(100px + env(safe-area-inset-bottom));
-      left: 50%;
-      transform: translateX(-50%);
-      width: 90%;
-      max-width: 600px;
-      height: 70vh;
-      border-radius: 10px;
-      box-shadow: 0px 4px 10px rgba(0,0,0,0.3);
-      background: white;
-      overflow: hidden;
-      display: none;
-      z-index: 10001;
-      position: relative;
+        position: fixed;
+        bottom: calc(100px + env(safe-area-inset-bottom));
+        left: 50%;
+        transform: translateX(-50%);
+        width: 90%;
+        max-width: 600px;
+        height: 70vh;
+        border-radius: 10px;
+        box-shadow: 0px 4px 10px rgba(0,0,0,0.3);
+        background: white;
+        overflow: hidden;
+        display: none;
+        z-index: 10001;
+        position: relative;
+    }
+    #wordSearchGameContainer {
+        height: 95vh;
     }
     .chatbot-container zapier-interfaces-chatbot-embed,
     .sabi-bible-container zapier-interfaces-chatbot-embed {

--- a/scripts/ui.js
+++ b/scripts/ui.js
@@ -181,6 +181,19 @@ function openWordSearchGame() {
     const wordSearchGameContainer = document.getElementById('wordSearchGameContainer');
     wordSearchGameContainer.style.display = 'block';
     updateEdgePanelBehavior();
+    const iframe = wordSearchGameContainer.querySelector('iframe');
+    if (!iframe) return;
+    const tryStart = () => {
+        if (iframe.contentWindow && typeof iframe.contentWindow.startGame === 'function') {
+            iframe.contentWindow.startGame();
+            iframe.removeEventListener('load', tryStart);
+        }
+    };
+    if (iframe.contentWindow && iframe.contentWindow.document.readyState === 'complete') {
+        tryStart();
+    } else {
+        iframe.addEventListener('load', tryStart);
+    }
 }
 
 function closeWordSearchGame() {

--- a/word-search.css
+++ b/word-search.css
@@ -2,7 +2,7 @@
 
 #game-title {
     font-family: 'Lobster', cursive;
-    font-size: 3rem;
+    font-size: 1.6rem;
     color: #00bcd4;
     text-shadow: 2px 2px 4px #000000;
     margin-bottom: 20px;
@@ -34,13 +34,29 @@ body {
 #new-game-btn {
     margin-bottom: 0.5rem;
     padding: 0.3rem 0.6rem;
-    font-size: 1rem;
+    font-size: 0.7rem;
     cursor: pointer;
 }
 
 #timer {
     margin-bottom: 0.5rem;
     font-weight: bold;
+}
+
+#controls {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    justify-content: center;
+    align-items: center;
+    margin-top: 1rem;
+}
+
+#controls label,
+#controls select,
+#controls button,
+#controls #timer {
+    font-size: 0.7rem;
 }
 
 #board-container {
@@ -61,6 +77,7 @@ body {
     grid-gap: 2px;
     border: 2px solid #333;
     padding: 5px;
+    box-sizing: border-box;
     max-width: 95vw;
     overflow: hidden;
     aspect-ratio: 1 / 1;
@@ -123,6 +140,15 @@ body {
     }
     #game-board {
         max-width: 90vw;
+    }
+    #game-title {
+        font-size: 1.2rem;
+    }
+    #controls label,
+    #controls select,
+    #controls button,
+    #controls #timer {
+        font-size: 0.6rem;
     }
     #word-list {
         grid-template-columns: repeat(2, max-content);

--- a/word-search.html
+++ b/word-search.html
@@ -8,16 +8,18 @@
 </head>
 <body>
     <h1 id="game-title">Ara Word Search</h1>
-    <label for="category-select">Choose a category:</label>
-    <select id="category-select"></select>
-    <button id="new-game-btn">New Game</button>
-    <div id="timer"></div>
     <div id="game-wrapper">
         <div id="board-container">
             <div id="game-board"></div>
             <canvas id="line-canvas"></canvas>
         </div>
         <ul id="word-list"></ul>
+        <div id="controls">
+            <label for="category-select">Category:</label>
+            <select id="category-select"></select>
+            <button id="new-game-btn">New Game</button>
+            <div id="timer"></div>
+        </div>
     </div>
     <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.9.3/dist/confetti.browser.min.js"></script>
     <script src="word-search.js"></script>

--- a/word-search.js
+++ b/word-search.js
@@ -59,7 +59,7 @@ let gridSize = window.innerWidth <= 480 ? 10 : 15;
 const GRID_GAP = 2; // must match CSS gap value
 const BOARD_PADDING = 5; // must match CSS padding
 const BOARD_BORDER = 2; // must match CSS border width
-const BOARD_SCALE = 0.9; // percentage of viewport used for board sizing
+const BOARD_SCALE = 0.8; // percentage of viewport used for board sizing
 
 function updateGridSize() {
     gridSize = window.innerWidth <= 480 ? 10 : 15;
@@ -92,8 +92,9 @@ function createBoard() {
     gameBoard.innerHTML = "";
     const cellSize = getCellSize();
     const boardSize = cellSize * gridSize + GRID_GAP * (gridSize - 1);
-    gameBoard.style.width = `${boardSize}px`;
-    gameBoard.style.height = `${boardSize}px`;
+    const containerSize = boardSize + BOARD_PADDING * 2;
+    gameBoard.style.width = `${containerSize}px`;
+    gameBoard.style.height = `${containerSize}px`;
     gameBoard.style.gridTemplateColumns = `repeat(${gridSize}, ${cellSize}px)`;
     board.length = 0;
     for (let i = 0; i < gridSize; i++) {
@@ -474,8 +475,9 @@ function resizeBoard() {
     const gameBoard = document.getElementById("game-board");
     const cellSize = getCellSize();
     const boardSize = cellSize * gridSize + GRID_GAP * (gridSize - 1);
-    gameBoard.style.width = `${boardSize}px`;
-    gameBoard.style.height = `${boardSize}px`;
+    const containerSize = boardSize + BOARD_PADDING * 2;
+    gameBoard.style.width = `${containerSize}px`;
+    gameBoard.style.height = `${containerSize}px`;
     gameBoard.style.gridTemplateColumns = `repeat(${gridSize}, ${cellSize}px)`;
     for (let i = 0; i < gridSize; i++) {
         for (let j = 0; j < gridSize; j++) {


### PR DESCRIPTION
## Summary
- start the embedded word search after the iframe loads
- resize the popup window to reduce scrolling
- place controls beneath the word list in smaller fonts
- keep every board row visible by using padding when setting width/height

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687ae30c8e408332a350b6e4c2954d2c