### PR TITLE
Adjust tetris UI spacing and button colors

### DIFF
--- a/main.html
+++ b/main.html
@@ -289,7 +289,7 @@
     .track-list a:hover, .album-list a:hover, .radio-list a:hover { background-color: var(--theme-color); }
     .chatbot-container, .sabi-bible-container {
       position: fixed;
-      bottom: calc(100px + env(safe-area-inset-bottom));
+      bottom: calc(80px + env(safe-area-inset-bottom));
       left: 50%;
       transform: translateX(-50%);
       width: 90%;
@@ -312,7 +312,7 @@
     #tetrisGameContainer {
       height: calc(100vh - (140px + env(safe-area-inset-bottom)));
       overflow-y: auto;
-      padding-top: 40px;
+      padding-top: 20px;
       box-sizing: border-box;
     }
     .popup-close {

--- a/tetris.css
+++ b/tetris.css
@@ -120,7 +120,7 @@ footer {
 
 #game-container {
     position: relative;
-    margin-top: 60px;
+    margin-top: 40px;
     padding: 20px;
     border-radius: 12px;
     background: rgba(0, 0, 0, 0.4);
@@ -130,4 +130,19 @@ footer {
 
 .action-buttons {
     justify-content: center;
+}
+
+#btn-start {
+    background: linear-gradient(145deg, #28a745, #218838);
+    color: #fff;
+}
+
+#btn-stop {
+    background: linear-gradient(145deg, #dc3545, #c82333);
+    color: #fff;
+}
+
+#btn-refresh {
+    background: linear-gradient(145deg, #ffc107, #e0a800);
+    color: #000;
 }


### PR DESCRIPTION
## Summary
- Differentiate Tetris start/stop/refresh buttons with green, red, and yellow gradients
- Lower modal containers slightly and move Tetris grid higher for better balance

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fe4dfdb7c8332ab705f41403e96b2