### PR TITLE
Ensure PWA clients receive updates

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -538,6 +538,13 @@
             .then(response => response.json())
             .then(data => {
                 if (currentVersion && currentVersion !== data.version) {
+                    if ('serviceWorker' in navigator) {
+                        navigator.serviceWorker.getRegistration().then(reg => {
+                            if (reg) {
+                                reg.update();
+                            }
+                        });
+                    }
                     // New version available, prompt user to update
                     if (confirm('A new version of Àríyò AI is available. Reload to update?')) {
                         window.location.reload();

--- a/service-worker.js
+++ b/service-worker.js
@@ -5,7 +5,7 @@ self.addEventListener('install', event => {
   // Activate this service worker immediately after installation
   self.skipWaiting();
   event.waitUntil(
-    fetch('/version.json')
+    fetch('/version.json', { cache: 'no-store' })
       .then(response => response.json())
       .then(data => {
         CACHE_NAME = `${CACHE_PREFIX}-${data.version}`;

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "6897a4ce"
+  "version": "ef3398b7"
 }


### PR DESCRIPTION
## Summary
- Avoid caching version metadata when installing the service worker
- Force service worker update before reloading when a new version is detected
- Bump version.json to trigger cache refresh

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689b30dc87b083328530055c6b146536