### PR TITLE
Shrink word search controls to prevent word list cutoff

### DIFF
--- a/word-search.css
+++ b/word-search.css
@@ -12,22 +12,23 @@ body {
 }
 
 h1 {
-  font-size: 1rem;
-  margin: 0.5rem 0;
+  font-size: 0.75rem;
+  margin: 0.25rem 0;
 }
 
 #instructions {
-  font-size: 0.5rem;
-  margin: 0;
+  font-size: 0.4rem;
+  margin: 0.1rem 0;
 }
 
 .controls {
-  margin-bottom: 1rem;
+  margin-bottom: 0.5rem;
 }
 
 select,
 button {
-  padding: 0.5rem 1rem;
+  padding: 0.25rem 0.5rem;
+  font-size: 0.5rem;
   border: none;
   border-radius: 4px;
   margin: 0 0.25rem;
@@ -37,8 +38,8 @@ button {
 }
 
 .timer {
-  margin-left: 0.5rem;
-  font-size: 0.75rem;
+  margin-left: 0.25rem;
+  font-size: 0.5rem;
   font-weight: bold;
 }
 


### PR DESCRIPTION
## Summary
- Reduce heading and instruction font sizes
- Minimize control padding and timer size for more screen space

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a7b00f34b0833282e7ae6c7a2b1952