### PR TITLE
Fix missing watermarks and add chatbot label

### DIFF
--- a/main.html
+++ b/main.html
@@ -366,6 +366,12 @@
         align-items: center;
         height: 100%;
     }
+    .edge-panel-title {
+        font-size: 0.7rem;
+        text-align: center;
+        color: #ffffff;
+        padding: 0.2rem;
+    }
     .tap-area {
         position: fixed;
         bottom: 0;
@@ -631,6 +637,7 @@
 <div class="edge-panel" id="edgePanel">
     <div class="edge-panel-handle"></div>
     <div class="edge-panel-content">
+        <div class="edge-panel-title">Àríyò AI Chatbot by Zapier</div>
         <!-- Chatbot Floating Icon & Comic Bubble -->
         <div class="chatbot-bubble-container" role="button" aria-label="Open Chatbot" onclick="toggleChatbot()">
           <img src="chatbot.png" alt="Chatbot Icon" class="chatbot-float-icon" />
@@ -726,8 +733,8 @@
   <!-- Floating Watermarks -->
   <div class="floating-watermarks">
     <div class="watermark" style="top: 10%; left: 5%; animation-delay: 0s;">Omoluabi Productions</div>
-    <div class="watermark" style="top: 55%; left: 80%; animation-delay: 3s;">Omoluabi Productions</div>
-    <div class="watermark" style="top: 85%; left: 50%; animation-delay: 5s;">Omoluabi Productions</div>
+    <div class="watermark" style="top: 55%; left: 60%; animation-delay: 3s;">Omoluabi Productions</div>
+    <div class="watermark" style="top: 85%; left: 40%; animation-delay: 5s;">Omoluabi Productions</div>
   </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- restore floating watermark positions on `main.html` so they match `index.html`
- add a label for the Zapier chatbot inside the edge panel

## Testing
- `npm test` *(fails: Could not find package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_687d25d6bb908332bf7c5b742eed91a1