### PR TITLE
Fix audio playback by removing duplicate element

### DIFF
--- a/main.html
+++ b/main.html
@@ -628,7 +628,6 @@
       aria-label="Seek bar for audio playback"
       aria-controls="audioPlayer"
     />
-    <audio id="audioPlayer" src="https://raw.githubusercontent.com/Omoluabi1003/Ariyo-AI/main/A%20Very%20Good%20Bad%20Guy%20v3.mp3"></audio>
     <button id="retryButton" class="retry-button" onclick="retryTrack()" aria-label="Retry loading track">Retry</button>
     <button id="cacheButton" class="retry-button" onclick="cacheTrackForOffline(albums[currentAlbumIndex].tracks[currentTrackIndex].src)" aria-label="Download track for offline playback">Download for Offline</button>
     <div class="dropdown" role="button" aria-label="Choose a track" onclick="openTrackList()" aria-haspopup="true" aria-expanded="false">🎵 Choose A Track</div>


### PR DESCRIPTION
## Summary
- Remove extra audio tag from `main.html` so player.js manages a single audio element

## Testing
- `npm test`
- `node - <<'NODE'
const {chromium} = require('playwright');
(async() => {
  const browser = await chromium.launch();
  const page = await browser.newPage();
  page.on('console', msg => console.log('console', msg.type(), msg.text()));
  await page.goto('file://' + process.cwd() + '/index.html');
  try {
    await page.click('#speaker-container');
    await page.waitForTimeout(2000);
  } catch(err) { console.error('error', err); }
  await browser.close();
})();
NODE`


------
https://chatgpt.com/codex/tasks/task_e_68a7ee2c4cd08332af9ad066a1a12412