### PR TITLE
feat: add track deep linking

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 - **PWA:** Install the application on your device for offline access and a native-like experience.
 - **Radio:** Listen to a variety of Nigerian and international radio stations.
 - **Games:** Play mini-games like Picture Game, Word Search, and Tetris.
+- **Shareable Links:** Copy or share a URL that opens the app to a specific track.
 
 ## Technologies Used
 

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -284,6 +284,23 @@
     });
 
     function initializePlayer() {
+      const params = new URLSearchParams(window.location.search);
+      const albumParam = params.get('album');
+      const trackParam = params.get('track');
+      if (albumParam !== null && trackParam !== null) {
+        const albumIndex = parseInt(albumParam, 10);
+        const trackIndex = parseInt(trackParam, 10);
+        if (!isNaN(albumIndex) && albumIndex >= 0 && albumIndex < albums.length) {
+          const album = albums[albumIndex];
+          if (!isNaN(trackIndex) && trackIndex >= 0 && trackIndex < album.tracks.length) {
+            currentAlbumIndex = albumIndex;
+            updateTrackListModal();
+            selectTrack(album.tracks[trackIndex].src, album.tracks[trackIndex].title, trackIndex);
+            return;
+          }
+        }
+      }
+
       const savedState = loadPlayerState();
       if (savedState) {
         currentAlbumIndex = savedState.albumIndex;

--- a/scripts/player.js
+++ b/scripts/player.js
@@ -251,6 +251,10 @@ function selectTrack(src, title, index) {
       console.log(`[selectTrack] Selecting track: ${title} from album: ${albums[currentAlbumIndex].name}`);
       currentTrackIndex = index;
       currentRadioIndex = -1;
+      const params = new URLSearchParams(window.location.search);
+      params.set('album', currentAlbumIndex);
+      params.set('track', index);
+      window.history.replaceState({}, '', `${window.location.pathname}?${params.toString()}`);
       lastTrackSrc = src;
       lastTrackTitle = title;
       lastTrackIndex = index;
@@ -301,6 +305,11 @@ function selectTrack(src, title, index) {
       console.log(`[selectRadio] Selecting radio: ${title}`);
       currentRadioIndex = index;
       currentTrackIndex = -1;
+      const params = new URLSearchParams(window.location.search);
+      params.delete('album');
+      params.delete('track');
+      const newQuery = params.toString();
+      window.history.replaceState({}, '', `${window.location.pathname}${newQuery ? '?' + newQuery : ''}`);
       lastTrackSrc = src;
       lastTrackTitle = title;
       lastTrackIndex = index;


### PR DESCRIPTION
## Summary
- Add URL parameter support so a shared link opens the app to a specific track
- Update player to keep album/track in query string and clear when switching to radio
- Document shareable link capability in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689d4e22973083328c86c81d24130028