### PR TITLE
Cache additional static assets

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -11,7 +11,10 @@ self.addEventListener('install', event => {
           '/',
           '/index.html',
           '/main.html',
+          '/about.html',
           '/manifest.json',
+          'style.css',
+          'color-scheme.css',
           'icons/Ariyo.png',
           'scripts/data.js',
           'scripts/player.js',
@@ -20,7 +23,11 @@ self.addEventListener('install', event => {
           'color-scheme.js',
           'word-search.html',
           'word-search.css',
-          'word-search.js'
+          'word-search.js',
+          'picture-game.html',
+          'picture-game.css',
+          'picture-game.js',
+          'offline-audio.mp3'
         ];
         return caches.open(CACHE_NAME).then(cache => {
           return cache.addAll(urlsToCache);

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "157a9a8"
+  "version": "6897a4ce"
 }


### PR DESCRIPTION
## Summary
- cache color-scheme.css, style.css, about page, picture puzzle assets, and offline-audio in the service worker
- bump service worker version so updated cache installs

## Testing
- `node --check service-worker.js`
- `node <<'NODE'\n...\nNODE` *(simulated install with service-worker-mock; cache names [])*


------
https://chatgpt.com/codex/tasks/task_e_6897a3fd4bac833289fb5c83a8a823fc