### PR TITLE
Use slugs in track URLs for stable sharing

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 - **PWA:** Install the application on your device for offline access and a native-like experience.
 - **Radio:** Listen to a variety of Nigerian and international radio stations.
 - **Games:** Play mini-games like Picture Game and Omoluabi Tetris.
-- **Shareable Links:** Copy or share a URL that opens the app to a specific track.
+- **Shareable Links:** Copy or share a URL that opens the app to a specific track (e.g., `main.html?album=kindness&track=locked-away`).
 
 ## Technologies Used
 

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1,4 +1,4 @@
-/* SHARE BUTTON (Web Share API) */
+    /* SHARE BUTTON (Web Share API) */
     function shareContent() {
       if (navigator.share) {
         navigator.share({
@@ -9,6 +9,14 @@
       } else {
         alert("Your browser doesn't support the Web Share API. Please copy the URL manually.");
       }
+    }
+
+    /* Utility to create URL-friendly slugs */
+    function slugify(str) {
+      return str
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/(^-|-$)+/g, '');
     }
 
     /* SEARCH BAR AUTO-COMPLETE */
@@ -317,12 +325,12 @@
       const params = new URLSearchParams(window.location.search);
       const albumParam = params.get('album');
       const trackParam = params.get('track');
-      if (albumParam !== null && trackParam !== null) {
-        const albumIndex = parseInt(albumParam, 10);
-        const trackIndex = parseInt(trackParam, 10);
-        if (!isNaN(albumIndex) && albumIndex >= 0 && albumIndex < albums.length) {
+      if (albumParam && trackParam) {
+        const albumIndex = albums.findIndex(a => slugify(a.name) === albumParam);
+        if (albumIndex !== -1) {
           const album = albums[albumIndex];
-          if (!isNaN(trackIndex) && trackIndex >= 0 && trackIndex < album.tracks.length) {
+          const trackIndex = album.tracks.findIndex(t => slugify(t.title) === trackParam);
+          if (trackIndex !== -1) {
             currentAlbumIndex = albumIndex;
             updateTrackListModal();
             selectTrack(album.tracks[trackIndex].src, album.tracks[trackIndex].title, trackIndex);

--- a/scripts/player.js
+++ b/scripts/player.js
@@ -241,8 +241,8 @@ function selectTrack(src, title, index) {
       currentTrackIndex = index;
       currentRadioIndex = -1;
       const params = new URLSearchParams(window.location.search);
-      params.set('album', currentAlbumIndex);
-      params.set('track', index);
+      params.set('album', slugify(albums[currentAlbumIndex].name));
+      params.set('track', slugify(title));
       window.history.replaceState({}, '', `${window.location.pathname}?${params.toString()}`);
       lastTrackSrc = src;
       lastTrackTitle = title;


### PR DESCRIPTION
## Summary
- Use slugified album and track names in URLs so shared links always load the correct track
- Parse slug parameters on startup to preselect the right track regardless of album order
- Document track-specific link format in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a87f884d90833290ec9d2194c33079