### PR TITLE
feat: show tetris controls for start stop refresh

### DIFF
--- a/tetris.css
+++ b/tetris.css
@@ -131,7 +131,6 @@ footer {
 #action-buttons {
     display: flex;
     gap: 5px;
-    margin-top: 5px;
     justify-content: center;
 }
 

--- a/tetris.html
+++ b/tetris.html
@@ -33,11 +33,11 @@
                     <div class="control-row">
                         <button id="btn-drop" class="wide" aria-label="Hard drop">⤓</button>
                     </div>
-                </div>
-                <div id="action-buttons">
-                    <button id="btn-start" aria-label="Start game">▶</button>
-                    <button id="btn-stop" aria-label="Stop game">■</button>
-                    <button id="btn-refresh" aria-label="Refresh game">↻</button>
+                    <div id="action-buttons">
+                        <button id="btn-start" aria-label="Start game">▶</button>
+                        <button id="btn-stop" aria-label="Stop game">■</button>
+                        <button id="btn-refresh" aria-label="Refresh game">↻</button>
+                    </div>
                 </div>
                 <div id="next-wrapper">
                     <h2 id="next-title">Next</h2>


### PR DESCRIPTION
## Summary
- Relocate start, stop and refresh buttons directly beneath Tetris controls so they're always accessible during play
- Simplify Tetris action button spacing for consistent layout

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fb9ae4c54833297d60fd805004b56