### PR TITLE
feat(word-search): improve word list layout and confetti

### DIFF
--- a/word-search.css
+++ b/word-search.css
@@ -72,10 +72,17 @@ button {
   text-decoration-color: red;
 }
 
+
+/*
+ * Display the list of words in two vertical columns so that long lists
+ * don't run off the bottom of the screen.  The previous grid layout
+ * arranged words row by row which could still grow very tall on small
+ * screens.  Using CSS multi-column layout keeps the height compact while
+ * allowing the words to flow into a second column automatically.
+ */
 .word-list {
-  display: grid;
-  grid-template-columns: repeat(2, auto);
-  gap: 4px 8px;
+  column-count: 2;
+  column-gap: 8px;
   font-size: 0.6rem;
   background: rgba(255, 255, 255, 0.8);
   padding: 1rem;
@@ -86,7 +93,9 @@ button {
 }
 
 .word-list .word {
+  display: block;
   text-transform: uppercase;
+  break-inside: avoid;
 }
 
 .word-list .found {

--- a/word-search.js
+++ b/word-search.js
@@ -35,6 +35,7 @@ let isPointerDown = false;
 let startCell = null;
 let currentPath = [];
 let foundWords = new Set();
+let confettiInterval = null;
 
 function setCellSize() {
   const parentWidth = gameContainer.parentElement.clientWidth;
@@ -67,6 +68,16 @@ function populateCategories() {
 
 function startGame() {
   const category = categorySelect.value || Object.keys(categories)[0];
+
+  // Stop any ongoing confetti from a previous game
+  if (confettiInterval) {
+    clearInterval(confettiInterval);
+    confettiInterval = null;
+  }
+  if (window.confetti && typeof window.confetti.reset === 'function') {
+    window.confetti.reset();
+  }
+
   gameContainer.innerHTML = '';
   foundWords = new Set();
   isPointerDown = false;
@@ -161,7 +172,14 @@ function checkSelection() {
     const wEl = document.getElementById(`word-${match}`);
     if (wEl) wEl.classList.add('found');
     if (foundWords.size === words.length && window.confetti) {
-      window.confetti({ particleCount: 200, spread: 70, origin: { y: 0.6 } });
+      // Celebrate with a short burst of confetti
+      confettiInterval = setInterval(() => {
+        window.confetti({ particleCount: 150, spread: 70, origin: { y: 0.6 } });
+      }, 300);
+      setTimeout(() => {
+        clearInterval(confettiInterval);
+        confettiInterval = null;
+      }, 2000);
     }
   }
 }


### PR DESCRIPTION
## Summary
- show word list in two columns to prevent clipping
- fire celebratory confetti on game completion and reset it when starting a new game

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a4f1ba72f0833280560bdaeec3116c