### PR TITLE
Improve modal layout on small screens

### DIFF
--- a/style.css
+++ b/style.css
@@ -337,4 +337,7 @@ body {
     .music-controls.icons-only {
         flex-wrap: wrap;
     }
+    .modal-content {
+        width: 90%;
+    }
 }


### PR DESCRIPTION
## Summary
- Ensure modal windows resize to 90% width on viewports under 480px

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ac4b0a38c8332a722ae44f2b23a74