### PR TITLE
Fix Tetris layout and enable word search gameplay

### DIFF
--- a/tetris.css
+++ b/tetris.css
@@ -126,13 +126,20 @@ footer {
     background: rgba(0, 0, 0, 0.4);
     backdrop-filter: blur(8px);
     box-shadow: 0 8px 16px rgba(0, 0, 0, 0.6);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
 }
 
-.action-buttons {
+#action-buttons {
+    display: flex;
     justify-content: center;
+    gap: 10px;
+    margin-top: 15px;
 }
 
-#controls .action-btn {
+#controls .action-btn,
+#action-buttons .action-btn {
     width: 80px;
     height: 35px;
     border-radius: 8px;

--- a/tetris.html
+++ b/tetris.html
@@ -33,11 +33,6 @@
                     <div class="control-row">
                         <button id="btn-drop" class="wide" aria-label="Hard drop">⤓</button>
                     </div>
-                    <div class="control-row action-buttons">
-                        <button id="btn-start" class="action-btn" aria-label="Start game">Start</button>
-                        <button id="btn-stop" class="action-btn" aria-label="Stop game">Stop</button>
-                        <button id="btn-refresh" class="action-btn" aria-label="Refresh game">Refresh</button>
-                    </div>
                 </div>
                 <div id="next-wrapper">
                     <h2 id="next-title">Next</h2>
@@ -45,6 +40,11 @@
                 </div>
                 <div id="score" aria-live="polite" role="status">Score: 0</div>
             </div>
+        </div>
+        <div id="action-buttons">
+            <button id="btn-start" class="action-btn" aria-label="Start game">Start</button>
+            <button id="btn-stop" class="action-btn" aria-label="Stop game">Stop</button>
+            <button id="btn-refresh" class="action-btn" aria-label="Refresh game">Refresh</button>
         </div>
     </div>
     <script src="tetris.js"></script>

--- a/word-search-grid.js
+++ b/word-search-grid.js
@@ -1,13 +1,13 @@
-export const directions = [
+const directions = [
   { dr: 0, dc: 1 },
   { dr: 0, dc: -1 },
   { dr: 1, dc: 0 },
   { dr: -1, dc: 0 }
 ];
 
-export function generateGrid(words, gridSize = 12) {
+function generateGrid(words, gridSize = 12) {
   const upperWords = words.map((w) => w.toUpperCase());
-  const grid = Array.from({ length: gridSize }, () => Array(gridSize).fill(""));
+  const grid = Array.from({ length: gridSize }, () => Array(gridSize).fill("") );
 
   for (const word of upperWords) {
     let placed = false;
@@ -55,3 +55,5 @@ function placeWord(grid, word, row, col, dir) {
     grid[r][c] = word[i];
   }
 }
+
+window.generateGrid = generateGrid;

--- a/word-search.html
+++ b/word-search.html
@@ -10,10 +10,12 @@
   <h1>Word Search Game</h1>
   <div class="controls">
     <select id="category"></select>
-    <button id="start">Start</button>
+    <button id="start" type="button">Start</button>
   </div>
+  <p id="instructions">Drag across the letters to highlight words from the list.</p>
   <div id="game" class="game-container"></div>
   <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.6.0/dist/confetti.browser.min.js"></script>
-  <script type="module" src="word-search.js"></script>
+  <script src="word-search-grid.js"></script>
+  <script src="word-search.js"></script>
 </body>
 </html>

--- a/word-search.js
+++ b/word-search.js
@@ -1,5 +1,3 @@
-import { generateGrid } from './word-search-grid.js';
-
 const categories = {
   Fruits: [
     'BANANA', 'MANGO', 'ORANGE', 'PAWPAW', 'GUAVA',


### PR DESCRIPTION
## Summary
- Center Tetris board and move Start/Stop/Refresh controls beneath the grid so gameplay isn't cut off
- Load word search logic without modules and add user instructions so the puzzle works on-screen

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a3d00bec0c83329e260047f1d13101