### PR TITLE
Refine Tetris controls and modal layout

### DIFF
--- a/tetris.css
+++ b/tetris.css
@@ -120,7 +120,7 @@ footer {
 
 #game-container {
     position: relative;
-    margin-top: 20px;
+    margin-top: 60px;
     padding: 20px;
     border-radius: 12px;
     background: rgba(0, 0, 0, 0.4);
@@ -128,19 +128,6 @@ footer {
     box-shadow: 0 8px 16px rgba(0, 0, 0, 0.6);
 }
 
-#action-buttons {
-    display: flex;
-    gap: 5px;
+.action-buttons {
     justify-content: center;
-}
-
-#action-buttons button {
-    width: 24px;
-    height: 24px;
-    border: none;
-    border-radius: 4px;
-    background: var(--theme-color, #00f);
-    color: var(--background-color, #000);
-    font-size: 0.8rem;
-    cursor: pointer;
 }

--- a/tetris.html
+++ b/tetris.html
@@ -33,7 +33,7 @@
                     <div class="control-row">
                         <button id="btn-drop" class="wide" aria-label="Hard drop">⤓</button>
                     </div>
-                    <div id="action-buttons">
+                    <div class="control-row action-buttons">
                         <button id="btn-start" aria-label="Start game">▶</button>
                         <button id="btn-stop" aria-label="Stop game">■</button>
                         <button id="btn-refresh" aria-label="Refresh game">↻</button>


### PR DESCRIPTION
## Summary
- Keep Start, Stop, and Refresh buttons persistently visible beneath directional controls.
- Simplify control styling to use existing layout spacing for a cleaner look.
- Offset Tetris modal downward to avoid covering the sidebar and header.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fe2eff70c833297ec873a4e771209