### PR TITLE
Fix mobile layout for word search game

### DIFF
--- a/word-search.css
+++ b/word-search.css
@@ -147,11 +147,11 @@ label[for="category-select"] {
 
 @media (max-width: 480px) {
     #game-wrapper {
-        flex-direction: column;
-        align-items: center;
+        overflow-x: auto;
+        flex-wrap: nowrap;
     }
     #game-board {
-        max-width: 90vw;
+        max-width: 55vw;
     }
     #controls {
         margin: 0.5rem 0;
@@ -162,9 +162,10 @@ label[for="category-select"] {
         font-size: 0.65rem;
     }
     #word-list {
-        margin: 1rem 0 0 0;
+        margin: 1rem 0 0 0.5rem;
         grid-template-columns: repeat(2, auto);
         font-size: 0.55rem;
+        max-width: 40vw;
     }
     #word-list li {
         font-size: 0.5rem;

--- a/word-search.js
+++ b/word-search.js
@@ -69,7 +69,8 @@ function updateGridSize() {
 
 function getCellSize() {
     const maxSize = 24;
-    const availableWidth = window.innerWidth * 0.6;
+    const widthRatio = window.innerWidth <= 480 ? 0.55 : 0.6;
+    const availableWidth = window.innerWidth * widthRatio;
     const availableHeight = window.innerHeight * 0.8;
     const available = Math.floor(Math.min(availableWidth, availableHeight));
     const extras = (GRID_GAP * (gridSize - 1)) + (BOARD_PADDING * 2) + (BOARD_BORDER * 2);
@@ -448,6 +449,7 @@ document.addEventListener("DOMContentLoaded", () => {
     select.addEventListener("change", startGame);
     const newBtn = document.getElementById("new-game-btn");
     newBtn.addEventListener("click", startGame);
+    startGame();
 });
 
 let resizeTimeout;


### PR DESCRIPTION
## Summary
- make word search game start automatically
- reduce board width on small screens and keep layout horizontal

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6882e3efb68c8332b46ec7f33fc55997