### PR TITLE
Add neon-themed chess game and icon

### DIFF
--- a/chess.css
+++ b/chess.css
@@ -1,0 +1,54 @@
+body {
+    background: radial-gradient(circle at top, #00111a, #000);
+    font-family: 'Orbitron', sans-serif;
+    color: #00f8ff;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 100vh;
+    margin: 0;
+}
+
+#chess-app {
+    text-align: center;
+}
+
+#board {
+    width: 320px;
+    margin: 0 auto;
+    box-shadow: 0 0 20px #00f8ff;
+    border: 2px solid #00f8ff;
+}
+
+.white-1e1d7 {
+    background: #00f8ff33;
+}
+
+.black-3c85d {
+    background: #001f3f;
+}
+
+.white-1e1d7, .black-3c85d {
+    box-shadow: inset 0 0 10px #00f8ff55;
+}
+
+#status {
+    margin-top: 15px;
+}
+
+#resetBtn {
+    margin-top: 15px;
+    background: transparent;
+    border: 1px solid #00f8ff;
+    color: #00f8ff;
+    padding: 8px 16px;
+    cursor: pointer;
+    border-radius: 4px;
+    text-shadow: 0 0 5px #00f8ff;
+    transition: background 0.3s, color 0.3s;
+}
+
+#resetBtn:hover {
+    background: #00f8ff;
+    color: #000;
+}

--- a/chess.html
+++ b/chess.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+    <meta name="apple-mobile-web-app-title" content="Àríyò AI" />
+    <meta name="apple-touch-fullscreen" content="yes" />
+    <link rel="apple-touch-icon" href="icons/Ariyo.png" />
+    <meta name="description" content="Play Omoluabi Chess in Àríyò AI by Paul Iyogun (Omoluabi)." />
+    <meta name="keywords" content="Paul Iyogun, Omoluabi, Ariyo AI, Omoluabi Chess game, Naija AI" />
+    <title>Omoluabi Chess</title>
+    <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/chessboard.js/1.0.0/chessboard.min.css" integrity="sha512-GQdpAt4E4YaL6VLdystD5nq2WEYLRh1SeDsICoZ6irMUiP+6JGZveHFkNjEcNWef39/C4R2tQeM+c/fi91RrIw==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <link rel="stylesheet" href="chess.css" />
+</head>
+<body>
+    <div id="chess-app">
+        <div id="board" aria-label="Omoluabi Chess board"></div>
+        <div id="status" role="status" aria-live="polite"></div>
+        <button id="resetBtn" aria-label="Reset game">Reset</button>
+    </div>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/chess.js/0.10.3/chess.min.js" integrity="sha512-8p9E9/7dkQNBbiEhYXTTsE4H0uGAaHo9dZYkTfGZNVVRFlE0YyqS/fWznuaCG2lKT9IAXoJ2Bs8LJIrrHV+4jw==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/chessboard.js/1.0.0/chessboard.min.js" integrity="sha512-JFykunDrXfCPp0wOykG++Hj6kUMlzUxr87hcPLZ9eczsQnUnxE27XGr0CcsMEY0S8mV+4CSkiqhSSjMBD+kh9A==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script src="chess.js"></script>
+    <script src="prevent-zoom.js"></script>
+</body>
+</html>

--- a/chess.js
+++ b/chess.js
@@ -1,0 +1,41 @@
+const game = new Chess();
+const board = Chessboard('board', {
+    draggable: true,
+    position: 'start',
+    onDragStart: (source, piece) => {
+        if (game.game_over()) return false;
+        if (game.turn() === 'w' && piece.startsWith('b')) return false;
+        if (game.turn() === 'b' && piece.startsWith('w')) return false;
+        return true;
+    },
+    onDrop: (source, target) => {
+        const move = game.move({ from: source, to: target, promotion: 'q' });
+        if (move === null) return 'snapback';
+        updateStatus();
+    },
+    onSnapEnd: () => board.position(game.fen())
+});
+
+function updateStatus() {
+    let status = '';
+    const moveColor = game.turn() === 'b' ? 'Black' : 'White';
+    if (game.in_checkmate()) {
+        status = `Game over, ${moveColor} is in checkmate.`;
+    } else if (game.in_draw()) {
+        status = 'Game over, drawn position';
+    } else {
+        status = `${moveColor} to move`;
+        if (game.in_check()) {
+            status += `, ${moveColor} is in check`;
+        }
+    }
+    document.getElementById('status').textContent = status;
+}
+
+document.getElementById('resetBtn').addEventListener('click', () => {
+    game.reset();
+    board.start();
+    updateStatus();
+});
+
+updateStatus();

