### PR TITLE
Use column-first layout for word list

### DIFF
--- a/word-search.css
+++ b/word-search.css
@@ -87,8 +87,9 @@ button {
  * Display the word list in two vertical columns. The grid fills
  * from top to bottom so the left column holds the first six words and
  * the right column the next six, matching a west-to-east reading
- * order. Fonts are intentionally tiny to keep the list compact.
- */
+ * order. Fonts and line height are intentionally tiny to keep the list
+ * compact and avoid cutting off entries at the bottom.
+*/
 .word-list {
   display: grid;
   grid-auto-flow: column;
@@ -97,12 +98,11 @@ button {
   column-gap: 1rem;
   row-gap: 0.25rem;
   font-size: 0.5rem;
+  line-height: 1;
   background: rgba(255, 255, 255, 0.8);
   padding: 1rem;
   border-radius: 8px;
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
-  max-height: 90vh;
-  overflow-y: auto;
   justify-items: start;
   text-align: left;
 }


### PR DESCRIPTION
## Summary
- keep word search hints compact by stacking first six words in the left column and the next six in the right using tiny fonts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a66cf425588332b4d9c7375a1b635d