### PR TITLE
feat: show track durations

### DIFF
--- a/scripts/player.js
+++ b/scripts/player.js
@@ -81,8 +81,25 @@
         const trackLink = document.createElement('a');
         trackLink.href = '#';
         trackLink.onclick = () => selectTrack(track.src, track.title, index);
-        trackLink.textContent = track.title;
+
+        // Use cached duration if available, otherwise fetch it
+        const displayDuration = track.duration ? ` (${formatTime(track.duration)})` : '';
+        trackLink.textContent = `${track.title}${displayDuration}`;
         trackListContainer.appendChild(trackLink);
+
+        if (!track.duration) {
+          const tempAudio = new Audio();
+          tempAudio.preload = 'metadata';
+          tempAudio.crossOrigin = 'anonymous';
+          tempAudio.src = track.src;
+          tempAudio.addEventListener('loadedmetadata', () => {
+            track.duration = tempAudio.duration;
+            trackLink.textContent = `${track.title} (${formatTime(track.duration)})`;
+          });
+          tempAudio.addEventListener('error', () => {
+            trackLink.textContent = `${track.title} (N/A)`;
+          });
+        }
       });
       console.log(`Track list updated for album: ${albums[currentAlbumIndex].name}`);
     }


### PR DESCRIPTION
## Summary
- display each track's duration in the track selection modal
- fetch and cache track metadata to show formatted minutes:seconds

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a665ee4dfc833289f4637da59b6948