### PR TITLE
Add Suno links to Omoluabi production catalogue

### DIFF
--- a/Omoluabi_Production_Catalogue.md
+++ b/Omoluabi_Production_Catalogue.md
@@ -14,13 +14,13 @@
 - No Look Down
 - Wonder's Breeze
 - Covenant Of Isolation
-- Ghostwriter
-- A Wa Good Gan
-- Stir Am Well
-- Talk Wey Bend (Obfuscation)
-- Belong Wahala
-- Habatically
-- Party No Go Stop (Instrumental)
-- Blood On The Lithium
-- No Be My Story
-- Na We Dey
+- [Ghostwriter](https://suno.com/s/RHUdAKZxJpiO6NPW)
+- [A Wa Good Gan](https://suno.com/s/nKEV7ZI53jTK0JpB)
+- [Stir Am Well](https://suno.com/s/K1NgmbeDWMdovyDW)
+- [Talk Wey Bend (Obfuscation)](https://suno.com/s/21WKYiqeiIc3HowV)
+- [Belong Wahala](https://suno.com/s/M4lYXsER1CVgoy8E)
+- [Habatically](https://suno.com/s/mGDmxgwrG7o5PDei)
+- [Party No Go Stop (Instrumental)](https://suno.com/s/6Bf8h533CmlknY4a)
+- [Blood On The Lithium](https://suno.com/s/wl8GdV5utszvEs9q)
+- [No Be My Story](https://suno.com/s/iMWJBndE9509dw8Z)
+- [Na We Dey](https://suno.com/s/bOd4eDFLqNrpfhAA)

--- a/scripts/data.js
+++ b/scripts/data.js
@@ -143,7 +143,17 @@ const albums = [
             { src: 'https://cdn1.suno.ai/7356371a-b8f7-470a-87a3-dbe5c2916f72.mp3', title: 'Fore-runner’s Map' },
             { src: 'https://cdn1.suno.ai/5ad4f8bc-4cef-4ad4-b847-c4f1b8147445.mp3', title: 'No Look Down' },
             { src: 'https://cdn1.suno.ai/4f81332a-d833-4dc9-9763-7db0dfde3610.mp3', title: 'Wonder\'s Breeze' },
-            { src: 'https://cdn1.suno.ai/7578528b-34c1-492c-9e97-df93216f0cc2.mp3', title: 'Covenant Of Isolation' }
+            { src: 'https://cdn1.suno.ai/7578528b-34c1-492c-9e97-df93216f0cc2.mp3', title: 'Covenant Of Isolation' },
+            { src: 'https://cdn1.suno.ai/57a24cc6-ab05-447a-91ab-008321e9fc6a.mp3', title: 'Ghostwriter' },
+            { src: 'https://cdn1.suno.ai/c84b1a3e-b364-41d3-be5f-8e3b2273eb96.mp3', title: 'A Wa Good Gan' },
+            { src: 'https://cdn1.suno.ai/ce45202a-56e3-4d86-b185-3aa741aac131.mp3', title: 'Stir Am Well' },
+            { src: 'https://cdn1.suno.ai/d58c70e0-b330-4cda-8ee5-afd65f874d39.mp3', title: 'Talk Wey Bend (Obfuscation)' },
+            { src: 'https://cdn1.suno.ai/dbb44f28-64a1-49bb-bcbf-b5460c29ccd4.mp3', title: 'Belong Wahala' },
+            { src: 'https://cdn1.suno.ai/19c15d58-c776-4f1c-9ef7-3bb7890b26bb.mp3', title: 'Habatically' },
+            { src: 'https://cdn1.suno.ai/c6bb53b4-def2-4a68-bfaf-35f7f6dd7810.mp3', title: 'Party No Go Stop (Instrumental)' },
+            { src: `${BASE_URL}Blood%20On%20The%20Lithium.mp3`, title: 'Blood On The Lithium' },
+            { src: `${BASE_URL}No%20Be%20My%20Story.mp3`, title: 'No Be My Story' },
+            { src: `${BASE_URL}Na%20We%20Dey.mp3`, title: 'Na We Dey' }
         ]
       },
     ];


### PR DESCRIPTION
## Summary
- link Omoluabi catalogue tracks to their Suno pages
- surface new Suno tracks in the data.js track list so they appear in the modal

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a871f76cd48332bd5b948a3f08862e