### PR TITLE
fix: adjust tetris modal height

### DIFF
--- a/main.html
+++ b/main.html
@@ -310,7 +310,7 @@
       border-radius: 10px;
     }
     #tetrisGameContainer {
-      height: calc(100vh - (100px + env(safe-area-inset-bottom)));
+      height: calc(100vh - (140px + env(safe-area-inset-bottom)));
       overflow-y: auto;
       padding-top: 40px;
       box-sizing: border-box;


### PR DESCRIPTION
## Summary
- reduce Tetris modal height so it fits within viewport

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fb693863883328181c6ddbcd9d2dd