### PR TITLE
Fix duplicate audio element

### DIFF
--- a/main.html
+++ b/main.html
@@ -598,7 +598,6 @@
       aria-label="Seek bar for audio playback"
       aria-controls="audioPlayer"
     />
-    <audio id="audioPlayer" src="https://raw.githubusercontent.com/Omoluabi1003/Ariyo-AI/main/A%20Very%20Good%20Bad%20Guy%20v3.mp3"></audio>
     <button id="retryButton" class="retry-button" onclick="retryTrack()" aria-label="Retry loading track">Retry</button>
     <button id="cacheButton" class="retry-button" onclick="cacheTrackForOffline(albums[currentAlbumIndex].tracks[currentTrackIndex].src)" aria-label="Download track for offline playback">Download for Offline</button>
     <div class="dropdown" role="button" aria-label="Choose a track" onclick="openTrackList()" aria-haspopup="true" aria-expanded="false">🎵 Choose A Track</div>

--- a/scripts/player.js
+++ b/scripts/player.js
@@ -1,5 +1,5 @@
 /* MUSIC PLAYER LOGIC */
-    const audioPlayer = new Audio();
+    const audioPlayer = document.getElementById('audioPlayer') || new Audio();
     audioPlayer.crossOrigin = "anonymous";
     const audioContext = new (window.AudioContext || window.webkitAudioContext)();
     let isAudioContextResumed = false;
@@ -14,8 +14,10 @@
     }
 
     audioPlayer.id = 'audioPlayer';
-    audioPlayer.preload = 'auto';
-    document.body.appendChild(audioPlayer);
+    audioPlayer.preload = 'metadata';
+    if (!document.getElementById('audioPlayer')) {
+        document.body.appendChild(audioPlayer);
+    }
     const albumCover = document.getElementById('albumCover');
     const trackInfo = document.getElementById('trackInfo');
     const trackArtist = document.getElementById('trackArtist');


### PR DESCRIPTION
## Summary
- ensure there's only one audio player
- prevent early audio download by switching to metadata preload

## Testing
- `python3 -m http.server 8001 >/tmp/server2.log 2>&1 &`
- `curl http://localhost:8001/main.html | head`


------
https://chatgpt.com/codex/tasks/task_e_687c232c21048332a269b3e4a512e100