### PR TITLE
Make Tetris action buttons distinct

### DIFF
--- a/tetris.css
+++ b/tetris.css
@@ -132,6 +132,14 @@ footer {
     justify-content: center;
 }
 
+#controls .action-btn {
+    width: 80px;
+    height: 35px;
+    border-radius: 8px;
+    font-size: 0.8rem;
+    font-weight: bold;
+}
+
 #btn-start {
     background: linear-gradient(145deg, #28a745, #218838);
     color: #fff;

--- a/tetris.html
+++ b/tetris.html
@@ -34,9 +34,9 @@
                         <button id="btn-drop" class="wide" aria-label="Hard drop">⤓</button>
                     </div>
                     <div class="control-row action-buttons">
-                        <button id="btn-start" aria-label="Start game">▶</button>
-                        <button id="btn-stop" aria-label="Stop game">■</button>
-                        <button id="btn-refresh" aria-label="Refresh game">↻</button>
+                        <button id="btn-start" class="action-btn" aria-label="Start game">Start</button>
+                        <button id="btn-stop" class="action-btn" aria-label="Stop game">Stop</button>
+                        <button id="btn-refresh" class="action-btn" aria-label="Refresh game">Refresh</button>
                     </div>
                 </div>
                 <div id="next-wrapper">


### PR DESCRIPTION
## Summary
- Replace Tetris start/stop/refresh icons with labeled buttons for clearer differentiation from control buttons
- Style action buttons with rectangular shape and bold font to stand out from round control buttons

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fec8079888332b34689e300b998a6