### PR TITLE
feat: add gradient glow animations

### DIFF
--- a/color-scheme.css
+++ b/color-scheme.css
@@ -1,6 +1,10 @@
-:root { --theme-color: #6a5acd; } /* Default color updated from cyan to slate blue */
+:root {
+  --theme-color: #6a5acd;
+  --gradient-start: var(--theme-color);
+  --gradient-end: #333;
+} /* Default color updated from cyan to slate blue */
 .header { background: linear-gradient(135deg, var(--theme-color), #000); }
-.sidebar button { background: linear-gradient(135deg, var(--theme-color), #333); }
+.sidebar button { background: linear-gradient(135deg, var(--gradient-start), var(--gradient-end)); }
 .music-controls.icons-only button { background: var(--theme-color); }
 .track-list a:hover, .album-list a:hover, .radio-list a:hover { background-color: var(--theme-color); }
 .popup-close { background: var(--theme-color); }

--- a/color-scheme.js
+++ b/color-scheme.js
@@ -14,35 +14,39 @@ function changeColorScheme() {
 function applyTheme(theme, color) {
     const style = document.createElement('style');
     let themeColor = color;
+    let gradientEnd = '#333';
+    let headerEnd = '#000';
     let css = '';
 
     switch (theme) {
         case 'dark':
             themeColor = '#333333';
+            gradientEnd = '#555';
+            headerEnd = '#000';
             css = `
         body { background-color: #121212; color: #ffffff; }
-        .header { background: linear-gradient(135deg, ${themeColor}, #000); }
-        .sidebar button { background: linear-gradient(135deg, ${themeColor}, #555); }
       `;
             break;
         case 'light':
             themeColor = '#e0e0e0';
+            gradientEnd = '#ccc';
+            headerEnd = '#fff';
             css = `
         body { background-color: #f5f5f5; color: #000000; }
-        .header { background: linear-gradient(135deg, ${themeColor}, #fff); }
-        .sidebar button { background: linear-gradient(135deg, ${themeColor}, #ccc); }
         .dark-mode { color: #000000; }
       `;
             break;
         default:
             themeColor = color || '#6a5acd';
+            gradientEnd = '#333';
+            headerEnd = '#000';
             break;
     }
 
     style.innerHTML = `
-    :root { --theme-color: ${themeColor}; }
-    .header { background: linear-gradient(135deg, ${themeColor}, #000); }
-    .sidebar button { background: linear-gradient(135deg, ${themeColor}, #333); }
+    :root { --theme-color: ${themeColor}; --gradient-start: ${themeColor}; --gradient-end: ${gradientEnd}; }
+    .header { background: linear-gradient(135deg, ${themeColor}, ${headerEnd}); }
+    .sidebar button { background: linear-gradient(135deg, var(--gradient-start), var(--gradient-end)); }
     .music-controls.icons-only button { background: ${themeColor}; }
     .track-list a:hover, .album-list a:hover, .radio-list a:hover { background-color: ${themeColor}; }
     .popup-close { background: ${themeColor}; }

--- a/style.css
+++ b/style.css
@@ -54,7 +54,7 @@ body {
 }
 
 .sidebar button {
-    background: linear-gradient(135deg, var(--theme-color), #333);
+    background: linear-gradient(135deg, var(--gradient-start), var(--gradient-end));
     color: white;
     padding: 0.8rem 1rem;
     border: none;
@@ -72,7 +72,7 @@ body {
 
 .sidebar button:hover {
     transform: scale(1.08);
-    box-shadow: 0px 4px 10px var(--theme-color);
+    animation: gradient-glow 1.5s infinite alternate;
 }
 
 /* Main Content */
@@ -134,6 +134,21 @@ body {
     100% { transform: rotate(360deg); }
 }
 
+@keyframes gradient-glow {
+    0% {
+        background: linear-gradient(135deg, var(--gradient-start), var(--gradient-end));
+        box-shadow: 0 0 5px var(--gradient-start);
+    }
+    50% {
+        background: linear-gradient(135deg, var(--gradient-end), var(--gradient-start));
+        box-shadow: 0 0 15px var(--gradient-end);
+    }
+    100% {
+        background: linear-gradient(135deg, var(--gradient-start), var(--gradient-end));
+        box-shadow: 0 0 5px var(--gradient-start);
+    }
+}
+
 .loading-spinner {
     display: none;
     width: 30px;
@@ -171,6 +186,7 @@ body {
 
 .music-controls.icons-only button:hover {
     transform: scale(1.1);
+    animation: gradient-glow 1.5s infinite alternate;
 }
 
 .track-info {
@@ -267,6 +283,7 @@ body {
 .album-list a:hover,
 .radio-list a:hover {
     background-color: var(--theme-color);
+    animation: gradient-glow 1.5s infinite alternate;
 }
 
 /* Responsive Design */


### PR DESCRIPTION
## Summary
- animate sidebar buttons and other controls with a theme-aware gradient glow
- expose gradient variables so glow adapts to selected themes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a437d01d8833282342be8dd129f4c