--- a/icons/chess.svg
+++ b/icons/chess.svg
@@ -1,6 +1,17 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="96" height="96" viewBox="0 0 96 96">
-  <rect x="24" y="8" width="48" height="16" fill="#000"/>
-  <rect x="24" y="24" width="48" height="16" fill="#000"/>
-  <rect x="32" y="40" width="32" height="32" fill="#000"/>
-  <rect x="20" y="72" width="56" height="16" fill="#000"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <defs>
+    <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#00f8ff" />
+      <stop offset="100%" stop-color="#0072ff" />
+    </linearGradient>
+    <filter id="glow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur stdDeviation="3.5" result="coloredBlur" />
+      <feMerge>
+        <feMergeNode in="coloredBlur" />
+        <feMergeNode in="SourceGraphic" />
+      </feMerge>
+    </filter>
+  </defs>
+  <rect width="100" height="100" rx="15" fill="#0a0a0a" />
+  <path d="M30 80 L70 80 L70 70 L60 60 L65 40 L55 20 L40 20 L35 35 L45 40 L30 55 Z" fill="url(#grad)" filter="url(#glow)"/>
 </svg>

--- a/main.html
+++ b/main.html
@@ -410,10 +410,21 @@
       box-shadow: 0px 4px 10px rgba(0,0,0,0.3);
       animation: float 3s ease-in-out infinite;
     }
+    .chess-float-icon {
+      width: 60px;
+      height: 60px;
+      border-radius: 50%;
+      animation: float 3s ease-in-out infinite, glow 2s ease-in-out infinite;
+      box-shadow: 0 0 5px #00f8ff, 0 0 15px #0051ff;
+    }
     @keyframes float {
       0%   { transform: translateY(0px); }
       50%  { transform: translateY(-10px); }
       100% { transform: translateY(0px); }
+    }
+    @keyframes glow {
+      0%, 100% { box-shadow: 0 0 5px #00f8ff, 0 0 15px #0051ff; }
+      50% { box-shadow: 0 0 20px #00f8ff, 0 0 30px #0051ff; }
     }
     @keyframes pulse {
       0% { transform: scale(1); }
@@ -710,7 +721,7 @@
         </div>
         <!-- Omoluabi Chess Floating Icon -->
         <div class="chess-bubble-container" role="button" aria-label="Open Omoluabi Chess" onclick="openChessGame()">
-            <img src="icons/chess.svg" alt="Omoluabi Chess Game Icon" class="picture-game-float-icon" />
+            <img src="icons/chess.svg" alt="Omoluabi Chess Game Icon" class="chess-float-icon" />
         </div>
     </div>
 </div>
@@ -768,7 +779,7 @@
 <div id="chessGameContainer" class="chatbot-container" role="dialog" aria-labelledby="chessGameTitle">
     <button class="popup-close ripple shockwave" onclick="closeChessGame()">×</button>
     <h3 id="chessGameTitle" class="modal-title">Omoluabi Chess</h3>
-    <iframe src="https://omoluabi1003.github.io/Omoluabi-Chess/" style="width: 100%; height: 100%; border: none;"></iframe>
+    <iframe src="chess.html" style="width: 100%; height: 100%; border: none;"></iframe>
 </div>
 
 <!-- About Us Container -->


### PR DESCRIPTION
## Summary
- add local Omoluabi Chess page styled with a neon futuristic theme
- replace chess icon with gradient glow and animate floating button
- wire main page to new chess game iframe

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a89b276fa483328992a9fac4f54d8f