### PR TITLE
Improve modal accessibility and unify palette

### DIFF
--- a/about.html
+++ b/about.html
@@ -46,7 +46,7 @@
       line-height: 1.6;
     }
     header {
-      background: linear-gradient(135deg, rgba(0, 188, 212, 0.8), rgba(0, 150, 136, 0.8));
+      background: linear-gradient(135deg, var(--theme-color), #000);
       padding: 1rem;
       text-align: center;
     }

--- a/main.html
+++ b/main.html
@@ -77,14 +77,14 @@
       font-weight: bold;
       border-bottom: 1px solid rgba(255, 255, 255, 0.2);
       box-shadow: 0px 5px 15px rgba(0,0,0,0.3);
-      background: linear-gradient(135deg, rgba(0, 188, 212, 0.8), rgba(0, 150, 136, 0.8));
+      background: linear-gradient(135deg, var(--theme-color), #000);
       position: relative;
     }
     .share-button {
       position: absolute;
       top: 0.5rem;
       right: 0.5rem;
-      background-color: rgba(0, 123, 255, 0.7);
+      background-color: var(--theme-color);
       color: white;
       padding: 0.6rem;
       border: none;
@@ -98,18 +98,18 @@
     @keyframes pulse {
       0% {
         transform: scale(1);
-        box-shadow: 0 0 0 0 rgba(0, 123, 255, 0.4);
+        box-shadow: 0 0 0 0 var(--theme-color);
       }
       70% {
         transform: scale(1);
-        box-shadow: 0 0 0 10px rgba(0, 123, 255, 0);
+        box-shadow: 0 0 0 10px var(--theme-color);
       }
       100% {
         transform: scale(1);
-        box-shadow: 0 0 0 0 rgba(0, 123, 255, 0);
+        box-shadow: 0 0 0 0 var(--theme-color);
       }
     }
-    .share-button:hover { background-color: rgba(0, 123, 255, 1); }
+    .share-button:hover { background-color: var(--theme-color); }
     .container {
       flex: 1;
       display: flex;
@@ -148,7 +148,7 @@
     }
     .sidebar button:hover {
       transform: scale(1.08);
-      box-shadow: 0px 4px 10px rgba(0, 188, 212, 0.6);
+      box-shadow: 0px 4px 10px var(--theme-color);
     }
     .content {
       flex: 1;
@@ -260,6 +260,11 @@
       max-height: 80vh;
       overflow-y: auto;
       border-radius: 10px;
+    }
+    .modal-title {
+      margin-top: 0;
+      text-align: center;
+      color: var(--theme-color);
     }
     .close {
       color: #aaa;
@@ -633,9 +638,10 @@
   </div>
 
 <!-- Modal for Radio Stations -->
-<div id="radioModal" class="modal" role="dialog" aria-labelledby="radioModalTitle">
+  <div id="radioModal" class="modal" role="dialog" aria-labelledby="radioModalTitle">
   <div class="modal-content">
     <button class="close ripple shockwave" role="button" aria-label="Close radio list" onclick="closeRadioList()">×</button>
+    <h3 id="radioModalTitle" class="modal-title">Choose A Radio Station</h3>
     <!-- Group: Nigeria -->
     <h4>Nigeria</h4>
     <div id="nigeria-stations" class="radio-list"></div>
@@ -676,8 +682,9 @@
 </div>
 
 <!-- Chatbot Container -->
-<div class="chatbot-container" id="chatbotContainer">
+<div class="chatbot-container" id="chatbotContainer" role="dialog" aria-labelledby="chatbotTitle">
   <button class="popup-close ripple shockwave" role="button" aria-label="Close Chatbot" onclick="toggleChatbot()">×</button>
+  <h3 id="chatbotTitle" class="modal-title">Àríyò AI Chatbot</h3>
   <zapier-interfaces-chatbot-embed
     is-popup="false"
     chatbot-id="cm7s2oyu2000b3vmuwcwkj9kn"
@@ -689,8 +696,9 @@
 </div>
 
 <!-- Sabi Bible Container -->
-<div class="sabi-bible-container" id="sabiBibleContainer">
+<div class="sabi-bible-container" id="sabiBibleContainer" role="dialog" aria-labelledby="sabiBibleTitle">
   <button class="popup-close ripple shockwave" role="button" aria-label="Close Sabi Bible" onclick="toggleSabiBible()">×</button>
+  <h3 id="sabiBibleTitle" class="modal-title">Sabi Bible Chatbot</h3>
   <zapier-interfaces-chatbot-embed
     is-popup="false"
     chatbot-id="cm7ve7fdl002jlclh8y1n6n1y"
@@ -702,14 +710,16 @@
 </div>
 
 <!-- Picture Game Container -->
-<div id="pictureGameContainer" class="chatbot-container">
+<div id="pictureGameContainer" class="chatbot-container" role="dialog" aria-labelledby="pictureGameTitle">
     <button class="popup-close ripple shockwave" onclick="closePictureGame()">×</button>
+    <h3 id="pictureGameTitle" class="modal-title">Picture Game</h3>
     <iframe src="picture-game.html" style="width: 100%; height: 100%; border: none;"></iframe>
 </div>
 
 <!-- Word Search Game Container -->
-<div id="wordSearchGameContainer" class="chatbot-container">
+<div id="wordSearchGameContainer" class="chatbot-container" role="dialog" aria-labelledby="wordSearchGameTitle">
     <button class="popup-close ripple shockwave" onclick="closeWordSearchGame()">×</button>
+    <h3 id="wordSearchGameTitle" class="modal-title">Word Search Game</h3>
     <iframe src="word-search.html" style="width: 100%; height: 100%; border: none;"></iframe>
 </div>
 


### PR DESCRIPTION
## Summary
- unify header gradient and share-button color under theme variable
- add `.modal-title` styling for modals
- give each modal or popup its own title for accessibility

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688193e3c48c8332b5c73b5d5b94e2ce