### PR TITLE
fix: dynamically render album list

### DIFF
--- a/main.html
+++ b/main.html
@@ -644,11 +644,7 @@
       <button class="close ripple shockwave" role="button" aria-label="Close album list" onclick="closeAlbumList()">×</button>
       <h3 id="albumModalTitle">Choose An Album</h3>
       <div class="album-list">
-        <a href="#" onclick="selectAlbum(0); closeAlbumList();">Album 1: Kindness</a>
-        <a href="#" onclick="selectAlbum(1); closeAlbumList();">Album 2: Street Sense</a>
-        <a href="#" onclick="selectAlbum(2); closeAlbumList();">Album 3: Needs</a>
-        <a href="#" onclick="selectAlbum(3); closeAlbumList();">Album 4: Holy Vibes Only</a>
-        <a href="#" onclick="selectAlbum(4); closeAlbumList();">Album 5: Terms Of Agreement</a>
+        <!-- Dynamically populated -->
       </div>
     </div>
   </div>

--- a/scripts/ui.js
+++ b/scripts/ui.js
@@ -1,7 +1,22 @@
+function populateAlbumList() {
+  const albumList = document.querySelector('.album-list');
+  if (!albumList) return;
+  albumList.innerHTML = '';
+  albums.forEach((album, index) => {
+    const link = document.createElement('a');
+    link.href = '#';
+    link.onclick = () => { selectAlbum(index); closeAlbumList(); };
+    link.textContent = `Album ${index + 1}: ${album.name}`;
+    albumList.appendChild(link);
+  });
+}
+
 function openAlbumList() {
       document.getElementById('main-content').classList.remove('about-us-active');
       const modal = document.getElementById('albumModal');
       const modalContent = modal.querySelector('.modal-content');
+
+      populateAlbumList();
 
       modalContent.style.pointerEvents = 'none';
       modal.style.display = 'block';


### PR DESCRIPTION
## Summary
- generate album list dynamically from `albums` data
- remove hardcoded album entries in album modal so new albums like "Terms Of Agreement" appear automatically

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689d459782e4833283897316f59b4444