### PR TITLE
feat: auto refresh on service worker update

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -381,6 +381,10 @@
 
     // PWA Install Prompt
     if ('serviceWorker' in navigator) {
+      // Reload the page when a new service worker activates
+      navigator.serviceWorker.addEventListener('controllerchange', () => {
+        window.location.reload();
+      });
       window.addEventListener('load', function() {
         showIosInstallBanner();
         navigator.serviceWorker.getRegistrations().then(function(registrations) {

--- a/service-worker.js
+++ b/service-worker.js
@@ -2,6 +2,8 @@ const CACHE_PREFIX = 'ariyo-ai-cache-v3';
 let CACHE_NAME;
 
 self.addEventListener('install', event => {
+  // Activate this service worker immediately after installation
+  self.skipWaiting();
   event.waitUntil(
     fetch('/version.json')
       .then(response => response.json())


### PR DESCRIPTION
## Summary
- force new service worker to activate immediately with skipWaiting
- reload page when controller changes so users see updates without manual refresh

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a752ff98483328c4c12dce15c23eb