### PR TITLE
Fix chess board initialization

### DIFF
--- a/chess.js
+++ b/chess.js
@@ -1,21 +1,31 @@
 document.addEventListener('DOMContentLoaded', () => {
   const game = new Chess();
-  const board = Chessboard('board', {
+  let board = null;
+
+  function onDragStart(source, piece) {
+    if (game.game_over() ||
+        (game.turn() === 'w' && piece.search(/^b/) !== -1) ||
+        (game.turn() === 'b' && piece.search(/^w/) !== -1)) {
+      return false;
+    }
+  }
+
+  function onDrop(source, target) {
+    const move = game.move({ from: source, to: target, promotion: 'q' });
+    if (move === null) return 'snapback';
+  }
+
+  function onSnapEnd() {
+    board.position(game.fen());
+  }
+
+  const config = {
     draggable: true,
     position: 'start',
-    onDragStart: function (source, piece) {
-      if (game.game_over() ||
-          (game.turn() === 'w' && piece.search(/^b/) !== -1) ||
-          (game.turn() === 'b' && piece.search(/^w/) !== -1)) {
-        return false;
-      }
-    },
-    onDrop: function (source, target) {
-      const move = game.move({ from: source, to: target, promotion: 'q' });
-      if (move === null) return 'snapback';
-    },
-    onSnapEnd: function () {
-      board.position(game.fen());
-    }
-  });
+    onDragStart: onDragStart,
+    onDrop: onDrop,
+    onSnapEnd: onSnapEnd
+  };
+
+  board = Chessboard('board', config);
 });


### PR DESCRIPTION
## Summary
- Avoid referencing the board before it's initialized to prevent runtime errors
- Refactor chess game setup into standalone functions for clarity and reliability

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa79b3b5a88332931507746d1d736d