### PR TITLE
Fix grid layout and add word validation

### DIFF
--- a/word-search.css
+++ b/word-search.css
@@ -51,9 +51,10 @@ body {
 
 #game-wrapper {
     display: flex;
-    flex-wrap: wrap;
+    flex-wrap: nowrap;
     gap: 1rem;
     justify-content: center;
+    align-items: flex-start;
 }
 
 #game-board {
@@ -61,6 +62,7 @@ body {
     grid-gap: 2px;
     border: 2px solid #333;
     padding: 5px;
+    box-sizing: border-box;
     max-width: 95vw;
     overflow: hidden;
     aspect-ratio: 1 / 1;
@@ -97,7 +99,7 @@ body {
     padding: 0.25rem 0.5rem;
     border: 1px solid #ccc;
     border-radius: 4px;
-    font-size: 0.7rem;
+    font-size: 0.6rem;
 }
 
 #word-list li.found {

--- a/word-search.js
+++ b/word-search.js
@@ -93,6 +93,7 @@ function createBoard() {
     gameBoard.style.width = `${boardSize}px`;
     gameBoard.style.height = `${boardSize}px`;
     gameBoard.style.gridTemplateColumns = `repeat(${gridSize}, ${cellSize}px)`;
+    gameBoard.style.gridTemplateRows = `repeat(${gridSize}, ${cellSize}px)`;
     board.length = 0;
     for (let i = 0; i < gridSize; i++) {
         const row = [];
@@ -238,6 +239,26 @@ function fillEmptyCells() {
     }
 }
 
+function validateWordPlacement() {
+    const counts = {};
+    for (let i = 0; i < gridSize; i++) {
+        for (let j = 0; j < gridSize; j++) {
+            const w = board[i][j].dataset.word;
+            if (w) {
+                counts[w] = (counts[w] || 0) + 1;
+            }
+        }
+    }
+    for (const w of wordsInGame) {
+        const c = counts[w] || 0;
+        if (c !== w.length) {
+            console.warn(`Word '${w}' expected ${w.length} letters, found ${c}`);
+            return false;
+        }
+    }
+    return true;
+}
+
 function drawLine(cells) {
     if (!lineCtx || cells.length === 0) return;
     const boardRect = document.getElementById("game-board").getBoundingClientRect();
@@ -375,10 +396,11 @@ function checkWin() {
 }
 
 function pickWords(wordList, maxWords = 20) {
-    if (wordList.length <= maxWords) {
-        return wordList;
+    const unique = [...new Set(wordList)];
+    if (unique.length <= maxWords) {
+        return unique;
     }
-    const shuffled = [...wordList].sort(() => 0.5 - Math.random());
+    const shuffled = [...unique].sort(() => 0.5 - Math.random());
     return shuffled.slice(0, maxWords);
 }
 
@@ -417,6 +439,7 @@ function startGame() {
     createBoard();
     placeWords(wordsInGame);
     fillEmptyCells();
+    validateWordPlacement();
     populateWordList();
 }
 
@@ -433,6 +456,7 @@ function resizeBoard() {
     gameBoard.style.width = `${boardSize}px`;
     gameBoard.style.height = `${boardSize}px`;
     gameBoard.style.gridTemplateColumns = `repeat(${gridSize}, ${cellSize}px)`;
+    gameBoard.style.gridTemplateRows = `repeat(${gridSize}, ${cellSize}px)`;
     for (let i = 0; i < gridSize; i++) {
         for (let j = 0; j < gridSize; j++) {
             const cell = board[i][j];


### PR DESCRIPTION
## Summary
- ensure word search grid renders all tiles by setting row template
- keep grid beside word list and reduce word list font size
- verify each puzzle word is placed once in the grid

## Testing
- `node --check word-search.js`

------
https://chatgpt.com/codex/tasks/task_e_687d74f9abf0833293907876776e55a2