### PR TITLE
Enhance visibility of player text and adjust share button

### DIFF
--- a/main.html
+++ b/main.html
@@ -81,8 +81,8 @@
     }
     .share-button {
       position: absolute;
-      top: 0.5rem;
-      right: 0.5rem;
+      top: calc(0.5rem + env(safe-area-inset-top));
+      right: 1rem;
       background-color: var(--theme-color);
       color: white;
       padding: 0.6rem;
@@ -92,6 +92,9 @@
       cursor: pointer;
       transition: all 0.3s ease;
       animation: pulse 2s infinite;
+      display: flex;
+      align-items: center;
+      justify-content: center;
     }
 
 
@@ -551,7 +554,7 @@
   <div class="header">
     Welcome to Àríyò AI
     <button class="share-button" aria-label="Share this page" onclick="shareContent()">
-      <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon icon-tabler icons-tabler-outline icon-tabler-share"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M6 12m-3 0a3 3 0 1 0 6 0a3 3 0 1 0 -6 0" /><path d="M18 6m-3 0a3 3 0 1 0 6 0a3 3 0 1 0 -6 0" /><path d="M18 18m-3 0a3 3 0 1 0 6 0a3 3 0 1 0 -6 0" /><path d="M8.7 10.7l6.6 -3.4" /><path d="M8.7 13.3l6.6 3.4" /></svg>
+      <i class="fas fa-share-alt"></i>
     </button>
   </div>
 

--- a/style.css
+++ b/style.css
@@ -31,6 +31,9 @@ body {
     box-shadow: 0px 5px 15px rgba(0,0,0,0.3);
     background: linear-gradient(135deg, var(--gradient-start), var(--gradient-end));
     position: relative;
+    color: #000;
+    -webkit-text-stroke: 1px #fff;
+    text-shadow: 0 0 2px #fff;
 }
 
 /* Container and Sidebar */
@@ -202,17 +205,32 @@ body {
     margin-top: 0.3rem;
     font-size: clamp(1rem, 3vw, 1.2rem);
     font-weight: bold; /* Improve legibility */
+    color: #000;
+    -webkit-text-stroke: 0.5px #fff;
+    text-shadow: 0 0 1px #fff;
 }
 
 .track-duration {
     font-size: clamp(0.8rem, 2vw, 0.9rem);
     margin-top: 0.2rem;
+    color: #000;
+    -webkit-text-stroke: 0.5px #fff;
+    text-shadow: 0 0 1px #fff;
 }
 
 .track-details {
     margin-top: 0.2rem;
     font-size: clamp(0.8rem, 2vw, 0.9rem);
     font-weight: bold; /* Improve legibility */
+    color: #000;
+    -webkit-text-stroke: 0.5px #fff;
+    text-shadow: 0 0 1px #fff;
+}
+
+.music-player h3 {
+    color: #000;
+    -webkit-text-stroke: 0.5px #fff;
+    text-shadow: 0 0 1px #fff;
 }
 
 #streakInfo {


### PR DESCRIPTION
## Summary
- Add white outlines to app header and media player text for better contrast
- Reposition share button with safe-area spacing and swap to Font Awesome icon

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ac858020883329668e591be8f08f9