### PR TITLE
feat: add tetris mini-game

### DIFF
--- a/main.html
+++ b/main.html
@@ -398,7 +398,7 @@
     .tap-area.right {
         right: 0;
     }
-    .chatbot-float-icon, .sabi-bible-float-icon, .picture-game-float-icon {
+    .chatbot-float-icon, .sabi-bible-float-icon, .picture-game-float-icon, .tetris-float-icon {
       width: 50px;
       height: 50px;
       border-radius: 50%;
@@ -704,6 +704,10 @@
         <div class="word-search-bubble-container" role="button" aria-label="Open Word Search Game" onclick="openWordSearchGame()">
             <img src="https://img.icons8.com/color/96/search.png" alt="Word Search Game Icon" class="picture-game-float-icon" />
         </div>
+        <!-- Tetris Game Floating Icon -->
+        <div class="tetris-bubble-container" role="button" aria-label="Open Tetris Game" onclick="openTetrisGame()">
+            <img src="https://img.icons8.com/color/96/joystick.png" alt="Tetris Game Icon" class="tetris-float-icon" />
+        </div>
     </div>
 </div>
 
@@ -747,6 +751,13 @@
     <button class="popup-close ripple shockwave" onclick="closeWordSearchGame()">×</button>
     <h3 id="wordSearchGameTitle" class="modal-title">Word Search Game</h3>
     <iframe src="word-search.html" style="width: 100%; height: 100%; border: none;"></iframe>
+</div>
+
+<!-- Tetris Game Container -->
+<div id="tetrisGameContainer" class="chatbot-container" role="dialog" aria-labelledby="tetrisGameTitle">
+    <button class="popup-close ripple shockwave" onclick="closeTetrisGame()">×</button>
+    <h3 id="tetrisGameTitle" class="modal-title">Tetris</h3>
+    <iframe src="tetris.html" style="width: 100%; height: 100%; border: none;"></iframe>
 </div>
 
 

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -518,7 +518,7 @@
 
     // Dynamic Edge Panel Height
     const edgePanelContent = document.querySelector('.edge-panel-content');
-    const icons = edgePanelContent.querySelectorAll('.chatbot-bubble-container, .sabi-bible-bubble-container, .picture-game-bubble-container, .word-search-bubble-container');
+    const icons = edgePanelContent.querySelectorAll('.chatbot-bubble-container, .sabi-bible-bubble-container, .picture-game-bubble-container, .word-search-bubble-container, .tetris-bubble-container');
     const iconHeight = 50; // height of each icon
     const iconSpacing = 20; // spacing between icons
     const panelPadding = 20; // top and bottom padding of the panel

--- a/scripts/ui.js
+++ b/scripts/ui.js
@@ -133,12 +133,14 @@ const chatbotContainer = document.getElementById('chatbotContainer');
 const sabiBibleContainer = document.getElementById('sabiBibleContainer');
 const pictureGameContainer = document.getElementById('pictureGameContainer');
 const wordSearchGameContainer = document.getElementById('wordSearchGameContainer');
+const tetrisGameContainer = document.getElementById('tetrisGameContainer');
 
 function isAnyPanelOpen() {
     return chatbotContainer.style.display === 'block' ||
            sabiBibleContainer.style.display === 'block' ||
            pictureGameContainer.style.display === 'block' ||
-           wordSearchGameContainer.style.display === 'block';
+           wordSearchGameContainer.style.display === 'block' ||
+           tetrisGameContainer.style.display === 'block';
 }
 
 // Spoof user as if dem dey America
@@ -186,6 +188,16 @@ function openWordSearchGame() {
 function closeWordSearchGame() {
     const wordSearchGameContainer = document.getElementById('wordSearchGameContainer');
     wordSearchGameContainer.style.display = 'none';
+    updateEdgePanelBehavior();
+}
+
+function openTetrisGame() {
+    tetrisGameContainer.style.display = 'block';
+    updateEdgePanelBehavior();
+}
+
+function closeTetrisGame() {
+    tetrisGameContainer.style.display = 'none';
     updateEdgePanelBehavior();
 }
 

--- a/service-worker.js
+++ b/service-worker.js
@@ -29,6 +29,9 @@ self.addEventListener('install', event => {
           'picture-game.html',
           'picture-game.css',
           'picture-game.js',
+          'tetris.html',
+          'tetris.css',
+          'tetris.js',
           'offline-audio.mp3'
         ];
         return caches.open(CACHE_NAME).then(cache => {

--- a/tetris.css
+++ b/tetris.css
@@ -1,0 +1,32 @@
+body {
+    font-family: 'Montserrat', sans-serif;
+    background: var(--background-color, #000);
+    color: var(--text-color, #fff);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: flex-start;
+    margin: 0;
+    height: 100vh;
+}
+
+#game-title {
+    margin-top: 20px;
+    font-size: 2rem;
+}
+
+#tetris {
+    border: 2px solid var(--theme-color, #00f);
+    background: #000;
+    margin-top: 10px;
+}
+
+#score {
+    margin-top: 10px;
+    font-size: 1.2rem;
+}
+
+footer {
+    margin-top: auto;
+    padding: 10px;
+}

--- a/tetris.html
+++ b/tetris.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+    <meta name="apple-mobile-web-app-title" content="Àríyò AI" />
+    <meta name="apple-touch-fullscreen" content="yes" />
+    <link rel="apple-touch-icon" href="icons/Ariyo.png" />
+    <meta name="description" content="Play a simple Tetris game in Àríyò AI by Paul Iyogun (Omoluabi)." />
+    <meta name="keywords" content="Paul Iyogun, Omoluabi, Ariyo AI, Tetris game, Naija AI" />
+    <title>Tetris Game</title>
+    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="color-scheme.css" />
+    <link rel="stylesheet" href="tetris.css" />
+</head>
+<body>
+    <div id="game-container">
+        <h1 id="game-title">Tetris</h1>
+        <canvas id="tetris" width="200" height="400" aria-label="Tetris play field"></canvas>
+        <div id="score">Score: 0</div>
+    </div>
+    <script src="tetris.js"></script>
+    <script src="color-scheme.js"></script>
+    <script>
+        changeColorScheme();
+    </script>
+    <footer>
+        <p>&copy; 2024 Omoluabi</p>
+    </footer>
+</body>
+</html>

--- a/tetris.js
+++ b/tetris.js
@@ -1,0 +1,218 @@
+const canvas = document.getElementById('tetris');
+const context = canvas.getContext('2d');
+context.scale(20, 20);
+
+function createMatrix(w, h) {
+    const matrix = [];
+    while (h--) {
+        matrix.push(new Array(w).fill(0));
+    }
+    return matrix;
+}
+
+function createPiece(type) {
+    switch (type) {
+        case 'I': return [
+            [0, 0, 0, 0],
+            [1, 1, 1, 1],
+            [0, 0, 0, 0],
+            [0, 0, 0, 0],
+        ];
+        case 'J': return [
+            [1, 0, 0],
+            [1, 1, 1],
+            [0, 0, 0],
+        ];
+        case 'L': return [
+            [0, 0, 1],
+            [1, 1, 1],
+            [0, 0, 0],
+        ];
+        case 'O': return [
+            [1, 1],
+            [1, 1],
+        ];
+        case 'S': return [
+            [0, 1, 1],
+            [1, 1, 0],
+            [0, 0, 0],
+        ];
+        case 'T': return [
+            [0, 1, 0],
+            [1, 1, 1],
+            [0, 0, 0],
+        ];
+        case 'Z': return [
+            [1, 1, 0],
+            [0, 1, 1],
+            [0, 0, 0],
+        ];
+    }
+}
+
+function collide(arena, player) {
+    const [m, o] = [player.matrix, player.pos];
+    for (let y = 0; y < m.length; ++y) {
+        for (let x = 0; x < m[y].length; ++x) {
+            if (m[y][x] !== 0 &&
+                (arena[y + o.y] && arena[y + o.y][x + o.x]) !== 0) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+function merge(arena, player) {
+    player.matrix.forEach((row, y) => {
+        row.forEach((value, x) => {
+            if (value !== 0) {
+                arena[y + player.pos.y][x + player.pos.x] = value;
+            }
+        });
+    });
+}
+
+function rotate(matrix, dir) {
+    for (let y = 0; y < matrix.length; ++y) {
+        for (let x = 0; x < y; ++x) {
+            [matrix[x][y], matrix[y][x]] = [matrix[y][x], matrix[x][y]];
+        }
+    }
+    if (dir > 0) {
+        matrix.forEach(row => row.reverse());
+    } else {
+        matrix.reverse();
+    }
+}
+
+function arenaSweep() {
+    outer: for (let y = arena.length - 1; y >= 0; --y) {
+        for (let x = 0; x < arena[y].length; ++x) {
+            if (arena[y][x] === 0) {
+                continue outer;
+            }
+        }
+        const row = arena.splice(y, 1)[0].fill(0);
+        arena.unshift(row);
+        ++y;
+        player.score += 10;
+    }
+}
+
+function drawMatrix(matrix, offset) {
+    matrix.forEach((row, y) => {
+        row.forEach((value, x) => {
+            if (value !== 0) {
+                context.fillStyle = colors[value];
+                context.fillRect(x + offset.x, y + offset.y, 1, 1);
+            }
+        });
+    });
+}
+
+function draw() {
+    context.fillStyle = '#000';
+    context.fillRect(0, 0, canvas.width, canvas.height);
+    drawMatrix(arena, { x: 0, y: 0 });
+    drawMatrix(player.matrix, player.pos);
+}
+
+function playerDrop() {
+    player.pos.y++;
+    if (collide(arena, player)) {
+        player.pos.y--;
+        merge(arena, player);
+        playerReset();
+        arenaSweep();
+        updateScore();
+    }
+    dropCounter = 0;
+}
+
+function playerMove(dir) {
+    player.pos.x += dir;
+    if (collide(arena, player)) {
+        player.pos.x -= dir;
+    }
+}
+
+function playerReset() {
+    const pieces = 'TJLOSZI';
+    player.matrix = createPiece(pieces[(pieces.length * Math.random()) | 0]);
+    player.pos.y = 0;
+    player.pos.x = (arena[0].length / 2 | 0) - (player.matrix[0].length / 2 | 0);
+    if (collide(arena, player)) {
+        arena.forEach(row => row.fill(0));
+        player.score = 0;
+        updateScore();
+    }
+}
+
+function playerRotate(dir) {
+    const pos = player.pos.x;
+    let offset = 1;
+    rotate(player.matrix, dir);
+    while (collide(arena, player)) {
+        player.pos.x += offset;
+        offset = -(offset + (offset > 0 ? 1 : -1));
+        if (offset > player.matrix[0].length) {
+            rotate(player.matrix, -dir);
+            player.pos.x = pos;
+            return;
+        }
+    }
+}
+
+let dropCounter = 0;
+let dropInterval = 1000;
+let lastTime = 0;
+
+function update(time = 0) {
+    const deltaTime = time - lastTime;
+    lastTime = time;
+    dropCounter += deltaTime;
+    if (dropCounter > dropInterval) {
+        playerDrop();
+    }
+    draw();
+    requestAnimationFrame(update);
+}
+
+function updateScore() {
+    document.getElementById('score').innerText = `Score: ${player.score}`;
+}
+
+document.addEventListener('keydown', event => {
+    if (event.key === 'ArrowLeft') {
+        playerMove(-1);
+    } else if (event.key === 'ArrowRight') {
+        playerMove(1);
+    } else if (event.key === 'ArrowDown') {
+        playerDrop();
+    } else if (event.key === 'ArrowUp') {
+        playerRotate(1);
+    }
+});
+
+const colors = [
+    null,
+    '#00f0f0',
+    '#0000f0',
+    '#f0a000',
+    '#f0f000',
+    '#00f000',
+    '#a000f0',
+    '#f00000'
+];
+
+const arena = createMatrix(10, 20);
+const player = {
+    pos: { x: 0, y: 0 },
+    matrix: null,
+    score: 0
+};
+
+playerReset();
+updateScore();
+update();

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "ef3398b7"
+  "version": "tetris1"
 }


### PR DESCRIPTION
## Summary
- add standalone Tetris game with HTML, CSS and JavaScript
- integrate Tetris into edge panel with new icon and open/close handlers
- cache Tetris assets for offline play

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689bd9a6fe90833294a2ca4bd7c0a16e