### PR TITLE
feat: responsive word search with celebration

### DIFF
--- a/word-search.css
+++ b/word-search.css
@@ -1,4 +1,9 @@
+:root {
+  --cell-size: 30px;
+}
+
 body {
+  margin: 0;
   font-family: 'Arial', sans-serif;
   padding: 1rem;
   background: linear-gradient(135deg, #f0f4ff, #d9e4ff);
@@ -26,21 +31,23 @@ button {
   gap: 1rem;
   align-items: flex-start;
   justify-content: center;
+  flex-wrap: wrap;
 }
 
 .grid {
   display: grid;
-  grid-template-columns: repeat(var(--grid-size), 30px);
-  grid-auto-rows: 30px;
+  grid-template-columns: repeat(var(--grid-size), var(--cell-size));
+  grid-auto-rows: var(--cell-size);
   gap: 2px;
   background: #fff;
   border: 2px solid #4a90e2;
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+  max-width: 100%;
 }
 
 .cell {
-  width: 30px;
-  height: 30px;
+  width: var(--cell-size);
+  height: var(--cell-size);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -57,21 +64,23 @@ button {
 }
 
 .cell.found {
-  background: #4caf50;
-  color: #fff;
+  background: #ffe0e0;
+  color: red;
   text-decoration: line-through;
-  text-decoration-color: #fff;
+  text-decoration-color: red;
 }
 
 .word-list {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  font-size: 0.8rem;
+  display: grid;
+  grid-template-columns: repeat(2, auto);
+  gap: 4px 8px;
+  font-size: 0.6rem;
   background: rgba(255, 255, 255, 0.8);
   padding: 1rem;
   border-radius: 8px;
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+  max-height: 90vh;
+  overflow-y: auto;
 }
 
 .word-list .word {

--- a/word-search.html
+++ b/word-search.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Word Search Game</title>
   <link rel="stylesheet" href="word-search.css" />
 </head>
@@ -12,6 +13,7 @@
     <button id="start">Start</button>
   </div>
   <div id="game" class="game-container"></div>
+  <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.6.0/dist/confetti.browser.min.js"></script>
   <script type="module" src="word-search.js"></script>
 </body>
 </html>

--- a/word-search.js
+++ b/word-search.js
@@ -1,13 +1,30 @@
 import { generateGrid } from './word-search-grid.js';
 
 const categories = {
-  Fruits: ['BANANA', 'MANGO', 'ORANGE', 'PAWPAW', 'GUAVA'],
-  Animals: ['ZEBRA', 'LION', 'GOAT', 'SNAKE', 'ELEPHANT'],
-  Technology: ['PYTHON', 'REACT', 'CODE'],
-  'Nigerian States': ['LAGOS', 'KANO', 'ENUGU', 'ABIA', 'BENUE', 'DELTA', 'KWARA', 'ONDO', 'OSUN', 'KATSINA']
+  Fruits: [
+    'BANANA', 'MANGO', 'ORANGE', 'PAWPAW', 'GUAVA',
+    'PINEAPPLE', 'APPLE', 'GRAPE', 'PEACH', 'PLUM',
+    'APRICOT', 'KIWI'
+  ],
+  Animals: [
+    'ZEBRA', 'LION', 'GOAT', 'SNAKE', 'ELEPHANT',
+    'GIRAFFE', 'CHEETAH', 'HIPPO', 'MONKEY', 'PANTHER',
+    'HYENA', 'RABBIT'
+  ],
+  Technology: [
+    'PYTHON', 'REACT', 'CODE', 'COMPUTER', 'INTERNET',
+    'ALGORITHM', 'ROBOT', 'AI', 'JAVA', 'NODE',
+    'SERVER', 'APP'
+  ],
+  'Nigerian States': [
+    'LAGOS', 'KANO', 'ENUGU', 'ABIA', 'BENUE', 'DELTA',
+    'KWARA', 'ONDO', 'OSUN', 'KATSINA', 'BAYELSA',
+    'JIGAWA', 'KOGI', 'EKITI', 'OGUN', 'ANAMBRA',
+    'EDO', 'IMO', 'SOKOTO', 'TARABA'
+  ]
 };
 
-const gridSize = 12;
+const gridSize = 15;
 const gameContainer = document.getElementById('game');
 const categorySelect = document.getElementById('category');
 const startBtn = document.getElementById('start');
@@ -19,6 +36,12 @@ let isMouseDown = false;
 let startCell = null;
 let currentPath = [];
 let foundWords = new Set();
+
+function setCellSize() {
+  const dimension = Math.min(window.innerWidth, window.innerHeight) * 0.8;
+  const size = Math.max(20, Math.floor(dimension / gridSize));
+  document.documentElement.style.setProperty('--cell-size', `${size}px`);
+}
 
 function shuffle(arr) {
   for (let i = arr.length - 1; i > 0; i--) {
@@ -47,6 +70,8 @@ function startGame() {
 
   words = categories[category].map((w) => w.toUpperCase());
   shuffle(words);
+
+  setCellSize();
 
   const grid = generateGrid(words, gridSize);
 
@@ -128,6 +153,9 @@ function checkSelection() {
     foundWords.add(match);
     const wEl = document.getElementById(`word-${match}`);
     if (wEl) wEl.classList.add('found');
+    if (foundWords.size === words.length && window.confetti) {
+      window.confetti({ particleCount: 200, spread: 70, origin: { y: 0.6 } });
+    }
   }
 }
 
@@ -158,6 +186,7 @@ function handleMouseUp() {
 document.addEventListener('mouseup', handleMouseUp);
 startBtn.addEventListener('click', startGame);
 categorySelect.addEventListener('change', startGame);
+window.addEventListener('resize', setCellSize);
 
 populateCategories();
 startGame();


### PR DESCRIPTION
## Summary
- make word search grid responsive and keep entire grid visible
- expand vocab lists, show them in two compact columns, and mark found words in red
- add confetti celebration once all words are found

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a2540dc92c8332b10939b7c7308012