### PR TITLE
feat: add about modal with chatbot height

### DIFF
--- a/main.html
+++ b/main.html
@@ -590,7 +590,7 @@
       <datalist id="searchSuggestions"></datalist>
       <button onclick="openAlbumList()" aria-label="Choose an album" class="ripple shockwave">🎧 Choose An Album</button>
       <button onclick="openRadioList()" aria-label="Radio stations" class="ripple shockwave">📻 Radio Stations</button>
-      <button onclick="navigateToAbout()" aria-label="About us" class="ripple shockwave">ℹ️ About Us</button>
+      <button onclick="openAboutModal()" aria-label="About us" class="ripple shockwave">ℹ️ About Us</button>
     </div>
     <div class="content" id="main-content">
       <div id="newsContainer" class="news-container" style="display: none;"></div>
@@ -759,6 +759,13 @@
     <button class="popup-close ripple shockwave" onclick="closeWordSearchGame()">×</button>
     <h3 id="wordSearchTitle" class="modal-title">Omoluabi Word Search</h3>
     <iframe src="word-search.html" style="width: 100%; height: 100%; border: none;"></iframe>
+</div>
+
+<!-- About Us Container -->
+<div id="aboutModalContainer" class="chatbot-container" role="dialog" aria-labelledby="aboutModalTitle">
+    <button class="popup-close ripple shockwave" onclick="closeAboutModal()" aria-label="Close About Us">×</button>
+    <h3 id="aboutModalTitle" class="modal-title">About Us</h3>
+    <iframe src="about.html" title="About Us" style="width: 100%; height: 100%; border: none;"></iframe>
 </div>
 
 <!-- 🎧 Now Playing Toast -->

--- a/scripts/ui.js
+++ b/scripts/ui.js
@@ -160,13 +160,15 @@ const sabiBibleContainer = document.getElementById('sabiBibleContainer');
 const pictureGameContainer = document.getElementById('pictureGameContainer');
 const tetrisGameContainer = document.getElementById('tetrisGameContainer');
 const wordSearchContainer = document.getElementById('wordSearchContainer');
+const aboutModalContainer = document.getElementById('aboutModalContainer');
 
 function isAnyPanelOpen() {
     return chatbotContainer.style.display === 'block' ||
            sabiBibleContainer.style.display === 'block' ||
            pictureGameContainer.style.display === 'block' ||
            tetrisGameContainer.style.display === 'block' ||
-           wordSearchContainer.style.display === 'block';
+           wordSearchContainer.style.display === 'block' ||
+           aboutModalContainer.style.display === 'block';
 }
 
 // Spoof user as if dem dey America
@@ -192,6 +194,16 @@ function toggleChatbot() {
 function toggleSabiBible() {
     const isHidden = sabiBibleContainer.style.display === 'none' || !sabiBibleContainer.style.display;
     sabiBibleContainer.style.display = isHidden ? 'block' : 'none';
+    updateEdgePanelBehavior();
+}
+
+function openAboutModal() {
+    aboutModalContainer.style.display = 'block';
+    updateEdgePanelBehavior();
+}
+
+function closeAboutModal() {
+    aboutModalContainer.style.display = 'none';
     updateEdgePanelBehavior();
 }
 


### PR DESCRIPTION
## Summary
- Replace About Us sidebar link to open new modal
- Add About Us modal using chatbot container styling for matching height
- Include JS handlers to open and close the modal and track its state

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a2ad2d63bc83329c8c7e87d40576d3