### PR TITLE
Enhance word search layout

### DIFF
--- a/about.html
+++ b/about.html
@@ -2,7 +2,12 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+  <meta name="apple-mobile-web-app-capable" content="yes" />
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+  <meta name="apple-mobile-web-app-title" content="Àríyò AI" />
+  <meta name="apple-touch-fullscreen" content="yes" />
+  <link rel="apple-touch-icon" href="icons/Ariyo.png">
   <title>About - Àríyò AI</title>
   <meta name="description" content="Learn more about Àríyò AI, a smart Naija AI powered by Omoluabi. Discover our mission, our music, and our team." />
   <meta name="keywords" content="About Àríyò AI, Omoluabi, Paul A.K. Iyogun, Nigerian AI, AI music" />

--- a/index.html
+++ b/index.html
@@ -2,7 +2,11 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+  <meta name="apple-mobile-web-app-capable" content="yes" />
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+  <meta name="apple-mobile-web-app-title" content="Àríyò AI" />
+  <meta name="apple-touch-fullscreen" content="yes" />
     <title>Welcome to Àríyò AI</title>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.2/gsap.min.js" defer></script>
     <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&display=swap" rel="stylesheet">

--- a/picture-game.html
+++ b/picture-game.html
@@ -2,7 +2,12 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+  <meta name="apple-mobile-web-app-capable" content="yes" />
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+  <meta name="apple-mobile-web-app-title" content="Àríyò AI" />
+  <meta name="apple-touch-fullscreen" content="yes" />
+  <link rel="apple-touch-icon" href="icons/Ariyo.png">
     <title>Picture Puzzle Game</title>
     <link rel="stylesheet" href="picture-game.css">
 </head>

--- a/word-search.css
+++ b/word-search.css
@@ -54,6 +54,7 @@ body {
     flex-wrap: wrap;
     gap: 1rem;
     justify-content: center;
+    align-items: flex-start;
 }
 
 #game-board {
@@ -86,18 +87,20 @@ body {
 #word-list {
     list-style: none;
     padding: 0;
-    margin-top: 1rem;
+    margin: 0 0 0 1rem;
+    max-width: 200px;
     display: flex;
     flex-wrap: wrap;
     gap: 0.5rem;
     justify-content: center;
+    font-size: 0.8rem;
 }
 
 #word-list li {
     padding: 0.25rem 0.5rem;
     border: 1px solid #ccc;
     border-radius: 4px;
-    font-size: 0.7rem;
+    font-size: 0.6rem;
 }
 
 #word-list li.found {
@@ -125,10 +128,11 @@ body {
         max-width: 90vw;
     }
     #word-list {
+        margin: 1rem 0 0 0;
         font-size: 0.8rem;
     }
     #word-list li {
-        font-size: 0.6rem;
+        font-size: 0.55rem;
     }
 }
 

--- a/word-search.html
+++ b/word-search.html
@@ -2,7 +2,12 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+  <meta name="apple-mobile-web-app-capable" content="yes" />
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+  <meta name="apple-mobile-web-app-title" content="Àríyò AI" />
+  <meta name="apple-touch-fullscreen" content="yes" />
+  <link rel="apple-touch-icon" href="icons/Ariyo.png">
     <title>Ara Word Search</title>
     <link rel="stylesheet" type="text/css" href="word-search.css">
 </head>

--- a/word-search.js
+++ b/word-search.js
@@ -65,8 +65,10 @@ function updateGridSize() {
 }
 
 function getCellSize() {
-    const maxSize = 30;
-    const available = Math.floor(Math.min(window.innerWidth, window.innerHeight) * 0.85);
+    const maxSize = 24;
+    const availableWidth = window.innerWidth * 0.6;
+    const availableHeight = window.innerHeight * 0.8;
+    const available = Math.floor(Math.min(availableWidth, availableHeight));
     const extras = (GRID_GAP * (gridSize - 1)) + (BOARD_PADDING * 2) + (BOARD_BORDER * 2);
     return Math.min(maxSize, Math.floor((available - extras) / gridSize));
 }
@@ -102,6 +104,7 @@ function createBoard() {
             cell.style.width = `${cellSize}px`;
             cell.style.height = `${cellSize}px`;
             cell.style.lineHeight = `${cellSize}px`;
+            cell.style.fontSize = `${Math.floor(cellSize * 0.6)}px`;
             cell.dataset.row = i;
             cell.dataset.col = j;
             cell.addEventListener("pointerdown", handlePointerDown);
@@ -439,6 +442,7 @@ function resizeBoard() {
             cell.style.width = `${cellSize}px`;
             cell.style.height = `${cellSize}px`;
             cell.style.lineHeight = `${cellSize}px`;
+            cell.style.fontSize = `${Math.floor(cellSize * 0.6)}px`;
         }
     }
     const boardRect = gameBoard.getBoundingClientRect();


### PR DESCRIPTION
## Summary
- tweak word search container so word list sits beside the grid
- shrink tile and word list font sizes for better fit

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68802c0da62c8332aede6fb30687c2dd