### PR TITLE
Update word list layout

### DIFF
--- a/word-search.css
+++ b/word-search.css
@@ -105,18 +105,18 @@ label[for="category-select"] {
     padding: 0;
     margin: 0 0 0 1rem;
     max-width: 200px;
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.5rem;
+    display: grid;
+    grid-template-columns: repeat(2, auto);
+    gap: 0.3rem 0.5rem;
     justify-content: center;
-    font-size: 0.8rem;
+    font-size: 0.55rem;
 }
 
 #word-list li {
-    padding: 0.25rem 0.5rem;
+    padding: 0.2rem 0.4rem;
     border: 1px solid #ccc;
     border-radius: 4px;
-    font-size: 0.6rem;
+    font-size: 0.55rem;
 }
 
 #word-list li.found {
@@ -147,10 +147,11 @@ label[for="category-select"] {
     }
     #word-list {
         margin: 1rem 0 0 0;
-        font-size: 0.8rem;
+        grid-template-columns: repeat(2, auto);
+        font-size: 0.55rem;
     }
     #word-list li {
-        font-size: 0.55rem;
+        font-size: 0.5rem;
     }
 }
 


### PR DESCRIPTION
## Summary
- arrange the word list beside the puzzle grid using two columns
- reduce font sizing for a more compact layout

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6882d8c068c883329f72e0b6dc803bf3