### PR TITLE
Improve modal usability and add sticky return control

### DIFF
--- a/about.html
+++ b/about.html
@@ -100,6 +100,18 @@
       border-radius: 12px;
       box-shadow: 0 5px 15px rgba(0,0,0,0.5);
     }
+    .return-button {
+      position: sticky;
+      top: 10px;
+      background: var(--theme-color);
+      color: #fff;
+      border: none;
+      padding: 0.6rem 1rem;
+      border-radius: 25px;
+      cursor: pointer;
+      z-index: 1000;
+      display: inline-block;
+    }
     section.album-section, section.social-section {
       background-color: #1a1a1a;
       padding: 3rem 2rem;
@@ -159,6 +171,8 @@
   <header>
     <h1>Àríyò AI - About Us</h1>
   </header>
+
+  <button class="return-button" onclick="if (typeof navigateToHome === 'function') { navigateToHome(); } else { window.location.href='main.html'; }">🎵 Back to Player</button>
 
   <section class="banner">
     <h2>Who We Be</h2>

--- a/style.css
+++ b/style.css
@@ -262,24 +262,32 @@ body {
     background-color: rgba(0,0,0,0.4);
 }
 
+
 .modal-content {
     background-color: #222;
-    margin: 15% auto; /* Increased top margin to avoid header overlap */
+    margin: 5% auto; /* Raise modal vertically for more viewable area */
     padding: 1.5rem;
     border: 1px solid #888;
     width: 80%; /* Reduce width */
     max-width: 500px; /* Reduce max width */
-    max-height: 70vh; /* Reduce height */
+    max-height: 80vh; /* Increase height for better scrolling */
     overflow-y: auto;
     border-radius: 10px;
     color: #fff;
+    position: relative; /* Needed for sticky elements inside */
 }
+
 
 .close {
     color: #aaa;
     float: right;
     font-size: 1.8rem;
     font-weight: bold;
+    position: sticky;
+    top: 0;
+    background: #222;
+    padding: 0.2rem 0.5rem;
+    z-index: 1;
 }
 
 .close:hover,


### PR DESCRIPTION
## Summary
- Raise modal content and increase height for better visibility
- Keep modal close buttons in view while scrolling
- Add sticky "Back to Player" button to About page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b2c693a108332a662b8b777f01cff