### PR TITLE
Fix chess board initialization

### DIFF
--- a/chess.js
+++ b/chess.js
@@ -1,41 +1,44 @@
-const game = new Chess();
-const board = Chessboard('board', {
-    draggable: true,
-    position: 'start',
-    onDragStart: (source, piece) => {
-        if (game.game_over()) return false;
-        if (game.turn() === 'w' && piece.startsWith('b')) return false;
-        if (game.turn() === 'b' && piece.startsWith('w')) return false;
-        return true;
-    },
-    onDrop: (source, target) => {
-        const move = game.move({ from: source, to: target, promotion: 'q' });
-        if (move === null) return 'snapback';
-        updateStatus();
-    },
-    onSnapEnd: () => board.position(game.fen())
-});
+document.addEventListener('DOMContentLoaded', () => {
+    const game = new Chess();
+    const board = Chessboard('board', {
+        draggable: true,
+        position: 'start',
+        pieceTheme: 'https://cdnjs.cloudflare.com/ajax/libs/chessboard.js/1.0.0/img/chesspieces/wikipedia/{piece}.png',
+        onDragStart: (source, piece) => {
+            if (game.game_over()) return false;
+            if (game.turn() === 'w' && piece.startsWith('b')) return false;
+            if (game.turn() === 'b' && piece.startsWith('w')) return false;
+            return true;
+        },
+        onDrop: (source, target) => {
+            const move = game.move({ from: source, to: target, promotion: 'q' });
+            if (move === null) return 'snapback';
+            updateStatus();
+        },
+        onSnapEnd: () => board.position(game.fen())
+    });
 
-function updateStatus() {
-    let status = '';
-    const moveColor = game.turn() === 'b' ? 'Black' : 'White';
-    if (game.in_checkmate()) {
-        status = `Game over, ${moveColor} is in checkmate.`;
-    } else if (game.in_draw()) {
-        status = 'Game over, drawn position';
-    } else {
-        status = `${moveColor} to move`;
-        if (game.in_check()) {
-            status += `, ${moveColor} is in check`;
+    function updateStatus() {
+        let status = '';
+        const moveColor = game.turn() === 'b' ? 'Black' : 'White';
+        if (game.in_checkmate()) {
+            status = `Game over, ${moveColor} is in checkmate.`;
+        } else if (game.in_draw()) {
+            status = 'Game over, drawn position';
+        } else {
+            status = `${moveColor} to move`;
+            if (game.in_check()) {
+                status += `, ${moveColor} is in check`;
+            }
         }
+        document.getElementById('status').textContent = status;
     }
-    document.getElementById('status').textContent = status;
-}
 
-document.getElementById('resetBtn').addEventListener('click', () => {
-    game.reset();
-    board.start();
+    document.getElementById('resetBtn').addEventListener('click', () => {
+        game.reset();
+        board.start();
+        updateStatus();
+    });
+
     updateStatus();
 });
-
-updateStatus();


### PR DESCRIPTION
## Summary
- Ensure chess board renders by waiting for DOM content and using CDN-hosted piece images

## Testing
- `npm test`
- `node test_chess.js` *(fails: libatk-1.0.so.0: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68a8f4a8ae248332b6b44a6db0853efc