### PR TITLE
Remove source links from catalogue

### DIFF
--- a/Omoluabi_Production_Catalogue.md
+++ b/Omoluabi_Production_Catalogue.md
@@ -2,25 +2,25 @@
 
 ![Omoluabi Productions Logo](Logo.jpg)
 
-- [Watchman](https://suno.com/s/9usky5oWSoGQGKcc)
-- [Ọmọlúàbí](https://suno.com/s/x2bQklbUkff82SYs)
-- [Take The Risk](https://suno.com/s/HyOQ7i8g388Iq150)
-- [TikTok](https://suno.com/s/LywGqccYVUn28GyT)
-- [Something Is About To Happen](https://suno.com/s/s6u44uPoi1h1DREX)
-- [Haters](https://suno.com/s/LWrJEdJi8vQX9JeT)
-- [Does It Matter To Matter](https://suno.com/s/ATP2E7dOLOM5fYuq)
-- [Pastor or Hustler](https://suno.com/s/vku6n8S387UAehXA)
-- [Fore-runner’s Map](https://suno.com/s/vYSWq1n8Y6JkMwAb)
-- [No Look Down](https://suno.com/s/IBdo5IxyXR5Xm3Hi)
-- [Wonder's Breeze](https://suno.com/s/BSACk85GTIjp1YAm)
-- [Covenant Of Isolation](https://suno.com/s/EnZJCry311OUE38x)
-- [Ghostwriter](https://suno.com/s/RHUdAKZxJpiO6NPW)
-- [A Wa Good Gan](https://suno.com/s/nKEV7ZI53jTK0JpB)
-- [Stir Am Well](https://suno.com/s/K1NgmbeDWMdovyDW)
-- [Talk Wey Bend (Obfuscation)](https://suno.com/s/21WKYiqeiIc3HowV)
-- [Belong Wahala](https://suno.com/s/M4lYXsER1CVgoy8E)
-- [Habatically](https://suno.com/s/mGDmxgwrG7o5PDei)
-- [Party No Go Stop (Instrumental)](https://suno.com/s/6Bf8h533CmlknY4a)
-- [Blood On The Lithium](https://suno.com/s/wl8GdV5utszvEs9q)
-- [No Be My Story](https://suno.com/s/iMWJBndE9509dw8Z)
-- [Na We Dey](https://suno.com/s/bOd4eDFLqNrpfhAA)
+- Watchman
+- Ọmọlúàbí
+- Take The Risk
+- TikTok
+- Something Is About To Happen
+- Haters
+- Does It Matter To Matter
+- Pastor or Hustler
+- Fore-runner’s Map
+- No Look Down
+- Wonder's Breeze
+- Covenant Of Isolation
+- Ghostwriter
+- A Wa Good Gan
+- Stir Am Well
+- Talk Wey Bend (Obfuscation)
+- Belong Wahala
+- Habatically
+- Party No Go Stop (Instrumental)
+- Blood On The Lithium
+- No Be My Story
+- Na We Dey


### PR DESCRIPTION
## Summary
- strip external source links from Omoluabi Production Catalogue
- leave clean track list without revealing audio origins

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a86032fb148332b9d8bf7fa32f5d3b