### PR TITLE
Remove dark mode toggle and use static theme

### DIFF
--- a/about.html
+++ b/about.html
@@ -51,20 +51,6 @@
       text-align: center;
       position: relative;
     }
-    .dark-mode-toggle {
-      position: absolute;
-      top: 1rem;
-      left: 1rem;
-      background-color: var(--theme-color);
-      color: white;
-      padding: 0.6rem;
-      border: none;
-      border-radius: 50%;
-      font-size: 1.2rem;
-      cursor: pointer;
-      transition: all 0.3s ease;
-    }
-    .dark-mode-toggle:hover { background-color: var(--theme-color); }
     header h1 {
       margin: 0;
       font-size: 2.5rem;
@@ -171,7 +157,6 @@
 </head>
 <body>
   <header>
-    <button id="dark-mode-toggle" class="dark-mode-toggle" aria-label="Toggle dark mode">🌓</button>
     <h1>Àríyò AI - About Us</h1>
   </header>
 
@@ -234,7 +219,6 @@
   <script src="color-scheme.js"></script>
   <script>
     changeColorScheme();
-    document.getElementById('dark-mode-toggle').addEventListener('click', toggleDarkMode);
   </script>
 </body>
 </html>

--- a/color-scheme.js
+++ b/color-scheme.js
@@ -1,28 +1,13 @@
 function changeColorScheme() {
-    const darkMode = localStorage.getItem('darkMode') === 'true';
-    applyTheme(darkMode ? 'dark' : 'sunset');
+    applyTheme();
 }
 
-function toggleDarkMode() {
-    const darkMode = localStorage.getItem('darkMode') === 'true';
-    localStorage.setItem('darkMode', (!darkMode).toString());
-    applyTheme(!darkMode ? 'dark' : 'sunset');
-}
-
-function applyTheme(mode) {
+function applyTheme() {
     const themeColor = '#ff7043';
     const gradStart = themeColor;
     const gradEnd = '#bf360c';
     const style = document.getElementById('theme-style') || document.createElement('style');
     style.id = 'theme-style';
-    let css = '';
-
-    if (mode === 'dark') {
-        css = `body { background-color: #121212; color: #ffffff; }`;
-    } else {
-        css = `body { background-color: #fff3e0; color: #000000; }`;
-    }
-
     style.innerHTML = `
     :root { --theme-color: ${themeColor}; --gradient-start: ${gradStart}; --gradient-end: ${gradEnd}; }
     .header { background: linear-gradient(135deg, var(--gradient-start), var(--gradient-end)); }
@@ -34,7 +19,7 @@ function applyTheme(mode) {
     .progress-bar div { background: ${themeColor}; }
     .install-btn { background: ${themeColor}; }
     #start-button { background-color: ${themeColor}; }
-    ${css}
+    body { background-color: #fff3e0; color: #000000; }
   `;
     document.head.appendChild(style);
     const metaTheme = document.querySelector('meta[name="theme-color"]');

--- a/index.css
+++ b/index.css
@@ -66,20 +66,6 @@ p {
     font-size: 0.9rem;
     font-family: 'Montserrat', sans-serif;
 }
-.theme-button {
-    background: #fff;
-    color: #000;
-    border: 2px solid var(--theme-color);
-    padding: 0.5rem 1rem;
-    border-radius: 25px;
-    cursor: pointer;
-    margin: 0 0.5rem;
-    transition: all 0.3s ease-in-out;
-}
-.theme-button:hover {
-    background: var(--theme-color);
-    color: #fff;
-}
 
 @media (max-width: 768px) {
     h1 {

--- a/index.html
+++ b/index.html
@@ -42,7 +42,6 @@
                 <div class="tour-step" id="step4">🧩 Puzzle games available</div>
             </div>
         </div>
-        <button id="dark-mode-toggle" class="theme-button">Toggle Dark Mode</button>
         <div style="font-size: 0.8rem; margin-top: 1rem; font-weight: bold;">Click the speaker icon for sound</div>
         <div id="speaker-container" style="position: absolute; top: 1rem; right: 1rem; cursor: pointer;">
             <svg id="speaker-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon icon-tabler icons-tabler-outline icon-tabler-volume-off ripple shockwave"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M15 8a5 5 0 0 1 0 8" /><path d="M17.7 5a9 9 0 0 1 0 14" /><path d="M6 15h-2a1 1 0 0 1 -1 -1v-4a1 1 0 0 1 1 -1h2l3.5 -4.5a.8 .8 0 0 1 1.5 .5v14a.8 .8 0 0 1 -1.5 .5l-3.5 -4.5" /><path d="M12 12l0 .01" /></svg>
@@ -133,8 +132,6 @@
             })
         })
 
-        const darkModeToggle = document.getElementById('dark-mode-toggle');
-        darkModeToggle.addEventListener('click', toggleDarkMode);
 
         const steps = ["#step1", "#step2", "#step3", "#step4"];
         let currentStep = 0;

--- a/main.html
+++ b/main.html
@@ -69,7 +69,6 @@
       transition: background 0.5s ease-in-out, color 0.5s ease-in-out;
     }
     a { text-decoration: none; }
