### PR TITLE
Add chess game entry to edge panel

### DIFF
--- a/icons/chess.svg
+++ b/icons/chess.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="96" height="96" viewBox="0 0 96 96">
+  <rect x="24" y="8" width="48" height="16" fill="#000"/>
+  <rect x="24" y="24" width="48" height="16" fill="#000"/>
+  <rect x="32" y="40" width="32" height="32" fill="#000"/>
+  <rect x="20" y="72" width="56" height="16" fill="#000"/>
+</svg>

--- a/main.html
+++ b/main.html
@@ -708,6 +708,10 @@
         <div class="word-search-bubble-container" role="button" aria-label="Open Omoluabi Word Search" onclick="openWordSearchGame()">
             <img src="icons/word-search.svg" alt="Omoluabi Word Search Game Icon" class="picture-game-float-icon" />
         </div>
+        <!-- Omoluabi Chess Floating Icon -->
+        <div class="chess-bubble-container" role="button" aria-label="Open Omoluabi Chess" onclick="openChessGame()">
+            <img src="icons/chess.svg" alt="Omoluabi Chess Game Icon" class="picture-game-float-icon" />
+        </div>
     </div>
 </div>
 
@@ -758,6 +762,13 @@
     <button class="popup-close ripple shockwave" onclick="closeWordSearchGame()">×</button>
     <h3 id="wordSearchTitle" class="modal-title">Omoluabi Word Search</h3>
     <iframe src="word-search.html" style="width: 100%; height: 100%; border: none;"></iframe>
+</div>
+
+<!-- Omoluabi Chess Container -->
+<div id="chessGameContainer" class="chatbot-container" role="dialog" aria-labelledby="chessGameTitle">
+    <button class="popup-close ripple shockwave" onclick="closeChessGame()">×</button>
+    <h3 id="chessGameTitle" class="modal-title">Omoluabi Chess</h3>
+    <iframe src="https://omoluabi1003.github.io/Omoluabi-Chess/" style="width: 100%; height: 100%; border: none;"></iframe>
 </div>
 
 <!-- About Us Container -->

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -583,7 +583,7 @@
 
     // Dynamic Edge Panel Height
     const edgePanelContent = document.querySelector('.edge-panel-content');
-    const icons = edgePanelContent.querySelectorAll('.chatbot-bubble-container, .sabi-bible-bubble-container, .picture-game-bubble-container, .tetris-bubble-container, .word-search-bubble-container');
+    const icons = edgePanelContent.querySelectorAll('.chatbot-bubble-container, .sabi-bible-bubble-container, .picture-game-bubble-container, .tetris-bubble-container, .word-search-bubble-container, .chess-bubble-container');
     const iconHeight = 50; // height of each icon
     const iconSpacing = 20; // spacing between icons
     const panelPadding = 20; // top and bottom padding of the panel

--- a/scripts/ui.js
+++ b/scripts/ui.js
@@ -191,6 +191,7 @@ const sabiBibleContainer = document.getElementById('sabiBibleContainer');
 const pictureGameContainer = document.getElementById('pictureGameContainer');
 const tetrisGameContainer = document.getElementById('tetrisGameContainer');
 const wordSearchContainer = document.getElementById('wordSearchContainer');
+const chessGameContainer = document.getElementById('chessGameContainer');
 const aboutModalContainer = document.getElementById('aboutModalContainer');
 
 function isAnyPanelOpen() {
@@ -199,6 +200,7 @@ function isAnyPanelOpen() {
            pictureGameContainer.style.display === 'block' ||
            tetrisGameContainer.style.display === 'block' ||
            wordSearchContainer.style.display === 'block' ||
+           chessGameContainer.style.display === 'block' ||
            aboutModalContainer.style.display === 'block';
 }
 
@@ -269,6 +271,16 @@ function openWordSearchGame() {
 
 function closeWordSearchGame() {
     wordSearchContainer.style.display = 'none';
+    updateEdgePanelBehavior();
+}
+
+function openChessGame() {
+    chessGameContainer.style.display = 'block';
+    updateEdgePanelBehavior();
+}
+
+function closeChessGame() {
+    chessGameContainer.style.display = 'none';
     updateEdgePanelBehavior();
 }
 


### PR DESCRIPTION
## Summary
- Add chess icon and modal to edge panel with iframe pointing to Omoluabi Chess
- Include open/close logic for chess game and update edge panel height calculation
- Provide simple SVG asset for chess icon

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a8968c10d08332bcd388e868b250a6