### PR TITLE
Add interactive chess board with computer opponent

### DIFF
--- a/chess.css
+++ b/chess.css
@@ -13,6 +13,12 @@ body {
     text-align: center;
 }
 
+#player-info {
+    display: flex;
+    justify-content: space-between;
+    margin-bottom: 10px;
+}
+
 #board {
     width: min(90vmin, 500px);
     margin: 0 auto;

--- a/chess.html
+++ b/chess.html
@@ -17,6 +17,10 @@
 </head>
 <body>
     <div id="chess-app">
+        <div id="player-info">
+            <div id="white-player">White: Human</div>
+            <div id="black-player">Black: Computer</div>
+        </div>
         <div id="board" aria-label="Omoluabi Chess board"></div>
         <div id="status" role="status" aria-live="polite"></div>
         <div id="controls">

--- a/chess.js
+++ b/chess.js
@@ -17,6 +17,9 @@ document.addEventListener('DOMContentLoaded', () => {
             highlightSquare(source, 'last-move');
             highlightSquare(target, 'last-move');
             updateStatus();
+
+            // If playing against computer, make a move for black
+            window.setTimeout(makeRandomMove, 250);
         },
         onSnapEnd: () => board.position(game.fen()),
         onMouseoverSquare: (square, piece) => {
@@ -37,6 +40,18 @@ document.addEventListener('DOMContentLoaded', () => {
 
     function removeHighlights(className) {
         boardEl.querySelectorAll(`.${className}`).forEach(el => el.classList.remove(className));
+    }
+
+    function makeRandomMove() {
+        if (game.game_over() || game.turn() === 'w') return;
+        const moves = game.moves();
+        if (moves.length === 0) return;
+        const move = moves[Math.floor(Math.random() * moves.length)];
+        const result = game.move(move);
+        board.position(game.fen());
+        highlightSquare(result.from, 'last-move');
+        highlightSquare(result.to, 'last-move');
+        updateStatus();
     }
 
     function updateStatus() {


### PR DESCRIPTION
## Summary
- Display player info above the board
- Style player info and board layout
- Add simple computer opponent making random moves

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a8f935943c8332bc6158214a1385bc