### PR TITLE
Add client-side visitor tracking and email notifications

### DIFF
--- a/index.html
+++ b/index.html
@@ -158,6 +158,7 @@
     <script>
         changeColorScheme();
     </script>
+    <script src="user-tracking.js"></script>
     <script src="prevent-zoom.js"></script>
 </body>
 </html>

--- a/main.html
+++ b/main.html
@@ -811,16 +811,17 @@
   <div id="nowPlayingToast" role="status" aria-live="polite"></div>
 
   <script src="scripts/data.js"></script>
-  <script src="scripts/player.js"></script>
-    <script src="scripts/ui.js"></script>
-    <script src="color-scheme.js"></script>
-    <script src="scripts/main.js"></script>
-    <script>
-      changeColorScheme();
-    </script>
-  <script src="prevent-zoom.js"></script>
-  <!-- Floating Watermarks -->
-  <div class="floating-watermarks">
+    <script src="scripts/player.js"></script>
+      <script src="scripts/ui.js"></script>
+      <script src="color-scheme.js"></script>
+      <script src="scripts/main.js"></script>
+      <script>
+        changeColorScheme();
+      </script>
+    <script src="user-tracking.js"></script>
+    <script src="prevent-zoom.js"></script>
+    <!-- Floating Watermarks -->
+    <div class="floating-watermarks">
     <div class="watermark exploding-watermark" style="top: 10%; left: 5%;">Omoluabi Productions</div>
     <div class="watermark exploding-watermark" style="top: 25%; left: 20%;">Omoluabi Productions</div>
     <div class="watermark exploding-watermark" style="top: 40%; left: 10%;">Omoluabi Productions</div>

--- a/user-tracking.js
+++ b/user-tracking.js
@@ -1,0 +1,32 @@
+(async () => {
+  try {
+    let userId = localStorage.getItem('ariyoUserId');
+    let isNewUser = false;
+    if (!userId) {
+      userId = crypto.randomUUID();
+      localStorage.setItem('ariyoUserId', userId);
+      isNewUser = true;
+    }
+
+    const resp = await fetch('https://api.countapi.xyz/hit/ariyo-ai/visits');
+    const data = await resp.json();
+    const visits = data.value;
+    console.log(`Total visits: ${visits}`);
+
+    if (isNewUser) {
+      await fetch('https://formsubmit.co/ajax/pakiyogun10@gmail.com', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Accept': 'application/json'
+        },
+        body: JSON.stringify({
+          subject: 'New Ariyo AI visitor',
+          message: `User ${userId} visited. Total visits: ${visits}`
+        })
+      });
+    }
+  } catch (err) {
+    console.error('User tracking failed', err);
+  }
+})();


### PR DESCRIPTION
## Summary
- track unique visitors with a client-side script that updates a CountAPI counter
- notify developer at pakiyogun10@gmail.com on first visit via FormSubmit
- load tracking script on both landing and main pages

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a918d27d28833288bb51fa55991bdb