### PR TITLE
Add waveform visualisation with WaveSurfer

### DIFF
--- a/main.html
+++ b/main.html
@@ -651,6 +651,7 @@
     <div id="progressBar" class="progress-bar">
       <div id="progressBarFill"></div>
     </div>
+    <div id="waveform"></div>
     <p class="track-info" id="trackInfo" aria-live="polite">A Very Good Bad Guy v3</p>
     <p class="track-details" id="trackArtist">Artist: Omoluabi</p>
     <p class="track-details" id="trackYear">Release Year: 2025</p>
@@ -836,6 +837,7 @@
 
   <script src="scripts/data.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/lyric-parser@1.0.1/dist/lyric.min.js"></script>
+  <script src="https://unpkg.com/wavesurfer.js"></script>
   <script src="scripts/player.js"></script>
       <script src="scripts/ui.js"></script>
       <script src="color-scheme.js"></script>

--- a/scripts/player.js
+++ b/scripts/player.js
@@ -27,14 +27,30 @@
     const retryButton = document.getElementById('retryButton');
     const cacheButton = document.getElementById('cacheButton'); // New cache button
     const progressBar = document.getElementById('progressBarFill');
-    const lyricsContainer = document.getElementById('lyrics');
-    let lyricLines = [];
-    let shuffleMode = false; // True if any shuffle is active
-    let shuffleScope = 'off'; // 'off', 'album', 'all'
-    let isFirstPlay = true;
-    let lastTrackSrc = '';
-    let lastTrackTitle = '';
-    let lastTrackIndex = 0;
+const lyricsContainer = document.getElementById('lyrics');
+let lyricLines = [];
+let shuffleMode = false; // True if any shuffle is active
+let shuffleScope = 'off'; // 'off', 'album', 'all'
+let isFirstPlay = true;
+let lastTrackSrc = '';
+let lastTrackTitle = '';
+let lastTrackIndex = 0;
+
+    const waveformContainer = document.getElementById('waveform');
+    let wavesurfer;
+    if (waveformContainer && window.WaveSurfer) {
+      const isDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+      const waveColor = isDark ? '#888' : '#555';
+      const progressColor = getComputedStyle(document.documentElement).getPropertyValue('--theme-color') || '#ff7043';
+      wavesurfer = WaveSurfer.create({
+        container: waveformContainer,
+        waveColor: waveColor,
+        progressColor: progressColor.trim(),
+        height: 80,
+        cursorWidth: 0,
+        media: audioPlayer,
+      });
+    }
 
     let currentAlbumIndex = 0;
     let currentTrackIndex = 0;
@@ -295,6 +311,9 @@ function selectTrack(src, title, index) {
       lastTrackTitle = title;
       lastTrackIndex = index;
       audioPlayer.src = src + '?t=' + new Date().getTime();
+      if (wavesurfer) {
+        wavesurfer.load(audioPlayer);
+      }
       audioPlayer.currentTime = 0;
       trackInfo.textContent = title;
       trackArtist.textContent = 'Artist: Omoluabi';
@@ -320,6 +339,9 @@ function selectTrack(src, title, index) {
       currentTrackIndex = index;
       currentRadioIndex = -1;
       audioPlayer.src = src;
+      if (wavesurfer) {
+        wavesurfer.load(audioPlayer);
+      }
       audioPlayer.currentTime = 0;
       trackInfo.textContent = title;
       trackArtist.textContent = 'Artist: Omoluabi';
@@ -352,6 +374,9 @@ function selectTrack(src, title, index) {
       lastTrackTitle = title;
       lastTrackIndex = index;
       audioPlayer.src = src;
+      if (wavesurfer) {
+        wavesurfer.load(audioPlayer);
+      }
       audioPlayer.currentTime = 0;
       trackInfo.textContent = title;
       trackArtist.textContent = '';

--- a/style.css
+++ b/style.css
@@ -120,6 +120,22 @@ body {
     text-shadow: none;
 }
 
+#waveform {
+    width: 90%;
+    margin: 1rem auto;
+}
+
+@media (prefers-color-scheme: dark) {
+    #waveform {
+        background-color: #222;
+    }
+}
+
+@media (prefers-color-scheme: light) {
+    #waveform {
+        background-color: #f0f0f0;
+    }
+}
 .about-us-active {
     position: relative;
     z-index: 1001;


### PR DESCRIPTION
## Summary
- Load WaveSurfer.js from CDN and add waveform container in music player
- Style waveform for both light and dark modes
- Initialize WaveSurfer instance bound to existing audio player for synchronized playback

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ab63ee522083329ba80424f179a535