### PR TITLE
Ensure legible text across color themes

### DIFF
--- a/color-scheme.css
+++ b/color-scheme.css
@@ -13,3 +13,17 @@
 .progress-bar div { background: var(--theme-color); }
 .install-btn { background: var(--theme-color); }
 .radio-region-header { color: var(--theme-color); }
+
+/* Ensure text remains legible regardless of theme colors */
+body,
+body * {
+  text-shadow:
+    -1px -1px 2px #000,
+    1px -1px 2px #000,
+    -1px 1px 2px #000,
+    1px 1px 2px #000,
+    -1px -1px 2px #fff,
+    1px -1px 2px #fff,
+    -1px 1px 2px #fff,
+    1px 1px 2px #fff;
+}


### PR DESCRIPTION
## Summary
- Add universal text outline to keep content readable under all color themes

## Testing
- `npm test` *(fails: ENOENT package.json)*
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a883a5ba88332a3d2750165096415