### PR TITLE
Add autocomplete search for tracks and stations

### DIFF
--- a/main.html
+++ b/main.html
@@ -557,6 +557,8 @@
 
   <div class="container">
     <div class="sidebar">
+      <input type="text" id="searchInput" class="search-bar" list="searchSuggestions" placeholder="Search tracks or stations..." aria-label="Search tracks or radio stations">
+      <datalist id="searchSuggestions"></datalist>
       <button onclick="openAlbumList()" aria-label="Choose an album" class="ripple shockwave">🎧 Choose An Album</button>
       <button onclick="openRadioList()" aria-label="Radio stations" class="ripple shockwave">📻 Radio Stations</button>
       <button onclick="navigateToAbout()" aria-label="About us" class="ripple shockwave">ℹ️ About Us</button>

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -11,6 +11,45 @@
       }
     }
 
+    /* SEARCH BAR AUTO-COMPLETE */
+    const searchInput = document.getElementById('searchInput');
+    const searchSuggestions = document.getElementById('searchSuggestions');
+    const searchMap = {};
+
+    albums.forEach((album, albumIndex) => {
+      album.tracks.forEach((track, trackIndex) => {
+        const label = `${track.title} - ${album.name}`;
+        const option = document.createElement('option');
+        option.value = label;
+        searchSuggestions.appendChild(option);
+        searchMap[label.toLowerCase()] = { type: 'track', albumIndex, trackIndex };
+      });
+    });
+
+    radioStations.forEach((station, index) => {
+      const label = `${station.name} (${station.location})`;
+      const option = document.createElement('option');
+      option.value = label;
+      searchSuggestions.appendChild(option);
+      searchMap[label.toLowerCase()] = { type: 'radio', index };
+    });
+
+    searchInput.addEventListener('input', (e) => {
+      const key = e.target.value.trim().toLowerCase();
+      const result = searchMap[key];
+      if (result) {
+        if (result.type === 'track') {
+          currentAlbumIndex = result.albumIndex;
+          const track = albums[result.albumIndex].tracks[result.trackIndex];
+          selectTrack(track.src, track.title, result.trackIndex);
+        } else if (result.type === 'radio') {
+          const station = radioStations[result.index];
+          selectRadio(station.url, `${station.name} - ${station.location}`, result.index, station.logo);
+        }
+        e.target.value = '';
+      }
+    });
+
     /* NAVIGATE TO ABOUT PAGE & HOME */
     let originalMainContentHTML = '';
     let aboutButtonGlobal = null;

--- a/style.css
+++ b/style.css
@@ -53,6 +53,14 @@ body {
     flex-shrink: 0;
 }
 
+.sidebar .search-bar {
+    width: 90%;
+    padding: 0.6rem 1rem;
+    border-radius: 25px;
+    border: none;
+    font-size: clamp(0.9rem, 2vw, 1rem);
+}
+
 .sidebar button {
     background: linear-gradient(135deg, var(--gradient-start), var(--gradient-end));
     color: white;


### PR DESCRIPTION
## Summary
- Add sidebar search bar to quickly find tracks or radio stations
- Style search bar to blend with existing UI
- Implement autocomplete logic that plays selected track or station

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a4a5fe9788332a6c86244c3b9756e