### PR TITLE
Restore now playing toast notifications

### DIFF
--- a/main.html
+++ b/main.html
@@ -545,6 +545,27 @@
         bottom: calc(15rem + env(safe-area-inset-bottom));
       }
     }
+
+    #nowPlayingToast {
+      position: fixed;
+      bottom: 90px;
+      left: 50%;
+      transform: translateX(-50%);
+      background: rgba(0,0,0,0.85);
+      color: white;
+      padding: 0.8rem 1.5rem;
+      border-radius: 25px;
+      font-size: 0.95rem;
+      box-shadow: 0 4px 10px rgba(0,0,0,0.5);
+      opacity: 0;
+      pointer-events: none;
+      z-index: 9999;
+      transition: opacity 0.4s ease;
+    }
+
+    #nowPlayingToast.show {
+      opacity: 1;
+    }
   </style>
   <link rel="stylesheet" href="color-scheme.css">
   <link rel="stylesheet" href="style.css">
@@ -730,22 +751,8 @@
 
 
 
-  <!-- 🎧 Now Playing Toast -->
-<div id="nowPlayingToast" style="
-  position: fixed;
-  bottom: 90px;
-  left: 50%;
-  transform: translateX(-50%);
-  background: rgba(0,0,0,0.85);
-  color: white;
-  padding: 0.8rem 1.5rem;
-  border-radius: 25px;
-  font-size: 0.95rem;
-  box-shadow: 0 4px 10px rgba(0,0,0,0.5);
-  display: none;
-  z-index: 9999;
-  transition: all 0.4s ease;
-">Now playing</div>
+<!-- 🎧 Now Playing Toast -->
+  <div id="nowPlayingToast" role="status" aria-live="polite"></div>
 
   <script src="scripts/data.js"></script>
   <script src="scripts/player.js"></script>

--- a/scripts/ui.js
+++ b/scripts/ui.js
@@ -285,9 +285,10 @@ function closeWordSearchGame() {
 
 function showNowPlayingToast(trackTitle) {
   const toast = document.getElementById('nowPlayingToast');
+  if (!toast) return;
   toast.textContent = `Now playing: ${trackTitle}`;
-  toast.style.display = 'block';
+  toast.classList.add('show');
   setTimeout(() => {
-    toast.style.display = 'none';
+    toast.classList.remove('show');
   }, 3000);
 }


### PR DESCRIPTION
## Summary
- Add dedicated styles and markup for now playing toast
- Show toast by toggling CSS class instead of inline display

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b29daebf4833280a5d1bf2dca9cd5