### PR TITLE
Improve word search visibility on small screens

### DIFF
--- a/word-search.css
+++ b/word-search.css
@@ -80,6 +80,9 @@ label[for="category-select"] {
 
 .cell {
     text-align: center;
+    display: flex;
+    align-items: center;
+    justify-content: center;
     border: 1px solid #ccc;
     cursor: pointer;
     user-select: none;
@@ -129,7 +132,10 @@ label[for="category-select"] {
     position: absolute;
     top: 0;
     left: 0;
+    width: 100%;
+    height: 100%;
     pointer-events: none;
+    background: transparent;
 }
 
 @media (max-width: 480px) {
@@ -138,7 +144,7 @@ label[for="category-select"] {
         align-items: center;
     }
     #game-board {
-        max-width: 90vw;
+        max-width: 100vw;
     }
     #word-list {
         margin: 1rem 0 0 0;

--- a/word-search.js
+++ b/word-search.js
@@ -65,12 +65,14 @@ function updateGridSize() {
 }
 
 function getCellSize() {
-    const maxSize = 24;
-    const availableWidth = window.innerWidth * 0.6;
+    const maxSize = 32;
+    const minSize = 20;
+    const availableWidth = window.innerWidth * 0.9;
     const availableHeight = window.innerHeight * 0.8;
     const available = Math.floor(Math.min(availableWidth, availableHeight));
     const extras = (GRID_GAP * (gridSize - 1)) + (BOARD_PADDING * 2) + (BOARD_BORDER * 2);
-    return Math.min(maxSize, Math.floor((available - extras) / gridSize));
+    const size = Math.floor((available - extras) / gridSize);
+    return Math.max(minSize, Math.min(maxSize, size));
 }
 const board = [];
 const wordListElement = document.getElementById("word-list");


### PR DESCRIPTION
## Summary
- enlarge mobile grid cells and enforce minimum size for letter visibility
- center grid tile content and ensure overlay canvas covers the board transparently
- allow the puzzle board to use full width on narrow screens

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b2857ce30833281002cc91b2a47c0