### PR TITLE
test: add Playwright tests and CI

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,0 +1,17 @@
+name: Playwright Tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+      - run: npm ci
+      - run: npx playwright install
+      - run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+test-results/
+playwright-report/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,79 @@
+{
+  "name": "ariyo-ai",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "ariyo-ai",
+      "version": "1.0.0",
+      "devDependencies": {
+        "@playwright/test": "^1.55.0",
+        "playwright": "^1.55.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.55.0.tgz",
+      "integrity": "sha512-04IXzPwHrW69XusN/SIdDdKZBzMfOT9UNT/YiJit/xpy2VuAoB8NHc8Aplb96zsWDddLnbkPL3TsmrS04ZU2xQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.55.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.55.0.tgz",
+      "integrity": "sha512-sdCWStblvV1YU909Xqx0DhOjPZE4/5lJsIS84IfN9dAZfcl/CIZ5O8l3o0j7hPMjDvqoTF8ZUcc+i/GL5erstA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.55.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.0.tgz",
+      "integrity": "sha512-GvZs4vU3U5ro2nZpeiwyb0zuFaqb9sUiAJuyrWpcGouD8y9/HLgGbNRjIph7zU9D3hnPaisMl9zG9CgFi/biIg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "ariyo-ai",
   "version": "1.0.0",
   "scripts": {
-    "test": "echo \"No tests yet\""
+    "test": "playwright test"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.55.0",
+    "playwright": "^1.55.0"
   }
 }

--- a/tests/games.spec.ts
+++ b/tests/games.spec.ts
@@ -1,0 +1,33 @@
+import { test, expect } from '@playwright/test';
+import path from 'path';
+
+const root = path.join(__dirname, '..');
+
+function fileUrl(relativePath: string) {
+  return 'file://' + path.join(root, relativePath);
+}
+
+test('Connect Four game board renders', async ({ page }) => {
+  await page.goto(fileUrl('connect-four.html'));
+  await expect(page.locator('#game-title')).toHaveText('Ara Connect-4');
+  await expect(page.locator('#board')).toBeVisible();
+});
+
+test('Picture puzzle controls render', async ({ page }) => {
+  await page.goto(fileUrl('picture-game.html'));
+  await expect(page.locator('#game-title')).toHaveText('Ara Puzzle');
+  await expect(page.locator('#start-button')).toBeVisible();
+});
+
+test('Tetris canvas is visible', async ({ page }) => {
+  await page.goto(fileUrl('tetris.html'));
+  await expect(page.locator('#game-title')).toHaveText('Omoluabi Tetris');
+  await expect(page.locator('#tetris')).toBeVisible();
+});
+
+test('Word search grid container exists', async ({ page }) => {
+  await page.goto(fileUrl('word-search.html'));
+  await expect(page.getByRole('heading', { name: 'Word Search Game' })).toBeVisible();
+  await expect(page.locator('#game')).toBeVisible();
+});
+

--- a/tests/main.spec.ts
+++ b/tests/main.spec.ts
@@ -1,0 +1,32 @@
+import { test, expect } from '@playwright/test';
+import path from 'path';
+
+const mainHtml = 'file://' + path.join(__dirname, '..', 'main.html');
+
+test.describe('Main page functionality', () => {
+  test('plays music when play button is clicked', async ({ page }) => {
+    await page.goto(mainHtml);
+    const playButton = page.getByRole('button', { name: 'Play' });
+    await playButton.click();
+    await expect.poll(async () => {
+      return await page.evaluate(() => {
+        const audio = document.getElementById('audioPlayer') as HTMLAudioElement | null;
+        return audio ? !audio.paused : false;
+      });
+    }).toBe(true);
+  });
+
+  test('search input accepts text', async ({ page }) => {
+    await page.goto(mainHtml);
+    const searchInput = page.locator('#searchInput');
+    await searchInput.fill('test');
+    await expect(searchInput).toHaveValue('test');
+  });
+
+  test('PWA install button is present', async ({ page }) => {
+    await page.goto(mainHtml);
+    const installButton = page.getByRole('button', { name: 'Install Àríyò AI', hidden: true });
+    await expect(installButton).toHaveCount(1);
+  });
+});
+


### PR DESCRIPTION
## Summary
- set up Playwright and replace npm test script
- add main page and mini-game Playwright tests
- run Playwright in CI via GitHub Actions

## Testing
- `npx playwright install`
- `npm test` *(fails: Host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68ab551e53508332bae50f1fb1f5a2db