### PR TITLE
Use thumbnail images in album modal

### DIFF
--- a/scripts/ui.js
+++ b/scripts/ui.js
@@ -36,9 +36,13 @@ function populateAlbumList() {
     durationEl.className = 'album-duration';
     durationEl.textContent = 'Duration: …';
 
+    const info = document.createElement('div');
+    info.className = 'album-info';
+    info.appendChild(name);
+    info.appendChild(durationEl);
+
     link.appendChild(img);
-    link.appendChild(name);
-    link.appendChild(durationEl);
+    link.appendChild(info);
     albumList.appendChild(link);
 
     calculateAlbumDuration(album)

--- a/style.css
+++ b/style.css
@@ -307,15 +307,37 @@ body {
     font-size: clamp(0.9rem, 2vw, 1rem);
 }
 
+/* Use flex layout with smaller thumbnails for album list */
+.album-list a {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+}
+
 .album-list img {
-    width: 100%;
+    width: 80px;
+    height: 80px;
+    object-fit: cover;
     border-radius: 5px;
-    margin-bottom: 0.5rem;
+    margin-bottom: 0;
+    flex-shrink: 0;
+}
+
+.album-info {
+    display: flex;
+    flex-direction: column;
+}
+
+.album-info p {
+    margin: 0;
+}
+
+.album-info .album-duration {
+    margin-top: 0.2rem;
 }
 
 .album-duration {
     font-size: clamp(0.8rem, 2vw, 0.9rem);
-    margin-top: 0.2rem;
     color: #ccc;
 }
 


### PR DESCRIPTION
## Summary
- Display album entries with flex layout and 80px cover thumbnails
- Wrap album details in a column next to thumbnails for compact view

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa02632f788332a66ad157ed5bcef3