-    .dark-mode { background-color: #121212; color: #ffffff; }
     .header {
       padding: calc(1rem + env(safe-area-inset-top)) 1rem 1rem;
       text-align: center;
@@ -95,21 +94,6 @@
       animation: pulse 2s infinite;
     }
 
-    .dark-mode-toggle {
-      position: absolute;
-      top: 0.5rem;
-      left: 0.5rem;
-      background-color: var(--theme-color);
-      color: white;
-      padding: 0.6rem;
-      border: none;
-      border-radius: 50%;
-      font-size: 1.2rem;
-      cursor: pointer;
-      transition: all 0.3s ease;
-    }
-
-    .dark-mode-toggle:hover { background-color: var(--theme-color); }
 
     @keyframes pulse {
       0% {
@@ -566,7 +550,6 @@
 <body>
   <div class="header">
     Welcome to Àríyò AI
-    <button id="dark-mode-toggle" class="dark-mode-toggle" aria-label="Toggle dark mode">🌓</button>
     <button class="share-button" aria-label="Share this page" onclick="shareContent()">
       <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon icon-tabler icons-tabler-outline icon-tabler-share"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M6 12m-3 0a3 3 0 1 0 6 0a3 3 0 1 0 -6 0" /><path d="M18 6m-3 0a3 3 0 1 0 6 0a3 3 0 1 0 -6 0" /><path d="M18 18m-3 0a3 3 0 1 0 6 0a3 3 0 1 0 -6 0" /><path d="M8.7 10.7l6.6 -3.4" /><path d="M8.7 13.3l6.6 3.4" /></svg>
     </button>
@@ -763,12 +746,12 @@
 
   <script src="scripts/data.js"></script>
   <script src="scripts/player.js"></script>
-  <script src="scripts/ui.js"></script>
-  <script src="color-scheme.js"></script>
-  <script src="scripts/main.js"></script>
-  <script>
-    document.getElementById('dark-mode-toggle').addEventListener('click', toggleDarkMode);
-  </script>
+    <script src="scripts/ui.js"></script>
+    <script src="color-scheme.js"></script>
+    <script src="scripts/main.js"></script>
+    <script>
+      changeColorScheme();
+    </script>
   <!-- Floating Watermarks -->
   <div class="floating-watermarks">
     <div class="watermark exploding-watermark" style="top: 10%; left: 5%;">Omoluabi Productions</div>

--- a/picture-game.css
+++ b/picture-game.css
@@ -7,22 +7,6 @@
     text-align: center;
 }
 
-.dark-mode-toggle {
-    position: fixed;
-    top: 0.5rem;
-    left: 0.5rem;
-    background-color: var(--theme-color);
-    color: white;
-    padding: 0.6rem;
-    border: none;
-    border-radius: 50%;
-    font-size: 1.2rem;
-    cursor: pointer;
-    z-index: 1000;
-    transition: all 0.3s ease;
-}
-
-.dark-mode-toggle:hover { background-color: var(--theme-color); }
 
 #game-title::before {
     content: '';

--- a/picture-game.html
+++ b/picture-game.html
@@ -16,7 +16,6 @@
     <link rel="stylesheet" href="picture-game.css">
 </head>
 <body>
-    <button id="dark-mode-toggle" class="dark-mode-toggle" aria-label="Toggle dark mode">🌓</button>
     <div id="game-container">
         <h1 id="game-title">Ara Puzzle</h1>
         <div id="puzzle-container">
@@ -45,7 +44,6 @@
     <script src="color-scheme.js"></script>
     <script>
         changeColorScheme();
-        document.getElementById('dark-mode-toggle').addEventListener('click', toggleDarkMode);
     </script>
     <footer>
         <p>&copy; 2024 Omoluabi</p>

--- a/word-search.css
+++ b/word-search.css
@@ -7,22 +7,6 @@
     text-align: center;
 }
 
-.dark-mode-toggle {
-    position: fixed;
-    top: 0.5rem;
-    left: 0.5rem;
-    background-color: var(--theme-color);
-    color: white;
-    padding: 0.6rem;
-    border: none;
-    border-radius: 50%;
-    font-size: 1.2rem;
-    cursor: pointer;
-    z-index: 1000;
-    transition: all 0.3s ease;
-}
-
-.dark-mode-toggle:hover { background-color: var(--theme-color); }
 
 #game-title::before {
     content: '';

--- a/word-search.html
+++ b/word-search.html
@@ -16,7 +16,6 @@
     <link rel="stylesheet" type="text/css" href="word-search.css">
 </head>
 <body>
-    <button id="dark-mode-toggle" class="dark-mode-toggle" aria-label="Toggle dark mode">🌓</button>
     <h1 id="game-title">Ara Word Search</h1>
     <label for="category-select">Choose a category:</label>
     <select id="category-select"></select>
@@ -34,7 +33,6 @@
     <script src="color-scheme.js"></script>
     <script>
         changeColorScheme();
-        document.getElementById('dark-mode-toggle').addEventListener('click', toggleDarkMode);
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Remove dark mode toggle button and event listeners from all pages.
- Simplify color-scheme.js to always apply the sunset theme.
- Clean up unused CSS and scripts.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ab8f7cc448332bc9d92866f0ab965