### PR TITLE
Add waveform visualization with Wavesurfer.js

### DIFF
--- a/main.html
+++ b/main.html
@@ -676,6 +676,7 @@
       <button aria-label="Next track" onclick="nextTrack()" title="Next track" aria-controls="audioPlayer" class="ripple shockwave">⏭</button>
       <button aria-label="Toggle shuffle" onclick="toggleShuffle()" title="Toggle shuffle" aria-pressed="false" class="ripple shockwave">🔀</button>
     </div>
+    <div id="waveform"></div>
   </div>
 
   <!-- Modal for Album List -->
@@ -830,6 +831,7 @@
   <div id="nowPlayingToast" role="status" aria-live="polite"></div>
 
   <script src="scripts/data.js"></script>
+  <script src="https://unpkg.com/wavesurfer.js"></script>
     <script src="scripts/player.js"></script>
       <script src="scripts/ui.js"></script>
       <script src="color-scheme.js"></script>

--- a/scripts/player.js
+++ b/scripts/player.js
@@ -16,6 +16,17 @@
     audioPlayer.id = 'audioPlayer';
     audioPlayer.preload = 'auto';
     document.body.appendChild(audioPlayer);
+    const wavesurfer = WaveSurfer.create({
+        container: '#waveform',
+        waveColor: '#ccc',
+        progressColor: getComputedStyle(document.documentElement).getPropertyValue('--theme-color') || '#ff7043',
+        responsive: true,
+        height: 80,
+        backend: 'MediaElement',
+        media: audioPlayer
+    });
+    audioPlayer.addEventListener('play', () => wavesurfer.play());
+    audioPlayer.addEventListener('pause', () => wavesurfer.pause());
     const albumCover = document.getElementById('albumCover');
     const trackInfo = document.getElementById('trackInfo');
     const trackArtist = document.getElementById('trackArtist');
@@ -247,8 +258,10 @@ function selectTrack(src, title, index) {
       lastTrackSrc = src;
       lastTrackTitle = title;
       lastTrackIndex = index;
-      audioPlayer.src = src + '?t=' + new Date().getTime();
+      const waveSrc = src + '?t=' + new Date().getTime();
+      audioPlayer.src = waveSrc;
       audioPlayer.currentTime = 0;
+      wavesurfer.load(waveSrc);
       trackInfo.textContent = title;
       trackArtist.textContent = 'Artist: Omoluabi';
       trackYear.textContent = 'Release Year: 2025';

--- a/style.css
+++ b/style.css
@@ -203,6 +203,24 @@ body {
     animation: gradient-glow 1.5s infinite alternate;
 }
 
+#waveform {
+    width: 100%;
+    height: 100px;
+    margin-top: 1rem;
+}
+
+@media (prefers-color-scheme: dark) {
+    #waveform {
+        background-color: #333;
+    }
+}
+
+@media (prefers-color-scheme: light) {
+    #waveform {
+        background-color: #ddd;
+    }
+}
+
 .track-info {
     margin-top: 0.3rem;
     font-size: clamp(1rem, 3vw, 1.2rem);


### PR DESCRIPTION
## Summary
- load Wavesurfer.js from CDN and initialize waveform container
- sync Wavesurfer instance with existing audio player for play/pause
- style waveform for dark and light modes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ab550ba6cc8332bee9f5fc8f303157