### PR TITLE
Fix Ara Chess loading issue by correcting SRI hash

### DIFF
--- a/chess.html
+++ b/chess.html
@@ -22,7 +22,7 @@
         <div id="board" aria-label="Ara Chess board"></div>
     </div>
     <script src="https://code.jquery.com/jquery-3.6.0.min.js" integrity="sha256-/xUj+3OJXc+OGDH7gXuIyPefU1K/7/DF2yW8oOGObFo=" crossorigin="anonymous"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/chess.js/0.13.4/chess.js" integrity="sha512-6P5WWZKfXzavGUtkLjxJvLCYOtJk9gDC11FXGeUXrXe3G5UpiRaY1oCbcnZ6+QcmGeXgnz9K/Y/xFd25R7zPiw==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/chess.js/0.13.4/chess.js" integrity="sha512-40VRp1+fauX7g61ZdQpOiOJTkBbYwVlTLjCXHK9Svf0Mmz9K8Smg5k6LVrc0eEc9+pApf1HNL6Cim/wFqZeRkw==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
     <script src="https://cdn.jsdelivr.net/npm/@chrisoakman/chessboardjs@1.0.0/dist/chessboard-1.0.0.min.js" integrity="sha512-WfASs5HtTgTL/eZsLaOftSN9wMQl7WZGlU5UiKx/yxTViMfGh9whWRwKAC27qH8VtZJqSMqDdbq2uUb1tY3jvQ==" crossorigin="anonymous"></script>
     <script src="chess.js"></script>
     <script src="color-scheme.js"></script>


### PR DESCRIPTION
## Summary
- Correct the Subresource Integrity hash for the chess.js library so Ara Chess loads properly.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa77d979d88332ba6a83cdd8f9f8cc