### PR TITLE
Fix waveform load for audio tracks

### DIFF
--- a/scripts/player.js
+++ b/scripts/player.js
@@ -312,7 +312,7 @@ function selectTrack(src, title, index) {
       lastTrackIndex = index;
       audioPlayer.src = src + '?t=' + new Date().getTime();
       if (wavesurfer) {
-        wavesurfer.load(audioPlayer);
+        wavesurfer.load(audioPlayer.src);
       }
       audioPlayer.currentTime = 0;
       trackInfo.textContent = title;
@@ -340,7 +340,7 @@ function selectTrack(src, title, index) {
       currentRadioIndex = -1;
       audioPlayer.src = src;
       if (wavesurfer) {
-        wavesurfer.load(audioPlayer);
+        wavesurfer.load(audioPlayer.src);
       }
       audioPlayer.currentTime = 0;
       trackInfo.textContent = title;
@@ -375,7 +375,7 @@ function selectTrack(src, title, index) {
       lastTrackIndex = index;
       audioPlayer.src = src;
       if (wavesurfer) {
-        wavesurfer.load(audioPlayer);
+        wavesurfer.load(audioPlayer.src);
       }
       audioPlayer.currentTime = 0;
       trackInfo.textContent = title;


### PR DESCRIPTION
## Summary
- Load the waveform using the currently selected track source

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ab658c3b4083328a72b2991e2189bd