### PR TITLE
fix: ensure tetris controls visible

### DIFF
--- a/main.html
+++ b/main.html
@@ -310,6 +310,10 @@
       border: none;
       border-radius: 10px;
     }
+    #tetrisGameContainer {
+      height: calc(100vh - (100px + env(safe-area-inset-bottom)));
+      overflow-y: auto;
+    }
     .popup-close {
       position: absolute;
       top: 10px;


### PR DESCRIPTION
## Summary
- extend tetris game container height so the full game, including on-screen controls, remains visible

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e211057b88332b0e18d155614737f