### PR TITLE
feat: add Terms Of Agreement album data

### DIFF
--- a/scripts/data.js
+++ b/scripts/data.js
@@ -1,4 +1,5 @@
 const BASE_URL = 'https://raw.githubusercontent.com/Omoluabi1003/Ariyo-AI/main/';
+const TOA_URL = 'https://raw.githubusercontent.com/Omoluabi1003/Terms-Of-Agreement/main/';
 const albums = [
       {
         name: 'Kindness',
@@ -99,32 +100,32 @@ const albums = [
       },
       {
         name: 'Terms Of Agreement',
-        cover: 'https://raw.githubusercontent.com/Omoluabi1003/Terms-Of-Agreement/main/TOA%20Album%20Art.png',
+        cover: `${TOA_URL}TOA%20Album%20Art.png`,
         tracks: [
-            { src: 'https://raw.githubusercontent.com/Omoluabi1003/Terms-Of-Agreement/main/419.mp3', title: '419' },
-            { src: 'https://raw.githubusercontent.com/Omoluabi1003/Terms-Of-Agreement/main/Adimula%20Global.mp3', title: 'Adimula Global' },
-            { src: 'https://raw.githubusercontent.com/Omoluabi1003/Terms-Of-Agreement/main/Africa%20Song.mp3', title: 'Africa Song' },
-            { src: 'https://raw.githubusercontent.com/Omoluabi1003/Terms-Of-Agreement/main/Alujo%20For%20The%20Most%20High.mp3', title: 'Alujo For The Most High' },
-            { src: 'https://raw.githubusercontent.com/Omoluabi1003/Terms-Of-Agreement/main/As%20E%20Dey%20Hot.mp3', title: 'As E Dey Hot' },
-            { src: 'https://raw.githubusercontent.com/Omoluabi1003/Terms-Of-Agreement/main/Bleaching.mp3', title: 'Bleaching' },
-            { src: 'https://raw.githubusercontent.com/Omoluabi1003/Terms-Of-Agreement/main/Breaking%20Altars.mp3', title: 'Breaking Altars' },
-            { src: 'https://raw.githubusercontent.com/Omoluabi1003/Terms-Of-Agreement/main/Buried%20Gold.mp3', title: 'Buried Gold' },
-            { src: 'https://raw.githubusercontent.com/Omoluabi1003/Terms-Of-Agreement/main/Chained%20Headspace.mp3', title: 'Chained Headspace' },
-            { src: 'https://raw.githubusercontent.com/Omoluabi1003/Terms-Of-Agreement/main/Coalition%20Of%20Confusion.mp3', title: 'Coalition Of Confusion' },
-            { src: 'https://raw.githubusercontent.com/Omoluabi1003/Terms-Of-Agreement/main/Divine%20Twin.mp3', title: 'Divine Twin' },
-            { src: 'https://raw.githubusercontent.com/Omoluabi1003/Terms-Of-Agreement/main/Fathers%20That%20Left.mp3', title: 'Fathers That Left' },
-            { src: 'https://raw.githubusercontent.com/Omoluabi1003/Terms-Of-Agreement/main/GMO%20Seeds.mp3', title: 'GMO Seeds' },
-            { src: 'https://raw.githubusercontent.com/Omoluabi1003/Terms-Of-Agreement/main/Hail%20Mary.mp3', title: 'Hail Mary' },
-            { src: 'https://raw.githubusercontent.com/Omoluabi1003/Terms-Of-Agreement/main/More%20Stars%20Online.mp3', title: 'More Stars Online' },
-            { src: 'https://raw.githubusercontent.com/Omoluabi1003/Terms-Of-Agreement/main/Nigeria.mp3', title: 'Nigeria' },
-            { src: 'https://raw.githubusercontent.com/Omoluabi1003/Terms-Of-Agreement/main/Oga%20Jesus.mp3', title: 'Oga Jesus' },
-            { src: 'https://raw.githubusercontent.com/Omoluabi1003/Terms-Of-Agreement/main/Omo%20Oba.mp3', title: 'Omo Oba' },
-            { src: 'https://raw.githubusercontent.com/Omoluabi1003/Terms-Of-Agreement/main/Our%20Fada.mp3', title: 'Our Fada' },
-            { src: 'https://raw.githubusercontent.com/Omoluabi1003/Terms-Of-Agreement/main/Parrot.mp3', title: 'Parrot' },
-            { src: 'https://raw.githubusercontent.com/Omoluabi1003/Terms-Of-Agreement/main/Rigged%20Game.mp3', title: 'Rigged Game' },
-            { src: 'https://raw.githubusercontent.com/Omoluabi1003/Terms-Of-Agreement/main/Starvation%20Trap.mp3', title: 'Starvation Trap' },
-            { src: 'https://raw.githubusercontent.com/Omoluabi1003/Terms-Of-Agreement/main/Terms%20Of%20Agreement.mp3', title: 'Terms Of Agreement' },
-            { src: 'https://raw.githubusercontent.com/Omoluabi1003/Terms-Of-Agreement/main/The%20Shoulders%20We%20Stand%20On.mp3', title: 'The Shoulders We Stand On' }
+            { src: `${TOA_URL}419.mp3`, title: '419' },
+            { src: `${TOA_URL}Adimula%20Global.mp3`, title: 'Adimula Global' },
+            { src: `${TOA_URL}Africa%20Song.mp3`, title: 'Africa Song' },
+            { src: `${TOA_URL}Alujo%20For%20The%20Most%20High.mp3`, title: 'Alujo For The Most High' },
+            { src: `${TOA_URL}As%20E%20Dey%20Hot.mp3`, title: 'As E Dey Hot' },
+            { src: `${TOA_URL}Bleaching.mp3`, title: 'Bleaching' },
+            { src: `${TOA_URL}Breaking%20Altars.mp3`, title: 'Breaking Altars' },
+            { src: `${TOA_URL}Buried%20Gold.mp3`, title: 'Buried Gold' },
+            { src: `${TOA_URL}Chained%20Headspace.mp3`, title: 'Chained Headspace' },
+            { src: `${TOA_URL}Coalition%20Of%20Confusion.mp3`, title: 'Coalition Of Confusion' },
+            { src: `${TOA_URL}Divine%20Twin.mp3`, title: 'Divine Twin' },
+            { src: `${TOA_URL}Fathers%20That%20Left.mp3`, title: 'Fathers That Left' },
+            { src: `${TOA_URL}GMO%20Seeds.mp3`, title: 'GMO Seeds' },
+            { src: `${TOA_URL}Hail%20Mary.mp3`, title: 'Hail Mary' },
+            { src: `${TOA_URL}More%20Stars%20Online.mp3`, title: 'More Stars Online' },
+            { src: `${TOA_URL}Nigeria.mp3`, title: 'Nigeria' },
+            { src: `${TOA_URL}Oga%20Jesus.mp3`, title: 'Oga Jesus' },
+            { src: `${TOA_URL}Omo%20Oba.mp3`, title: 'Omo Oba' },
+            { src: `${TOA_URL}Our%20Fada.mp3`, title: 'Our Fada' },
+            { src: `${TOA_URL}Parrot.mp3`, title: 'Parrot' },
+            { src: `${TOA_URL}Rigged%20Game.mp3`, title: 'Rigged Game' },
+            { src: `${TOA_URL}Starvation%20Trap.mp3`, title: 'Starvation Trap' },
+            { src: `${TOA_URL}Terms%20Of%20Agreement.mp3`, title: 'Terms Of Agreement' },
+            { src: `${TOA_URL}The%20Shoulders%20We%20Stand%20On.mp3`, title: 'The Shoulders We Stand On' }
         ]
       }
     ];


### PR DESCRIPTION
## Summary
- add TOA_URL constant for Terms Of Agreement album assets
- list complete album with cover and 24 tracks using the base URL

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689d42eafe48833299265b876f5f6b26