### PR TITLE
Display word list in two horizontal columns

### DIFF
--- a/word-search.css
+++ b/word-search.css
@@ -74,28 +74,28 @@ button {
 
 
 /*
- * Display the list of words in two vertical columns so that long lists
- * don't run off the bottom of the screen.  The previous grid layout
- * arranged words row by row which could still grow very tall on small
- * screens.  Using CSS multi-column layout keeps the height compact while
- * allowing the words to flow into a second column automatically.
+ * Display the word list in two horizontal columns. Grid layout fills
+ * words row by row so that each row shows two words side-by-side. This
+ * keeps the list compact and preserves natural reading order while
+ * maintaining a small but legible font size.
  */
 .word-list {
-  column-count: 2;
-  column-gap: 8px;
-  font-size: 0.6rem;
+  display: grid;
+  grid-template-columns: repeat(2, max-content);
+  column-gap: 1rem;
+  row-gap: 0.25rem;
+  font-size: 0.75rem;
   background: rgba(255, 255, 255, 0.8);
   padding: 1rem;
   border-radius: 8px;
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
   max-height: 90vh;
   overflow-y: auto;
+  justify-content: center;
 }
 
 .word-list .word {
-  display: block;
   text-transform: uppercase;
-  break-inside: avoid;
 }
 
 .word-list .found {


### PR DESCRIPTION
## Summary
- Show word search word list in two side-by-side columns using CSS grid
- Use small but legible font to save space

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a4f3de6b388332b61415e3812561c0