### PR TITLE
Fix landing page watermarks

### DIFF
--- a/index.css
+++ b/index.css
@@ -117,3 +117,37 @@ p {
     fill: red;
     stroke: red;
 }
+.floating-watermarks {
+    pointer-events: none;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    overflow: hidden;
+    z-index: 9999;
+}
+
+.watermark {
+    position: absolute;
+    font-size: clamp(1rem, 4vw, 2rem);
+    color: rgba(255, 255, 255, 0.5);
+    white-space: nowrap;
+}
+
+.exploding-watermark span {
+    display: inline-block;
+    animation: letter-explode 2s ease-in-out infinite;
+    animation-delay: calc(0.1s * var(--i));
+}
+
+@keyframes letter-explode {
+    0% {
+        transform: translate(0, 0) rotate(0);
+        opacity: 1;
+    }
+    100% {
+        transform: translate(calc(100px * (var(--x) - 0.5)), calc(100px * (var(--y) - 0.5))) rotate(calc(360deg * var(--r)));
+        opacity: 0;
+    }
+}


### PR DESCRIPTION
## Summary
- add missing floating watermark styles to landing page so watermarks match main page

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897b86c85a4833292dfba9581b548ea