### PR TITLE
fix: prevent service worker reload loop and outline index text

### DIFF
--- a/index.css
+++ b/index.css
@@ -3,7 +3,10 @@ body {
     font-family: 'Montserrat', sans-serif;
     background-color: #000;
     color: #fff;
-    text-shadow: 1px 1px 2px #000;
+    text-shadow: -1px -1px 0 #000,
+                 1px -1px 0 #000,
+                 -1px 1px 0 #000,
+                 1px 1px 0 #000;
     display: flex;
     justify-content: center;
     align-items: center;
@@ -21,12 +24,15 @@ body {
 }
 h1 {
     font-size: 2.5rem;
-    color: #fff;
     font-family: 'Montserrat', sans-serif;
 }
 p {
     font-size: 1rem;
     margin-bottom: 1.5rem;
+}
+
+a {
+    color: #fff;
 }
 .enter-icon {
     cursor: pointer;

--- a/index.html
+++ b/index.html
@@ -46,8 +46,8 @@
         <div id="speaker-container" style="position: absolute; top: 1rem; right: 1rem; cursor: pointer;">
             <svg id="speaker-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon icon-tabler icons-tabler-outline icon-tabler-volume-off ripple shockwave"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M15 8a5 5 0 0 1 0 8" /><path d="M17.7 5a9 9 0 0 1 0 14" /><path d="M6 15h-2a1 1 0 0 1 -1 -1v-4a1 1 0 0 1 1 -1h2l3.5 -4.5a.8 .8 0 0 1 1.5 .5v14a.8 .8 0 0 1 -1.5 .5l-3.5 -4.5" /><path d="M12 12l0 .01" /></svg>
         </div>
-        <footer style="font-size: 0.7rem; margin-top: 2rem; color: #aaa;">
-            <p>&copy; 2024 <a href="https://linkedin.com/in/paul-iyogun-7591a571" target="_blank" style="color: var(--theme-color);">A Paul Iyogun (A.K.A. Omoluabi)</a> Project. All Rights Reserved.</p>
+        <footer style="font-size: 0.7rem; margin-top: 2rem;">
+            <p>&copy; 2024 <a href="https://linkedin.com/in/paul-iyogun-7591a571" target="_blank">A Paul Iyogun (A.K.A. Omoluabi)</a> Project. All Rights Reserved.</p>
         </footer>
     </div>
 

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -382,21 +382,18 @@
     // PWA Install Prompt
     if ('serviceWorker' in navigator) {
       // Reload the page when a new service worker activates
+      let refreshing = false;
       navigator.serviceWorker.addEventListener('controllerchange', () => {
+        if (refreshing) return;
+        refreshing = true;
         window.location.reload();
       });
       window.addEventListener('load', function() {
         showIosInstallBanner();
-        navigator.serviceWorker.getRegistrations().then(function(registrations) {
-          for(let registration of registrations) {
-            registration.unregister();
-          }
-        }).then(function() {
-          navigator.serviceWorker.register('/service-worker.js').then(function(registration) {
-            console.log('Service Worker registered with scope:', registration.scope);
-          }).catch(function(error) {
-            console.log('Service worker registration failed:', error);
-          });
+        navigator.serviceWorker.register('/service-worker.js').then(function(registration) {
+          console.log('Service Worker registered with scope:', registration.scope);
+        }).catch(function(error) {
+          console.log('Service worker registration failed:', error);
         });
       });
     }


### PR DESCRIPTION
## Summary
- prevent infinite refresh loop by avoiding service worker unregister on load
- reload once when a new service worker takes control with a guard
- outline index page text in white with black edges for readability

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689abb90c2088332a874ca6141a262a5