### PR TITLE
Fix radio station metadata index

### DIFF
--- a/scripts/player.js
+++ b/scripts/player.js
@@ -200,7 +200,8 @@ function loadMoreStations(region) {
   stations.slice(start, end).forEach((station, index) => {
     const stationLink = document.createElement("a");
     stationLink.href = "#";
-    stationLink.onclick = () => selectRadio(station.url, `${station.name} - ${station.location}`, index, station.logo);
+    const globalIndex = radioStations.indexOf(station);
+    stationLink.onclick = () => selectRadio(station.url, `${station.name} - ${station.location}`, globalIndex, station.logo);
 
     const statusSpan = document.createElement('span');
     statusSpan.style.marginLeft = '10px';


### PR DESCRIPTION
## Summary
- Ensure radio station selection uses global index so lock screen metadata reflects the correct station

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/Ariyo-AI/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_689a3780c00083328bc8ec08d6c1ebcd