### PR TITLE
Handle Suno audio without cache-busting

### DIFF
--- a/scripts/player.js
+++ b/scripts/player.js
@@ -300,7 +300,10 @@ function selectTrack(src, title, index) {
       lastTrackSrc = src;
       lastTrackTitle = title;
       lastTrackIndex = index;
-      audioPlayer.src = src + '?t=' + new Date().getTime();      audioPlayer.currentTime = 0;
+      const urlHost = new URL(src, window.location.origin).hostname;
+      const isSunoHosted = urlHost.includes('suno');
+      audioPlayer.src = isSunoHosted ? src : `${src}?t=${Date.now()}`;
+      audioPlayer.currentTime = 0;
       trackInfo.textContent = title;
       trackArtist.textContent = `Artist: ${albums[currentAlbumIndex].artist || 'Omoluabi'}`;
       trackYear.textContent = 'Release Year: 2025';


### PR DESCRIPTION
## Summary
- Skip adding cache-busting query strings to Suno-hosted tracks in the music player so Omoluabi Production Catalogue songs play reliably.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68adfcb1ba6083328f2d739357e0f525