### PR TITLE
Simplify theme to sunset with dark mode toggle

### DIFF
--- a/about.html
+++ b/about.html
@@ -49,7 +49,22 @@
       background: linear-gradient(135deg, var(--theme-color), #000);
       padding: 1rem;
       text-align: center;
+      position: relative;
     }
+    .dark-mode-toggle {
+      position: absolute;
+      top: 1rem;
+      left: 1rem;
+      background-color: var(--theme-color);
+      color: white;
+      padding: 0.6rem;
+      border: none;
+      border-radius: 50%;
+      font-size: 1.2rem;
+      cursor: pointer;
+      transition: all 0.3s ease;
+    }
+    .dark-mode-toggle:hover { background-color: var(--theme-color); }
     header h1 {
       margin: 0;
       font-size: 2.5rem;
@@ -156,6 +171,7 @@
 </head>
 <body>
   <header>
+    <button id="dark-mode-toggle" class="dark-mode-toggle" aria-label="Toggle dark mode">🌓</button>
     <h1>Àríyò AI - About Us</h1>
   </header>
 
@@ -218,6 +234,7 @@
   <script src="color-scheme.js"></script>
   <script>
     changeColorScheme();
+    document.getElementById('dark-mode-toggle').addEventListener('click', toggleDarkMode);
   </script>
 </body>
 </html>

--- a/color-scheme.css
+++ b/color-scheme.css
@@ -1,9 +1,14 @@
-/* Default color updated from cyan to slate blue */
+/* Sunset color scheme */
 :root {
-  --theme-color: #6a5acd;
+  --theme-color: #ff7043;
   --gradient-start: var(--theme-color);
-  --gradient-end: #000;
+  --gradient-end: #bf360c;
 }
+
+body {
+  font-family: 'Montserrat', sans-serif;
+}
+
 .header { background: linear-gradient(135deg, var(--gradient-start), var(--gradient-end)); }
 .sidebar button { background: linear-gradient(135deg, var(--gradient-start), var(--gradient-end)); }
 .music-controls.icons-only button { background: var(--theme-color); }

--- a/color-scheme.js
+++ b/color-scheme.js
@@ -1,70 +1,26 @@
 function changeColorScheme() {
-    const selectedTheme = localStorage.getItem('selectedTheme');
-
-    if (selectedTheme) {
-        applyTheme(selectedTheme);
-        return;
-    }
-
-    const currentColor = localStorage.getItem('currentColor') || '#6a5acd';
-    localStorage.setItem('currentColor', currentColor);
-    applyTheme('default', currentColor, currentColor, '#000');
+    const darkMode = localStorage.getItem('darkMode') === 'true';
+    applyTheme(darkMode ? 'dark' : 'sunset');
 }
 
-function applyTheme(theme, color, gradientStart, gradientEnd) {
-    const style = document.createElement('style');
-    let themeColor = color;
-    let gradStart = gradientStart || themeColor || '#6a5acd';
-    let gradEnd = gradientEnd || '#000';
+function toggleDarkMode() {
+    const darkMode = localStorage.getItem('darkMode') === 'true';
+    localStorage.setItem('darkMode', (!darkMode).toString());
+    applyTheme(!darkMode ? 'dark' : 'sunset');
+}
+
+function applyTheme(mode) {
+    const themeColor = '#ff7043';
+    const gradStart = themeColor;
+    const gradEnd = '#bf360c';
+    const style = document.getElementById('theme-style') || document.createElement('style');
+    style.id = 'theme-style';
     let css = '';
 
-    switch (theme) {
-        case 'dark':
-            themeColor = '#333333';
-            gradStart = themeColor;
-            gradEnd = '#555';
-            css = `
-        body { background-color: #121212; color: #ffffff; }
-      `;
-            break;
-        case 'light':
-            themeColor = '#e0e0e0';
-            gradStart = themeColor;
-            gradEnd = '#ccc';
-            css = `
-        body { background-color: #f5f5f5; color: #000000; }
-        .dark-mode { color: #000000; }
-      `;
-            break;
-        case 'ocean':
-            themeColor = '#1e90ff';
-            gradStart = themeColor;
-            gradEnd = '#01579b';
-            css = `
-        body { background-color: #e0f7fa; color: #000000; }
-      `;
-            break;
-        case 'forest':
-            themeColor = '#228b22';
-            gradStart = themeColor;
-            gradEnd = '#1b5e20';
-            css = `
-        body { background-color: #e8f5e9; color: #000000; }
-      `;
-            break;
-        case 'sunset':
-            themeColor = '#ff7043';
-            gradStart = themeColor;
-            gradEnd = '#bf360c';
-            css = `
-        body { background-color: #fff3e0; color: #000000; }
-      `;
-            break;
-        default:
-            themeColor = color || '#6a5acd';
-            gradStart = gradientStart || themeColor;
-            gradEnd = gradientEnd || '#000';
-            break;
+    if (mode === 'dark') {
+        css = `body { background-color: #121212; color: #ffffff; }`;
+    } else {
+        css = `body { background-color: #fff3e0; color: #000000; }`;
     }
 
     style.innerHTML = `
@@ -81,5 +37,9 @@ function applyTheme(theme, color, gradientStart, gradientEnd) {
     ${css}
   `;
     document.head.appendChild(style);
-    document.querySelector('meta[name="theme-color"]').setAttribute('content', themeColor);
+    const metaTheme = document.querySelector('meta[name="theme-color"]');
+    if (metaTheme) {
+        metaTheme.setAttribute('content', themeColor);
+    }
 }
+

--- a/index.css
+++ b/index.css
@@ -21,7 +21,7 @@ body {
 h1 {
     font-size: 2.5rem;
     color: var(--theme-color);
-    font-family: 'Georgia', serif;
+    font-family: 'Montserrat', sans-serif;
 }
 p {
     font-size: 1rem;
@@ -63,10 +63,7 @@ p {
 }
 .tour-step {
     font-size: 0.9rem;
-    font-family: 'Cursive', 'Brush Script MT', sans-serif;
-}
-.theme-selector {
-    margin-top: 2rem;
+    font-family: 'Montserrat', sans-serif;
 }
 .theme-button {
     background: #fff;

--- a/index.html
+++ b/index.html
@@ -42,14 +42,7 @@
                 <div class="tour-step" id="step4">🧩 Puzzle games available</div>
             </div>
         </div>
-        <div class="theme-selector">
-            <button class="theme-button" data-theme="default">Default</button>
-            <button class="theme-button" data-theme="dark">Dark</button>
-            <button class="theme-button" data-theme="light">Light</button>
-            <button class="theme-button" data-theme="ocean">Ocean</button>
-            <button class="theme-button" data-theme="forest">Forest</button>
-            <button class="theme-button" data-theme="sunset">Sunset</button>
-        </div>
+        <button id="dark-mode-toggle" class="theme-button">Toggle Dark Mode</button>
         <div style="font-size: 0.8rem; margin-top: 1rem; font-weight: bold;">Click the speaker icon for sound</div>
         <div id="speaker-container" style="position: absolute; top: 1rem; right: 1rem; cursor: pointer;">
             <svg id="speaker-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon icon-tabler icons-tabler-outline icon-tabler-volume-off ripple shockwave"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M15 8a5 5 0 0 1 0 8" /><path d="M17.7 5a9 9 0 0 1 0 14" /><path d="M6 15h-2a1 1 0 0 1 -1 -1v-4a1 1 0 0 1 1 -1h2l3.5 -4.5a.8 .8 0 0 1 1.5 .5v14a.8 .8 0 0 1 -1.5 .5l-3.5 -4.5" /><path d="M12 12l0 .01" /></svg>
@@ -140,13 +133,8 @@
             })
         })
 
-        document.querySelectorAll('.theme-button').forEach(button => {
-            button.addEventListener('click', () => {
-                const theme = button.dataset.theme;
-                localStorage.setItem('selectedTheme', theme);
-                applyTheme(theme);
-            });
-        });
+        const darkModeToggle = document.getElementById('dark-mode-toggle');
+        darkModeToggle.addEventListener('click', toggleDarkMode);
 
         const steps = ["#step1", "#step2", "#step3", "#step4"];
         let currentStep = 0;

--- a/main.html
+++ b/main.html
@@ -95,6 +95,22 @@
       animation: pulse 2s infinite;
     }
 
+    .dark-mode-toggle {
+      position: absolute;
+      top: 0.5rem;
+      left: 0.5rem;
+      background-color: var(--theme-color);
+      color: white;
+      padding: 0.6rem;
+      border: none;
+      border-radius: 50%;
+      font-size: 1.2rem;
+      cursor: pointer;
+      transition: all 0.3s ease;
+    }
+
+    .dark-mode-toggle:hover { background-color: var(--theme-color); }
+
     @keyframes pulse {
       0% {
         transform: scale(1);
@@ -550,6 +566,7 @@
 <body>
   <div class="header">
     Welcome to Àríyò AI
+    <button id="dark-mode-toggle" class="dark-mode-toggle" aria-label="Toggle dark mode">🌓</button>
     <button class="share-button" aria-label="Share this page" onclick="shareContent()">
       <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon icon-tabler icons-tabler-outline icon-tabler-share"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M6 12m-3 0a3 3 0 1 0 6 0a3 3 0 1 0 -6 0" /><path d="M18 6m-3 0a3 3 0 1 0 6 0a3 3 0 1 0 -6 0" /><path d="M18 18m-3 0a3 3 0 1 0 6 0a3 3 0 1 0 -6 0" /><path d="M8.7 10.7l6.6 -3.4" /><path d="M8.7 13.3l6.6 3.4" /></svg>
     </button>
@@ -749,6 +766,9 @@
   <script src="scripts/ui.js"></script>
   <script src="color-scheme.js"></script>
   <script src="scripts/main.js"></script>
+  <script>
+    document.getElementById('dark-mode-toggle').addEventListener('click', toggleDarkMode);
+  </script>
   <!-- Floating Watermarks -->
   <div class="floating-watermarks">
     <div class="watermark exploding-watermark" style="top: 10%; left: 5%;">Omoluabi Productions</div>

--- a/picture-game.css
+++ b/picture-game.css
@@ -1,13 +1,29 @@
-@import url('https://fonts.googleapis.com/css?family=Lobster&display=swap');
-
+/* Font and button styling */
 #game-title {
-    font-family: 'Lobster', cursive;
+    font-family: 'Montserrat', sans-serif;
     font-size: 3rem;
     color: var(--theme-color);
     text-shadow: 2px 2px 4px #000000;
     margin-bottom: 20px;
     text-align: center;
 }
+
+.dark-mode-toggle {
+    position: fixed;
+    top: 0.5rem;
+    left: 0.5rem;
+    background-color: var(--theme-color);
+    color: white;
+    padding: 0.6rem;
+    border: none;
+    border-radius: 50%;
+    font-size: 1.2rem;
+    cursor: pointer;
+    z-index: 1000;
+    transition: all 0.3s ease;
+}
+
+.dark-mode-toggle:hover { background-color: var(--theme-color); }
 
 #game-title::before {
     content: '';

--- a/picture-game.html
+++ b/picture-game.html
@@ -11,10 +11,12 @@
   <meta name="description" content="Play the Ara picture puzzle game from Àríyò AI by Paul Iyogun (Omoluabi)." />
   <meta name="keywords" content="Paul Iyogun, Omoluabi, Ariyo AI, picture puzzle game, Naija AI" />
   <title>Picture Puzzle Game</title>
+    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="color-scheme.css">
     <link rel="stylesheet" href="picture-game.css">
 </head>
 <body>
+    <button id="dark-mode-toggle" class="dark-mode-toggle" aria-label="Toggle dark mode">🌓</button>
     <div id="game-container">
         <h1 id="game-title">Ara Puzzle</h1>
         <div id="puzzle-container">
@@ -43,6 +45,7 @@
     <script src="color-scheme.js"></script>
     <script>
         changeColorScheme();
+        document.getElementById('dark-mode-toggle').addEventListener('click', toggleDarkMode);
     </script>
     <footer>
         <p>&copy; 2024 Omoluabi</p>

--- a/word-search.css
+++ b/word-search.css
@@ -1,13 +1,29 @@
-@import url('https://fonts.googleapis.com/css?family=Lobster&display=swap');
-
+/* Font and button styling */
 #game-title {
-    font-family: 'Lobster', cursive;
+    font-family: 'Montserrat', sans-serif;
     font-size: 3rem;
     color: var(--theme-color);
     text-shadow: 2px 2px 4px #000000;
     margin-bottom: 20px;
     text-align: center;
 }
+
+.dark-mode-toggle {
+    position: fixed;
+    top: 0.5rem;
+    left: 0.5rem;
+    background-color: var(--theme-color);
+    color: white;
+    padding: 0.6rem;
+    border: none;
+    border-radius: 50%;
+    font-size: 1.2rem;
+    cursor: pointer;
+    z-index: 1000;
+    transition: all 0.3s ease;
+}
+
+.dark-mode-toggle:hover { background-color: var(--theme-color); }
 
 #game-title::before {
     content: '';
@@ -21,7 +37,7 @@
 }
 
 body {
-    font-family: sans-serif;
+    font-family: 'Montserrat', sans-serif;
     display: flex;
     flex-direction: column;
     align-items: center;

--- a/word-search.html
+++ b/word-search.html
@@ -11,10 +11,12 @@
   <meta name="description" content="Enjoy the Ara word search puzzle from Àríyò AI created by Paul Iyogun (Omoluabi)." />
   <meta name="keywords" content="Paul Iyogun, Omoluabi, Ariyo AI, word search puzzle, Naija AI" />
   <title>Ara Word Search</title>
+    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="color-scheme.css">
     <link rel="stylesheet" type="text/css" href="word-search.css">
 </head>
 <body>
+    <button id="dark-mode-toggle" class="dark-mode-toggle" aria-label="Toggle dark mode">🌓</button>
     <h1 id="game-title">Ara Word Search</h1>
     <label for="category-select">Choose a category:</label>
     <select id="category-select"></select>
@@ -32,6 +34,7 @@
     <script src="color-scheme.js"></script>
     <script>
         changeColorScheme();
+        document.getElementById('dark-mode-toggle').addEventListener('click', toggleDarkMode);
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Simplify color handling to a single sunset palette with a new dark mode toggle stored in local storage
- Replace theme selector with a dark mode switch on landing, main, and game pages
- Standardize fonts to Montserrat for better readability

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a8f9f03fc8332b39b621b03f956d2