### PR TITLE
Persist chosen theme across all pages

### DIFF
--- a/main.html
+++ b/main.html
@@ -747,8 +747,8 @@
   <script src="scripts/data.js"></script>
   <script src="scripts/player.js"></script>
   <script src="scripts/ui.js"></script>
-  <script src="scripts/main.js"></script>
   <script src="color-scheme.js"></script>
+  <script src="scripts/main.js"></script>
   <!-- Floating Watermarks -->
   <div class="floating-watermarks">
     <div class="watermark exploding-watermark" style="top: 10%; left: 5%;">Omoluabi Productions</div>

--- a/picture-game.html
+++ b/picture-game.html
@@ -40,6 +40,10 @@
     </div>
     <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.9.3/dist/confetti.browser.min.js"></script>
     <script src="picture-game.js"></script>
+    <script src="color-scheme.js"></script>
+    <script>
+        changeColorScheme();
+    </script>
     <footer>
         <p>&copy; 2024 Omoluabi</p>
     </footer>

--- a/word-search.html
+++ b/word-search.html
@@ -11,6 +11,7 @@
   <meta name="description" content="Enjoy the Ara word search puzzle from Àríyò AI created by Paul Iyogun (Omoluabi)." />
   <meta name="keywords" content="Paul Iyogun, Omoluabi, Ariyo AI, word search puzzle, Naija AI" />
   <title>Ara Word Search</title>
+    <link rel="stylesheet" href="color-scheme.css">
     <link rel="stylesheet" type="text/css" href="word-search.css">
 </head>
 <body>
@@ -28,5 +29,9 @@
     </div>
     <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.9.3/dist/confetti.browser.min.js"></script>
     <script src="word-search.js"></script>
+    <script src="color-scheme.js"></script>
+    <script>
+        changeColorScheme();
+    </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Ensure color-scheme script loads before main logic so saved theme can apply on startup
- Apply stored color scheme on picture and word search games

## Testing
- `npm test` *(fails: enoent could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a7850719883329ef894330e3de249