### PR TITLE
Refine color scheme and game tile design

### DIFF
--- a/about.html
+++ b/about.html
@@ -8,6 +8,7 @@
   <meta name="apple-mobile-web-app-title" content="Àríyò AI" />
   <meta name="apple-touch-fullscreen" content="yes" />
   <link rel="apple-touch-icon" href="icons/Ariyo.png">
+  <meta name="theme-color" content="#6a5acd" />
   <title>About - Àríyò AI</title>
   <meta name="description" content="Learn more about Àríyò AI, a smart Naija AI powered by Omoluabi. Discover our mission, our music, and our team." />
   <meta name="keywords" content="About Àríyò AI, Omoluabi, Paul A.K. Iyogun, Nigerian AI, AI music" />

--- a/color-scheme.css
+++ b/color-scheme.css
@@ -1,4 +1,4 @@
-:root { --theme-color: #00bcd4; } /* Default color */
+:root { --theme-color: #6a5acd; } /* Default color updated from cyan to slate blue */
 .header { background: linear-gradient(135deg, var(--theme-color), #000); }
 .sidebar button { background: linear-gradient(135deg, var(--theme-color), #333); }
 .music-controls.icons-only button { background: var(--theme-color); }

--- a/color-scheme.js
+++ b/color-scheme.js
@@ -6,30 +6,9 @@ function changeColorScheme() {
         return;
     }
 
-    const lastColorChange = localStorage.getItem('lastColorChange');
-    const now = new Date().getTime();
-    const oneWeek = 7 * 24 * 60 * 60 * 1000;
-
-    if (!lastColorChange || (now - lastColorChange > oneWeek)) {
-        let newColor;
-        let recentColors = JSON.parse(localStorage.getItem('recentColors')) || [];
-        do {
-            newColor = '#' + Math.floor(Math.random() * 16777215).toString(16);
-        } while (recentColors.includes(newColor));
-
-        recentColors.push(newColor);
-        if (recentColors.length > 8) {
-            recentColors.shift();
-        }
-        localStorage.setItem('recentColors', JSON.stringify(recentColors));
-        localStorage.setItem('lastColorChange', now);
-        localStorage.setItem('currentColor', newColor);
-    }
-
-    const currentColor = localStorage.getItem('currentColor');
-    if (currentColor) {
-        applyTheme('default', currentColor);
-    }
+    const currentColor = localStorage.getItem('currentColor') || '#6a5acd';
+    localStorage.setItem('currentColor', currentColor);
+    applyTheme('default', currentColor);
 }
 
 function applyTheme(theme, color) {
@@ -56,7 +35,7 @@ function applyTheme(theme, color) {
       `;
             break;
         default:
-            themeColor = color || '#00bcd4';
+            themeColor = color || '#6a5acd';
             break;
     }
 

--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
   <meta name="apple-mobile-web-app-title" content="Àríyò AI" />
   <meta name="apple-touch-fullscreen" content="yes" />
+  <meta name="theme-color" content="#6a5acd" />
     <title>Welcome to Àríyò AI</title>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.2/gsap.min.js" defer></script>
     <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&display=swap" rel="stylesheet">

--- a/main.html
+++ b/main.html
@@ -10,7 +10,7 @@
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
   <meta name="apple-mobile-web-app-title" content="Àríyò AI">
   <meta name="apple-touch-fullscreen" content="yes">
-  <meta name="theme-color" content="#00bcd4" />
+  <meta name="theme-color" content="#6a5acd" />
   <link rel="manifest" href="manifest.json">
   <link rel="apple-touch-icon" href="icons/Ariyo.png">
   <meta name="description" content="Àríyò AI is a web-based music player that provides a unique and culturally-rich experience for users. It features a curated selection of Nigerian music, a chatbot, and a 'Sabi Bible' mode." />

--- a/manifest.json
+++ b/manifest.json
@@ -30,6 +30,6 @@
   ],
   "start_url": "/index.html",
   "display": "standalone",
-  "theme_color": "#00bcd4",
+  "theme_color": "#6a5acd",
   "background_color": "#000000"
 }

--- a/picture-game.css
+++ b/picture-game.css
@@ -57,10 +57,23 @@
     box-sizing: border-box;
     background-size: 400px 300px;
     cursor: pointer;
+    border-radius: 5px;
+    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.2);
+    transition: transform 0.1s ease-in-out;
+}
+
+.puzzle-tile:active {
+    transform: scale(0.98);
 }
 
 .empty-tile {
-    background: #eee;
+    background: repeating-linear-gradient(
+        45deg,
+        #f0f0f0,
+        #f0f0f0 10px,
+        #e0e0e0 10px,
+        #e0e0e0 20px
+    );
 }
 
 #puzzle-controls {

--- a/word-search.css
+++ b/word-search.css
@@ -86,10 +86,14 @@ label[for="category-select"] {
     user-select: none;
     touch-action: none;
     box-sizing: border-box;
+    border-radius: 4px;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+    transition: background-color 0.2s ease-in-out;
 }
 
 .selected {
-    background-color: #ff0;
+    background-color: var(--theme-color);
+    color: #fff;
 }
 
 #word-list {
@@ -112,12 +116,14 @@ label[for="category-select"] {
 }
 
 #word-list li.found {
-    background-color: lightgreen;
+    background-color: #c7e2ff;
     font-weight: bold;
+    border-color: var(--theme-color);
+    color: #000;
 }
 
 .found {
-    background-color: lightgreen;
+    background-color: #c7e2ff;
 }
 
 #line-canvas {


### PR DESCRIPTION
## Summary
- switch default theme color to slate blue
- stop random theme color selection
- add theme-color meta tag in HTML pages
- update puzzle tiles with rounded corners and shadows
- refresh word search tile visuals

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68818ff947108332bbfb166a266df7f0