### PR TITLE
Remove text shadows for legibility

### DIFF
--- a/color-scheme.css
+++ b/color-scheme.css
@@ -18,17 +18,3 @@ body {
 .progress-bar div { background: var(--theme-color); }
 .install-btn { background: var(--theme-color); }
 .radio-region-header { color: var(--theme-color); }
-
-/* Ensure text remains legible regardless of theme colors */
-body,
-body * {
-  text-shadow:
-    -1px -1px 2px #000,
-    1px -1px 2px #000,
-    -1px 1px 2px #000,
-    1px 1px 2px #000,
-    -1px -1px 2px #fff,
-    1px -1px 2px #fff,
-    -1px 1px 2px #fff,
-    1px 1px 2px #fff;
-}

--- a/picture-game.css
+++ b/picture-game.css
@@ -3,7 +3,6 @@
     font-family: 'Montserrat', sans-serif;
     font-size: 3rem;
     color: var(--theme-color);
-    text-shadow: 2px 2px 4px #000000;
     margin-bottom: 20px;
     text-align: center;
 }

--- a/word-search.css
+++ b/word-search.css
@@ -3,7 +3,6 @@
     font-family: 'Montserrat', sans-serif;
     font-size: 3rem;
     color: var(--theme-color);
-    text-shadow: 2px 2px 4px #000000;
     margin-bottom: 20px;
     text-align: center;
 }


### PR DESCRIPTION
## Summary
- eliminate global text-shadow styling from the theme to prevent illegible text
- drop text shadows from picture and word search game titles for cleaner visuals

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ab574c1248332b5acdaa4d91942d0