### PR TITLE
fix: prevent mobile zoom on orientation

### DIFF
--- a/about.html
+++ b/about.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover" />
   <meta name="apple-mobile-web-app-capable" content="yes" />
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
   <meta name="apple-mobile-web-app-title" content="Àríyò AI" />
@@ -237,5 +237,6 @@
   <script>
     changeColorScheme();
   </script>
+  <script src="prevent-zoom.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover" />
   <meta name="apple-mobile-web-app-capable" content="yes" />
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
   <meta name="apple-mobile-web-app-title" content="Àríyò AI" />
@@ -158,5 +158,6 @@
     <script>
         changeColorScheme();
     </script>
+    <script src="prevent-zoom.js"></script>
 </body>
 </html>

--- a/main.html
+++ b/main.html
@@ -5,7 +5,7 @@
   <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
   <meta http-equiv="Pragma" content="no-cache" />
   <meta http-equiv="Expires" content="0" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover" />
   <meta name="apple-mobile-web-app-capable" content="yes" />
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
   <meta name="apple-mobile-web-app-title" content="Àríyò AI">
@@ -774,6 +774,7 @@
     <script>
       changeColorScheme();
     </script>
+  <script src="prevent-zoom.js"></script>
   <!-- Floating Watermarks -->
   <div class="floating-watermarks">
     <div class="watermark exploding-watermark" style="top: 10%; left: 5%;">Omoluabi Productions</div>

--- a/picture-game.html
+++ b/picture-game.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover" />
   <meta name="apple-mobile-web-app-capable" content="yes" />
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
   <meta name="apple-mobile-web-app-title" content="Àríyò AI" />
@@ -45,6 +45,7 @@
     <script>
         changeColorScheme();
     </script>
+    <script src="prevent-zoom.js"></script>
     <footer>
         <p>&copy; 2024 Omoluabi</p>
     </footer>

--- a/prevent-zoom.js
+++ b/prevent-zoom.js
@@ -1,0 +1,22 @@
+// Prevent automatic zooming on mobile orientation changes
+// Applies only to touch devices to avoid affecting non-touch screens
+
+document.addEventListener('DOMContentLoaded', function () {
+  if (window.matchMedia('(pointer: coarse)').matches) {
+    const viewport = document.querySelector('meta[name="viewport"]');
+    if (!viewport) return;
+
+    const lockZoom = () => {
+      viewport.setAttribute(
+        'content',
+        'width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover'
+      );
+    };
+
+    lockZoom();
+    window.addEventListener('orientationchange', () => {
+      // Reapply the viewport settings after orientation change to avoid zoom
+      setTimeout(lockZoom, 200);
+    });
+  }
+});

--- a/tetris.html
+++ b/tetris.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+      <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <meta name="apple-mobile-web-app-title" content="Àríyò AI" />
@@ -52,6 +52,7 @@
     <script>
         changeColorScheme();
     </script>
+    <script src="prevent-zoom.js"></script>
     <footer>
         <p>&copy; 2024 Omoluabi</p>
     </footer>

--- a/word-search.html
+++ b/word-search.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+      <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover" />
   <meta name="apple-mobile-web-app-capable" content="yes" />
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
   <meta name="apple-mobile-web-app-title" content="Àríyò AI" />
@@ -34,5 +34,6 @@
     <script>
         changeColorScheme();
     </script>
+    <script src="prevent-zoom.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- lock viewport scaling to avoid mobile zoom when orientation changes
- add orientation-change handler to reapply viewport settings on touch devices

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0de614eb08332a5e96a40ccf47e3e