### PR TITLE
Replace game icon and resize Tetris controls

### DIFF
--- a/icons/tetris.svg
+++ b/icons/tetris.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="96" height="96" viewBox="0 0 96 96">
+  <rect x="32" y="0" width="32" height="32" fill="#4caf50"/>
+  <rect x="0" y="32" width="32" height="32" fill="#4caf50"/>
+  <rect x="32" y="32" width="32" height="32" fill="#4caf50"/>
+  <rect x="64" y="32" width="32" height="32" fill="#4caf50"/>
+</svg>

--- a/main.html
+++ b/main.html
@@ -706,7 +706,7 @@
         </div>
         <!-- Tetris Game Floating Icon -->
         <div class="tetris-bubble-container" role="button" aria-label="Open Tetris Game" onclick="openTetrisGame()">
-            <img src="https://img.icons8.com/color/96/tetris.png" alt="Tetris Game Icon" class="picture-game-float-icon" />
+            <img src="icons/tetris.svg" alt="Tetris Game Icon" class="picture-game-float-icon" />
         </div>
     </div>
 </div>

--- a/tetris.css
+++ b/tetris.css
@@ -32,13 +32,7 @@ body {
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: 10px;
-}
-
-#sidebar-icon {
-    width: 60px;
-    height: 60px;
-    border-radius: 10px;
+    gap: 5px;
 }
 
 #next-title {
@@ -62,30 +56,30 @@ body {
     margin-top: 20px;
     display: flex;
     flex-direction: column;
-    gap: 10px;
+    gap: 5px;
     align-items: center;
 }
 
 .control-row {
     display: flex;
-    gap: 10px;
+    gap: 5px;
 }
 
 #controls button {
-    width: 60px;
-    height: 60px;
+    width: 40px;
+    height: 40px;
     border: none;
     border-radius: 50%;
     background: var(--theme-color, #00f);
     color: var(--background-color, #000);
-    font-size: 1.5rem;
+    font-size: 1rem;
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.4);
     cursor: pointer;
 }
 
 #controls button.wide {
-    width: 150px;
-    border-radius: 30px;
+    width: 100px;
+    border-radius: 20px;
 }
 
 #controls button:active {

--- a/tetris.html
+++ b/tetris.html
@@ -21,7 +21,6 @@
         <div id="game-wrapper">
             <canvas id="tetris" width="200" height="400" aria-label="Tetris play field"></canvas>
             <div id="sidebar">
-                <img id="sidebar-icon" src="icons/Ariyo.png" alt="Ariyo icon" />
                 <h2 id="next-title">Next</h2>
                 <canvas id="next" width="80" height="80" aria-label="Next piece preview"></canvas>
                 <div id="score" aria-live="polite" role="status">Score: 0</div>


### PR DESCRIPTION
## Summary
- Use a local Tetris icon in the edge panel
- Drop Ariyo icon from Tetris sidebar
- Shrink Tetris control buttons for a better fit in the modal

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689cf1ddccc483329a06a89ec4cde8e2