### PR TITLE
fix: reposition tetris modal

### DIFF
--- a/main.html
+++ b/main.html
@@ -314,6 +314,7 @@
       overflow-y: auto;
       padding-top: 20px;
       box-sizing: border-box;
+      bottom: calc(40px + env(safe-area-inset-bottom));
     }
     .popup-close {
       position: absolute;


### PR DESCRIPTION
## Summary
- shift Tetris game modal lower so it no longer overlaps page header

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fe9deba948332a88a4fc24f09ef7e