### PR TITLE
Display word list horizontally and show album durations

### DIFF
--- a/style.css
+++ b/style.css
@@ -313,6 +313,12 @@ body {
     margin-bottom: 0.5rem;
 }
 
+.album-duration {
+    font-size: clamp(0.8rem, 2vw, 0.9rem);
+    margin-top: 0.2rem;
+    color: #ccc;
+}
+
 .track-list a:hover,
 .album-list a:hover,
 .radio-list a:hover {

--- a/word-search.css
+++ b/word-search.css
@@ -84,27 +84,20 @@ button {
 
 
 /*
- * Display the word list in two vertical columns. The grid fills
- * from top to bottom so the left column holds the first six words and
- * the right column the next six, matching a west-to-east reading
- * order. Fonts and line height are intentionally tiny to keep the list
- * compact and avoid cutting off entries at the bottom.
-*/
+ * Display the word list in a horizontal row that wraps as needed.
+ * Fonts and line height stay tiny to keep the list compact.
+ */
 .word-list {
-  display: grid;
-  grid-auto-flow: column;
-  grid-template-rows: repeat(6, max-content);
-  grid-template-columns: repeat(2, max-content);
-  column-gap: 1rem;
-  row-gap: 0.25rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem 1rem;
   font-size: 0.5rem;
   line-height: 1;
   background: rgba(255, 255, 255, 0.8);
   padding: 1rem;
   border-radius: 8px;
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
-  justify-items: start;
-  text-align: left;
+  justify-content: center;
 }
 
 .word-list .word {


### PR DESCRIPTION
## Summary
- Arrange word-search terms in a horizontal row with tiny fonts for compactness.
- Compute each album's total playback time and display it alongside the album art in the modal.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a66f6f8bc48332b3bb4bc366762fb1