### PR TITLE
Include album names in search suggestions

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -17,6 +17,12 @@
     const searchMap = {};
 
     albums.forEach((album, albumIndex) => {
+      const albumLabel = `Album ${albumIndex + 1}: ${album.name}`;
+      const albumOption = document.createElement('option');
+      albumOption.value = albumLabel;
+      searchSuggestions.appendChild(albumOption);
+      searchMap[albumLabel.toLowerCase()] = { type: 'album', albumIndex };
+
       album.tracks.forEach((track, trackIndex) => {
         const label = `${track.title} - ${album.name}`;
         const option = document.createElement('option');
@@ -45,6 +51,8 @@
         } else if (result.type === 'radio') {
           const station = radioStations[result.index];
           selectRadio(station.url, `${station.name} - ${station.location}`, result.index, station.logo);
+        } else if (result.type === 'album') {
+          selectAlbum(result.albumIndex);
         }
         e.target.value = '';
       }


### PR DESCRIPTION
## Summary
- add album entries to search suggestions so all five albums appear in search bar
- handle album selection from search results and load corresponding album

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d6e739eb08332844848a86173e807