### PR TITLE
style(word-search): align word list horizontally

### DIFF
--- a/word-search.css
+++ b/word-search.css
@@ -81,6 +81,7 @@ button {
  */
 .word-list {
   display: grid;
+  grid-auto-flow: row;
   grid-template-columns: repeat(2, max-content);
   column-gap: 1rem;
   row-gap: 0.25rem;
@@ -91,7 +92,8 @@ button {
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
   max-height: 90vh;
   overflow-y: auto;
-  justify-content: center;
+  justify-items: start;
+  text-align: left;
 }
 
 .word-list .word {


### PR DESCRIPTION
## Summary
- Ensure word search word list flows left-to-right by explicitly using row auto-flow
- Left-align entries within the list for clearer two-column layout

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a66946909483328a1ade5ae2e59abb