### PR TITLE
Add Covenant of Isolation to Omoluabi catalogue

### DIFF
--- a/scripts/data.js
+++ b/scripts/data.js
@@ -142,7 +142,8 @@ const albums = [
             { src: 'https://cdn1.suno.ai/a5a8c49a-6871-40b6-9054-36c81ed8be90.mp3', title: 'Pastor or Hustler' },
             { src: 'https://cdn1.suno.ai/7356371a-b8f7-470a-87a3-dbe5c2916f72.mp3', title: 'Fore-runner’s Map' },
             { src: 'https://cdn1.suno.ai/5ad4f8bc-4cef-4ad4-b847-c4f1b8147445.mp3', title: 'No Look Down' },
-            { src: 'https://cdn1.suno.ai/4f81332a-d833-4dc9-9763-7db0dfde3610.mp3', title: 'Wonder\'s Breeze' }
+            { src: 'https://cdn1.suno.ai/4f81332a-d833-4dc9-9763-7db0dfde3610.mp3', title: 'Wonder\'s Breeze' },
+            { src: 'https://cdn1.suno.ai/7578528b-34c1-492c-9e97-df93216f0cc2.mp3', title: 'Covenant Of Isolation' }
         ]
       },
     ];


### PR DESCRIPTION
## Summary
- add Covenant Of Isolation track to Omoluabi Production Catalogue album data

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a7e8b8a9ac8332a3c940d2ec735591