### PR TITLE
Move Tetris controls to sidebar

### DIFF
--- a/tetris.css
+++ b/tetris.css
@@ -32,6 +32,13 @@ body {
     display: flex;
     flex-direction: column;
     align-items: center;
+    gap: 10px;
+}
+
+#sidebar-icon {
+    width: 60px;
+    height: 60px;
+    border-radius: 10px;
 }
 
 #next-title {
@@ -92,13 +99,13 @@ footer {
 
 @media (max-width: 600px) {
     #game-wrapper {
-        flex-direction: column;
-        align-items: center;
+        flex-direction: row;
+        align-items: flex-start;
     }
     #sidebar {
-        flex-direction: row;
-        gap: 20px;
-        margin-top: 10px;
+        flex-direction: column;
+        gap: 10px;
+        margin-top: 0;
     }
     #next-title {
         align-self: center;

--- a/tetris.html
+++ b/tetris.html
@@ -21,22 +21,23 @@
         <div id="game-wrapper">
             <canvas id="tetris" width="200" height="400" aria-label="Tetris play field"></canvas>
             <div id="sidebar">
+                <img id="sidebar-icon" src="icons/Ariyo.png" alt="Ariyo icon" />
                 <h2 id="next-title">Next</h2>
                 <canvas id="next" width="80" height="80" aria-label="Next piece preview"></canvas>
                 <div id="score" aria-live="polite" role="status">Score: 0</div>
-            </div>
-        </div>
-        <div id="controls">
-            <div class="control-row">
-                <button id="btn-rotate" aria-label="Rotate piece">⟳</button>
-            </div>
-            <div class="control-row">
-                <button id="btn-left" aria-label="Move left">◀</button>
-                <button id="btn-down" aria-label="Soft drop">▼</button>
-                <button id="btn-right" aria-label="Move right">▶</button>
-            </div>
-            <div class="control-row">
-                <button id="btn-drop" class="wide" aria-label="Hard drop">⤓</button>
+                <div id="controls">
+                    <div class="control-row">
+                        <button id="btn-rotate" aria-label="Rotate piece">⟳</button>
+                    </div>
+                    <div class="control-row">
+                        <button id="btn-left" aria-label="Move left">◀</button>
+                        <button id="btn-down" aria-label="Soft drop">▼</button>
+                        <button id="btn-right" aria-label="Move right">▶</button>
+                    </div>
+                    <div class="control-row">
+                        <button id="btn-drop" class="wide" aria-label="Hard drop">⤓</button>
+                    </div>
+                </div>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- Add Ariyo icon to Tetris sidebar edge panel
- Move control buttons into sidebar so they sit beside play field
- Ensure side layout persists on small screens

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689cf033084c8332a29df98145e5d646