### PR TITLE
Ensure white text on index and resize media player modal

### DIFF
--- a/index.css
+++ b/index.css
@@ -16,16 +16,24 @@ body {
     background-size: cover;
     background-position: center;
 }
+
 .overlay {
     background-color: rgba(0, 0, 0, 0.7);
     padding: 2rem;
     border-radius: 15px;
     position: relative;
+    color: #fff; /* Ensure overlay text is white */
 }
+
+h1, p, .tour-step, footer {
+    color: #fff; /* Explicit white text for index page */
+}
+
 h1 {
     font-size: 2.5rem;
     font-family: 'Montserrat', sans-serif;
 }
+
 p {
     font-size: 1rem;
     margin-bottom: 1.5rem;

--- a/style.css
+++ b/style.css
@@ -201,6 +201,7 @@ body {
 .track-info {
     margin-top: 0.3rem;
     font-size: clamp(1rem, 3vw, 1.2rem);
+    font-weight: bold; /* Improve legibility */
 }
 
 .track-duration {
@@ -211,6 +212,7 @@ body {
 .track-details {
     margin-top: 0.2rem;
     font-size: clamp(0.8rem, 2vw, 0.9rem);
+    font-weight: bold; /* Improve legibility */
 }
 
 #streakInfo {
@@ -244,12 +246,12 @@ body {
 
 .modal-content {
     background-color: #fefefe;
-    margin: 10% auto;
+    margin: 15% auto; /* Increased top margin to avoid header overlap */
     padding: 1.5rem;
     border: 1px solid #888;
-    width: 90%;
-    max-width: 600px;
-    max-height: 80vh;
+    width: 60%; /* Further reduce width */
+    max-width: 400px; /* Further reduce max width */
+    max-height: 60vh; /* Further reduce height */
     overflow-y: auto;
     border-radius: 10px;
 }


### PR DESCRIPTION
## Summary
- Guarantee white text throughout the index overlay and main content for consistent contrast
- Reduce modal size to 60% and make music player details bold for legibility

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689abe4cb1908332850aa7b124bff89f