### PR TITLE
feat: add theme presets

### DIFF
--- a/color-scheme.js
+++ b/color-scheme.js
@@ -34,6 +34,30 @@ function applyTheme(theme, color) {
         .dark-mode { color: #000000; }
       `;
             break;
+        case 'ocean':
+            themeColor = '#1e90ff';
+            css = `
+        body { background-color: #e0f7fa; color: #000000; }
+        .header { background: linear-gradient(135deg, ${themeColor}, #01579b); }
+        .sidebar button { background: linear-gradient(135deg, ${themeColor}, #0288d1); }
+      `;
+            break;
+        case 'forest':
+            themeColor = '#228b22';
+            css = `
+        body { background-color: #e8f5e9; color: #000000; }
+        .header { background: linear-gradient(135deg, ${themeColor}, #1b5e20); }
+        .sidebar button { background: linear-gradient(135deg, ${themeColor}, #2e7d32); }
+      `;
+            break;
+        case 'sunset':
+            themeColor = '#ff7043';
+            css = `
+        body { background-color: #fff3e0; color: #000000; }
+        .header { background: linear-gradient(135deg, ${themeColor}, #bf360c); }
+        .sidebar button { background: linear-gradient(135deg, ${themeColor}, #e64a19); }
+      `;
+            break;
         default:
             themeColor = color || '#6a5acd';
             break;

--- a/index.html
+++ b/index.html
@@ -46,6 +46,9 @@
             <button class="theme-button" data-theme="default">Default</button>
             <button class="theme-button" data-theme="dark">Dark</button>
             <button class="theme-button" data-theme="light">Light</button>
+            <button class="theme-button" data-theme="ocean">Ocean</button>
+            <button class="theme-button" data-theme="forest">Forest</button>
+            <button class="theme-button" data-theme="sunset">Sunset</button>
         </div>
         <div style="font-size: 0.8rem; margin-top: 1rem; font-weight: bold;">Click the speaker icon for sound</div>
         <div id="speaker-container" style="position: absolute; top: 1rem; right: 1rem; cursor: pointer;">
@@ -141,6 +144,7 @@
             button.addEventListener('click', () => {
                 const theme = button.dataset.theme;
                 localStorage.setItem('selectedTheme', theme);
+                applyTheme(theme);
             });
         });
 


### PR DESCRIPTION
## Summary
- add selectable theme preset buttons for Ocean, Forest, and Sunset
- extend theme application logic to support new presets with custom colours
- persist theme choice in localStorage and apply immediately

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check color-scheme.js`


------
https://chatgpt.com/codex/tasks/task_e_689a43795c80833290cb37a70bd8ac9d