### PR TITLE
Fix word search grid clipping

### DIFF
--- a/word-search.css
+++ b/word-search.css
@@ -87,6 +87,7 @@ body {
 }
 
 .cell {
+    box-sizing: border-box;
     text-align: center;
     border: 1px solid #ccc;
     cursor: pointer;


### PR DESCRIPTION
## Summary
- prevent bottom row from being clipped in word search by accounting for cell borders

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687bddf8bf108332882c3e16c811e265