### PR TITLE
Fix word search layout and selection

### DIFF
--- a/word-search.css
+++ b/word-search.css
@@ -89,17 +89,18 @@ body {
     list-style: none;
     padding: 0;
     margin-top: 1rem;
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.5rem;
-    justify-content: center;
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 0.25rem;
+    justify-items: start;
+    max-width: 100%;
 }
 
 #word-list li {
-    padding: 0.25rem 0.5rem;
+    padding: 0.25rem 0.4rem;
     border: 1px solid #ccc;
     border-radius: 4px;
-    font-size: 0.6rem;
+    font-size: 0.55rem;
 }
 
 #word-list li.found {
@@ -127,10 +128,10 @@ body {
         max-width: 90vw;
     }
     #word-list {
-        font-size: 0.8rem;
+        font-size: 0.75rem;
     }
     #word-list li {
-        font-size: 0.6rem;
+        font-size: 0.55rem;
     }
 }
 


### PR DESCRIPTION
## Summary
- arrange word list in two columns and shrink font sizes
- remove diagonal word placements and selections
- track found word paths to draw lines correctly

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687d82f282d88332af290a6254689f92