### PR TITLE
Add SQLite user tracking script

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ npm test
 
 The command currently prints "No tests yet".
 
+## Utilities
+
+- `user_tracker.py`: example script that stores basic user information in a local SQLite database.
+
 ## License
 
 This project is licensed under the MIT License.

--- a/user_tracker.py
+++ b/user_tracker.py
@@ -1,0 +1,51 @@
+import sqlite3
+from datetime import datetime, timezone
+
+DB_PATH = "users.db"
+
+
+def init_db():
+    conn = sqlite3.connect(DB_PATH)
+    cursor = conn.cursor()
+    cursor.execute(
+        """
+        CREATE TABLE IF NOT EXISTS users (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT,
+            email TEXT,
+            city TEXT,
+            country TEXT,
+            last_seen TEXT
+        )
+        """
+    )
+    conn.commit()
+    return conn
+
+
+def add_user(conn, name, email, city, country):
+    cursor = conn.cursor()
+    cursor.execute(
+        """
+        INSERT INTO users (name, email, city, country, last_seen)
+        VALUES (?, ?, ?, ?, ?)
+        """,
+        (name, email, city, country, datetime.now(timezone.utc).isoformat()),
+    )
+    conn.commit()
+
+
+def list_users(conn):
+    cursor = conn.cursor()
+    cursor.execute(
+        "SELECT id, name, city, country, last_seen FROM users"
+    )
+    return cursor.fetchall()
+
+
+if __name__ == "__main__":
+    connection = init_db()
+    add_user(connection, "Jane Doe", "jane@example.com", "Lagos", "Nigeria")
+    for user in list_users(connection):
+        print(user)
+    connection.close()


### PR DESCRIPTION
## Summary
- add `user_tracker.py` demonstrating SQLite-based storage of user info
- document utility script in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a9219ac2bc8332bc75663ed456520c