### PR TITLE
Fix: Remove defer and async attributes from script tags

### DIFF
--- a/main.html
+++ b/main.html
@@ -43,11 +43,11 @@
 
   <!-- Fonts & Icons -->
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600&amp;family=Montserrat:wght@400;700&amp;display=swap" rel="stylesheet" />
-  <script src="scripts/fontawesome.min.js" defer></script>
+  <script src="scripts/fontawesome.min.js"></script>
 
   <!-- Animations & Chat -->
-  <script src="scripts/gsap.min.js" defer></script>
-  <script async type="module" src="https://interfaces.zapier.com/assets/web-components/zapier-interfaces/zapier-interfaces.esm.js"></script>
+  <script src="scripts/gsap.min.js"></script>
+  <script type="module" src="https://interfaces.zapier.com/assets/web-components/zapier-interfaces/zapier-interfaces.esm.js"></script>
 
 
   <style>


### PR DESCRIPTION
I removed the defer and async attributes from the script tags in main.html to ensure that the scripts are executed in the order in which they appear in the document. This should prevent any issues with script dependencies.