### PR TITLE
Ensure PWA cache updates automatically

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -335,16 +335,31 @@
     if ('serviceWorker' in navigator) {
       window.addEventListener('load', function() {
         showIosInstallBanner();
-        navigator.serviceWorker.getRegistrations().then(function(registrations) {
-          for(let registration of registrations) {
-            registration.unregister();
-          }
-        }).then(function() {
-          navigator.serviceWorker.register('/service-worker.js').then(function(registration) {
+        navigator.serviceWorker.register('service-worker.js', { updateViaCache: 'none' })
+          .then(function(registration) {
             console.log('Service Worker registered with scope:', registration.scope);
+
+            if (registration.waiting) {
+              registration.waiting.postMessage({ type: 'SKIP_WAITING' });
+            }
+
+            registration.addEventListener('updatefound', () => {
+              const newWorker = registration.installing;
+              newWorker.addEventListener('statechange', () => {
+                if (newWorker.state === 'installed' && navigator.serviceWorker.controller) {
+                  newWorker.postMessage({ type: 'SKIP_WAITING' });
+                }
+              });
+            });
           }).catch(function(error) {
             console.log('Service worker registration failed:', error);
           });
+
+        let refreshing = false;
+        navigator.serviceWorker.addEventListener('controllerchange', () => {
+          if (refreshing) return;
+          refreshing = true;
+          window.location.reload();
         });
       });
     }

--- a/service-worker.js
+++ b/service-worker.js
@@ -3,15 +3,15 @@ let CACHE_NAME;
 
 self.addEventListener('install', event => {
   event.waitUntil(
-    fetch('/version.json')
+    fetch('version.json', { cache: 'no-store' })
       .then(response => response.json())
       .then(data => {
         CACHE_NAME = `${CACHE_PREFIX}-${data.version}`;
         const urlsToCache = [
-          '/',
-          '/index.html',
-          '/main.html',
-          '/manifest.json',
+          './',
+          'index.html',
+          'main.html',
+          'manifest.json',
           'icons/Ariyo.png',
           'scripts/data.js',
           'scripts/player.js',
@@ -27,6 +27,7 @@ self.addEventListener('install', event => {
         });
       })
   );
+  self.skipWaiting();
 });
 
 self.addEventListener('activate', event => {
@@ -77,6 +78,10 @@ self.addEventListener('fetch', event => {
 });
 
 self.addEventListener('message', event => {
+  if (event.data && event.data.type === 'SKIP_WAITING') {
+    self.skipWaiting();
+    return;
+  }
   if (event.data && event.data.type === 'CACHE_TRACK') {
     const trackUrl = event.data.url;
     event.waitUntil(

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "157a9a8"
+  "version": "157a9aa"
 }


### PR DESCRIPTION
## Summary
- force service worker to always fetch fresh `version.json`
- skip waiting and reload clients when a new service worker installs
- update the service worker registration logic
- bump cached version number

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687c09c536f4833296fe9c80e789bbe1