### PR TITLE
Adjust music player layout for mobile

### DIFF
--- a/style.css
+++ b/style.css
@@ -351,6 +351,13 @@ body {
     }
     .music-player {
         z-index: 1000; /* Ensure the music player is on top */
+        left: 0;
+        transform: none;
+        width: 100%;
+    }
+    .album-cover {
+        width: clamp(80px, 40vw, 120px);
+        height: clamp(80px, 40vw, 120px);
     }
 }
 


### PR DESCRIPTION
## Summary
- Reposition music player on narrow screens to avoid overlap with sidebar
- Shrink album cover on mobile so vinyl remains fully visible

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689d752f42788332b91db037f8526a88