### PR TITLE
Fix puzzle UI spacing and header styles

### DIFF
--- a/picture-game.css
+++ b/picture-game.css
@@ -2,11 +2,12 @@
 
 #game-title {
     font-family: 'Lobster', cursive;
-    font-size: 3rem;
+    font-size: clamp(2rem, 5vw, 2.5rem);
     color: var(--theme-color);
-    text-shadow: 2px 2px 4px #000000;
-    margin-bottom: 20px;
+    text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.5);
+    margin: 1rem 0;
     text-align: center;
+    letter-spacing: 0.05em;
 }
 
 #game-title::before {
@@ -104,13 +105,14 @@
 }
 
 #instructions {
-    margin-top: 20px;
-    font-size: 0.9rem;
+    margin: 20px auto 0;
+    font-size: clamp(0.8rem, 1.8vw, 0.95rem);
     color: #333;
     text-align: center;
     font-weight: bold;
     max-width: 400px;
-    padding: 0 20px;
+    padding: 10px 20px;
+    line-height: 1.4;
 }
 
 @media screen and (max-width: 600px) {

--- a/picture-game.html
+++ b/picture-game.html
@@ -9,6 +9,7 @@
   <meta name="apple-touch-fullscreen" content="yes" />
   <link rel="apple-touch-icon" href="icons/Ariyo.png">
     <title>Picture Puzzle Game</title>
+    <link rel="stylesheet" href="color-scheme.css">
     <link rel="stylesheet" href="picture-game.css">
 </head>
 <body>

--- a/word-search.css
+++ b/word-search.css
@@ -2,11 +2,12 @@
 
 #game-title {
     font-family: 'Lobster', cursive;
-    font-size: 3rem;
+    font-size: clamp(2rem, 5vw, 2.5rem);
     color: var(--theme-color);
-    text-shadow: 2px 2px 4px #000000;
-    margin-bottom: 20px;
+    text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.5);
+    margin: 1rem 0;
     text-align: center;
+    letter-spacing: 0.05em;
 }
 
 #game-title::before {


### PR DESCRIPTION
## Summary
- adjust header styling on puzzle and word search games
- add padding and responsive sizing to puzzle instructions

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68827fdfa9f883329c2e53f846a7ef52