### PR TITLE
Improve word search layout

### DIFF
--- a/about.html
+++ b/about.html
@@ -2,7 +2,12 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+  <meta name="apple-mobile-web-app-capable" content="yes" />
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+  <meta name="apple-mobile-web-app-title" content="Àríyò AI" />
+  <meta name="apple-touch-fullscreen" content="yes" />
+  <link rel="apple-touch-icon" href="icons/Ariyo.png">
   <title>About - Àríyò AI</title>
   <meta name="description" content="Learn more about Àríyò AI, a smart Naija AI powered by Omoluabi. Discover our mission, our music, and our team." />
   <meta name="keywords" content="About Àríyò AI, Omoluabi, Paul A.K. Iyogun, Nigerian AI, AI music" />

--- a/index.html
+++ b/index.html
@@ -2,7 +2,11 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+  <meta name="apple-mobile-web-app-capable" content="yes" />
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+  <meta name="apple-mobile-web-app-title" content="Àríyò AI" />
+  <meta name="apple-touch-fullscreen" content="yes" />
     <title>Welcome to Àríyò AI</title>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.2/gsap.min.js" defer></script>
     <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&display=swap" rel="stylesheet">

--- a/picture-game.html
+++ b/picture-game.html
@@ -2,7 +2,12 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+  <meta name="apple-mobile-web-app-capable" content="yes" />
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+  <meta name="apple-mobile-web-app-title" content="Àríyò AI" />
+  <meta name="apple-touch-fullscreen" content="yes" />
+  <link rel="apple-touch-icon" href="icons/Ariyo.png">
     <title>Picture Puzzle Game</title>
     <link rel="stylesheet" href="picture-game.css">
 </head>

--- a/word-search.css
+++ b/word-search.css
@@ -54,6 +54,7 @@ body {
     flex-wrap: wrap;
     gap: 1rem;
     justify-content: center;
+    align-items: flex-start;
 }
 
 #game-board {
@@ -62,8 +63,9 @@ body {
     border: 2px solid #333;
     padding: 5px;
     max-width: 95vw;
+    max-height: 80vh;
     overflow: hidden;
-    aspect-ratio: 1 / 1;
+    box-sizing: content-box;
 }
 
 .cell {
@@ -86,18 +88,19 @@ body {
 #word-list {
     list-style: none;
     padding: 0;
-    margin-top: 1rem;
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.5rem;
-    justify-content: center;
+    margin: 0 0 0 0.5rem;
+    max-width: 180px;
+    display: grid;
+    grid-template-columns: repeat(2, max-content);
+    gap: 0.4rem;
+    font-size: 0.7rem;
 }
 
 #word-list li {
-    padding: 0.25rem 0.5rem;
+    padding: 0.25rem 0.4rem;
     border: 1px solid #ccc;
     border-radius: 4px;
-    font-size: 0.7rem;
+    font-size: 0.55rem;
 }
 
 #word-list li.found {
@@ -117,18 +120,16 @@ body {
 }
 
 @media (max-width: 480px) {
-    #game-wrapper {
-        flex-direction: column;
-        align-items: center;
-    }
     #game-board {
-        max-width: 90vw;
+        max-width: 60vw;
     }
     #word-list {
-        font-size: 0.8rem;
+        margin-left: 0.5rem;
+        max-width: 35vw;
+        font-size: 0.65rem;
     }
     #word-list li {
-        font-size: 0.6rem;
+        font-size: 0.5rem;
     }
 }
 

--- a/word-search.html
+++ b/word-search.html
@@ -2,7 +2,12 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+  <meta name="apple-mobile-web-app-capable" content="yes" />
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+  <meta name="apple-mobile-web-app-title" content="Àríyò AI" />
+  <meta name="apple-touch-fullscreen" content="yes" />
+  <link rel="apple-touch-icon" href="icons/Ariyo.png">
     <title>Ara Word Search</title>
     <link rel="stylesheet" type="text/css" href="word-search.css">
 </head>

--- a/word-search.js
+++ b/word-search.js
@@ -65,8 +65,10 @@ function updateGridSize() {
 }
 
 function getCellSize() {
-    const maxSize = 30;
-    const available = Math.floor(Math.min(window.innerWidth, window.innerHeight) * 0.85);
+    const maxSize = 24;
+    const availableWidth = window.innerWidth * 0.55;
+    const availableHeight = window.innerHeight * 0.8;
+    const available = Math.floor(Math.min(availableWidth, availableHeight));
     const extras = (GRID_GAP * (gridSize - 1)) + (BOARD_PADDING * 2) + (BOARD_BORDER * 2);
     return Math.min(maxSize, Math.floor((available - extras) / gridSize));
 }
@@ -102,6 +104,7 @@ function createBoard() {
             cell.style.width = `${cellSize}px`;
             cell.style.height = `${cellSize}px`;
             cell.style.lineHeight = `${cellSize}px`;
+            cell.style.fontSize = `${Math.floor(cellSize * 0.6)}px`;
             cell.dataset.row = i;
             cell.dataset.col = j;
             cell.addEventListener("pointerdown", handlePointerDown);
@@ -439,6 +442,7 @@ function resizeBoard() {
             cell.style.width = `${cellSize}px`;
             cell.style.height = `${cellSize}px`;
             cell.style.lineHeight = `${cellSize}px`;
+            cell.style.fontSize = `${Math.floor(cellSize * 0.6)}px`;
         }
     }
     const boardRect = gameBoard.getBoundingClientRect();


### PR DESCRIPTION
## Summary
- stop aspect ratio from shrinking the game grid
- use two-column layout for word list and reduce its font size
- reserve more screen width for the word list

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68802c0da62c8332aede6fb30687c2dd