### PR TITLE
fix: prevent service worker reload loop

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -382,21 +382,18 @@
     // PWA Install Prompt
     if ('serviceWorker' in navigator) {
       // Reload the page when a new service worker activates
+      let refreshing = false;
       navigator.serviceWorker.addEventListener('controllerchange', () => {
+        if (refreshing) return;
+        refreshing = true;
         window.location.reload();
       });
       window.addEventListener('load', function() {
         showIosInstallBanner();
-        navigator.serviceWorker.getRegistrations().then(function(registrations) {
-          for(let registration of registrations) {
-            registration.unregister();
-          }
-        }).then(function() {
-          navigator.serviceWorker.register('/service-worker.js').then(function(registration) {
-            console.log('Service Worker registered with scope:', registration.scope);
-          }).catch(function(error) {
-            console.log('Service worker registration failed:', error);
-          });
+        navigator.serviceWorker.register('/service-worker.js').then(function(registration) {
+          console.log('Service Worker registered with scope:', registration.scope);
+        }).catch(function(error) {
+          console.log('Service worker registration failed:', error);
         });
       });
     }


### PR DESCRIPTION
## Summary
- prevent infinite refresh loop by avoiding service worker unregister on load
- reload once when a new service worker takes control with a guard

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689abb90c2088332a874ca6141a262a5