### PR TITLE
Remove text shadows for legibility

### DIFF
--- a/color-scheme.css
+++ b/color-scheme.css
@@ -18,17 +18,3 @@ body {
 .progress-bar div { background: var(--theme-color); }
 .install-btn { background: var(--theme-color); }
 .radio-region-header { color: var(--theme-color); }
-
-/* Ensure text remains legible regardless of theme colors */
-body,
-body * {
-  text-shadow:
-    -1px -1px 2px #000,
-    1px -1px 2px #000,
-    -1px 1px 2px #000,
-    1px 1px 2px #000,
-    -1px -1px 2px #fff,
-    1px -1px 2px #fff,
-    -1px 1px 2px #fff,
-    1px 1px 2px #fff;
-}

--- a/index.css
+++ b/index.css
@@ -3,6 +3,7 @@ body {
     font-family: 'Montserrat', sans-serif;
     background-color: #000;
     color: #fff;
+    text-shadow: 1px 1px 2px #000;
     display: flex;
     justify-content: center;
     align-items: center;
@@ -20,7 +21,7 @@ body {
 }
 h1 {
     font-size: 2.5rem;
-    color: var(--theme-color);
+    color: #fff;
     font-family: 'Montserrat', sans-serif;
 }
 p {

--- a/picture-game.css
+++ b/picture-game.css
@@ -3,7 +3,6 @@
     font-family: 'Montserrat', sans-serif;
     font-size: 3rem;
     color: var(--theme-color);
-    text-shadow: 2px 2px 4px #000000;
     margin-bottom: 20px;
     text-align: center;
 }

--- a/style.css
+++ b/style.css
@@ -13,11 +13,12 @@ img {
 /* General Body Styles */
 body {
     font-family: 'Montserrat', sans-serif;
-    color: #fff;
-    background-color: #000;
+    color: #000;
+    background-color: #fff;
     margin: 0;
     padding: 0;
     overflow-x: hidden;
+    text-shadow: 1px 1px 2px #fff;
 }
 
 /* Header Styles */

--- a/word-search.css
+++ b/word-search.css
@@ -3,7 +3,6 @@
     font-family: 'Montserrat', sans-serif;
     font-size: 3rem;
     color: var(--theme-color);
-    text-shadow: 2px 2px 4px #000000;
     margin-bottom: 20px;
     text-align: center;
 }


### PR DESCRIPTION
## Summary
- set main page body text to black with a subtle white shadow
- keep index page text white, add black shadow, and normalize heading color

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ab574c1248332b5acdaa4d91942d0