### PR TITLE
Add Dirty Dancing soundtrack and support per-album artists

### DIFF
--- a/main.html
+++ b/main.html
@@ -652,7 +652,7 @@
       <div id="progressBarFill"></div>
     </div>
     <p class="track-info" id="trackInfo" aria-live="polite">A Very Good Bad Guy v3</p>
-    <p class="track-details" id="trackArtist">Artist: Omoluabi</p>
+    <p class="track-details" id="trackArtist">Artist:</p>
     <p class="track-details" id="trackYear">Release Year: 2025</p>
     <p class="track-details" id="trackAlbum"></p> <!-- Added for album display -->
     <p class="track-duration" id="trackDuration">0:00 / 0:00</p>

--- a/scripts/data.js
+++ b/scripts/data.js
@@ -59,6 +59,25 @@ const albums = [
         ]
       },
       {
+        name: 'Dirty Dancing (Original Soundtrack from the Vestron Motion Picture)',
+        artist: 'Various Artists',
+        cover: 'https://upload.wikimedia.org/wikipedia/en/9/90/DirtyDancingSoundtrack.jpg',
+        tracks: [
+          { src: 'https://drive.google.com/uc?export=download&id=10Sj4C9EjL_oTC5BrUEO124F3IIJIIUJi', title: "(I've Had) The Time Of My Life" },
+          { src: 'https://drive.google.com/uc?export=download&id=15OZoamtswdbYjhjKpvUcQ3HK0MXq0_mQ', title: 'Be My Baby' },
+          { src: 'https://drive.google.com/uc?export=download&id=1VUl5XVXi5jjszQKFzMpSBvFCQrjDMs7j', title: "She's Like The Wind" },
+          { src: 'https://drive.google.com/uc?export=download&id=1JU2aOZt3mnj_wIa4Tzt6r57EkPQu5U7j', title: 'Hungry Eyes' },
+          { src: 'https://drive.google.com/uc?export=download&id=1fmZvd26VVRuON_KpsyCJLrY9CxwctUmc', title: 'Stay' },
+          { src: 'https://drive.google.com/uc?export=download&id=1PUecCtvYXO5jy8IYiPN7olDWnno39hHl', title: 'Yes' },
+          { src: 'https://drive.google.com/uc?export=download&id=1pau2Z86nwxk9ystblR1kbAF901EtuKLi', title: "You Don't Own Me" },
+          { src: 'https://drive.google.com/uc?export=download&id=1Tmb0pfUsx9HUVmTLppIpuxeuQGLIS64P', title: 'Hey Baby' },
+          { src: 'https://drive.google.com/uc?export=download&id=1N8gGmzP_vXIYCB9_AgifNLiZWK3rUNg0', title: 'Overload' },
+          { src: 'https://drive.google.com/uc?export=download&id=1kdywx21VMHJQ0SUEfEZa66-pxPxxv2GW', title: 'Love Is Strange' },
+          { src: 'https://drive.google.com/uc?export=download&id=1ttGd5IDKcmr5xkfKqFWI0Own18Q3zOE0', title: 'Where Are You Tonight?' },
+          { src: 'https://drive.google.com/uc?export=download&id=1Aba8QhFHZhgfbxDouD9ZwkCZvqJveXaM', title: 'In The Still Of The Night' }
+        ]
+      },
+      {
         name: 'Needs',
         cover: 'https://raw.githubusercontent.com/Omoluabi1003/afro-gospel-stream/main/FaithandB.jpg',
         tracks: [

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -347,7 +347,7 @@
 
         navigator.mediaSession.metadata = new MediaMetadata({
           title: currentRadioIndex === -1 ? track.title : track.name + ' - ' + track.location,
-          artist: currentRadioIndex === -1 ? 'Omoluabi' : '',
+          artist: currentRadioIndex === -1 ? (albums[currentAlbumIndex].artist || 'Omoluabi') : '',
           album: currentRadioIndex === -1 ? albums[currentAlbumIndex].name : '',
           artwork: [
             { src: artwork, sizes: '96x96', type: 'image/jpeg' },
@@ -422,7 +422,7 @@
           const track = albums[currentAlbumIndex].tracks[currentTrackIndex];
           audioPlayer.src = track.src;
           trackInfo.textContent = track.title;
-          trackArtist.textContent = 'Artist: Omoluabi';
+          trackArtist.textContent = `Artist: ${albums[currentAlbumIndex].artist || 'Omoluabi'}`;
           trackYear.textContent = 'Release Year: 2025';
            trackAlbum.textContent = `Album: ${albums[currentAlbumIndex].name}`; // Display album name
           cacheButton.style.display = 'block'; // Show for tracks

--- a/scripts/player.js
+++ b/scripts/player.js
@@ -296,7 +296,7 @@ function selectTrack(src, title, index) {
       lastTrackIndex = index;
       audioPlayer.src = src + '?t=' + new Date().getTime();      audioPlayer.currentTime = 0;
       trackInfo.textContent = title;
-      trackArtist.textContent = 'Artist: Omoluabi';
+      trackArtist.textContent = `Artist: ${albums[currentAlbumIndex].artist || 'Omoluabi'}`;
       trackYear.textContent = 'Release Year: 2025';
       trackAlbum.textContent = `Album: ${albums[currentAlbumIndex].name}`; // Display album name
       albumCover.src = albums[currentAlbumIndex].cover; // Ensure album cover updates
@@ -320,7 +320,7 @@ function selectTrack(src, title, index) {
       currentRadioIndex = -1;
       audioPlayer.src = src;      audioPlayer.currentTime = 0;
       trackInfo.textContent = title;
-      trackArtist.textContent = 'Artist: Omoluabi';
+      trackArtist.textContent = `Artist: ${albums[currentAlbumIndex].artist || 'Omoluabi'}`;
       trackYear.textContent = 'Release Year: 2025';
       trackAlbum.textContent = `Album: ${albums[currentAlbumIndex].name}`; // Display album name
       stopMusic();


### PR DESCRIPTION
## Summary
- add Dirty Dancing (Original Soundtrack from the Vestron Motion Picture) with cover art and tracks
- show correct artist per album and expose in media session metadata
- clean up artist placeholder in UI

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ade90122e483329b8dd909fcc678ee