### PR TITLE
Fix word search layout

### DIFF
--- a/word-search.css
+++ b/word-search.css
@@ -50,6 +50,7 @@ body {
     justify-content: center;
     align-items: center;
     margin-top: 1rem;
+    width: 100%;
 }
 
 #controls label,
@@ -70,6 +71,7 @@ body {
     flex-wrap: wrap;
     gap: 1rem;
     justify-content: center;
+    align-items: flex-start;
 }
 
 #game-board {
@@ -87,6 +89,7 @@ body {
 }
 
 .cell {
+    box-sizing: border-box;
     text-align: center;
     border: 1px solid #ccc;
     cursor: pointer;
@@ -101,7 +104,7 @@ body {
 #word-list {
     list-style: none;
     padding: 0;
-    margin-top: 1rem;
+    margin: 0 0 0 1rem;
     display: grid;
     grid-template-columns: repeat(2, max-content);
     gap: 0.25rem 0.5rem;
@@ -150,6 +153,7 @@ body {
     }
     #word-list {
         grid-template-columns: repeat(2, max-content);
+        margin: 1rem 0 0 0;
     }
     #word-list li {
         font-size: 0.5rem;


### PR DESCRIPTION
## Summary
- move word list next to the grid for better centering
- keep controls on their own row

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687bddf8bf108332882c3e16c811e265