### PR TITLE
Fix cross-origin track loading and add missing catalogue links

### DIFF
--- a/Omoluabi_Production_Catalogue.md
+++ b/Omoluabi_Production_Catalogue.md
@@ -2,18 +2,18 @@
 
 ![Omoluabi Productions Logo](Logo.jpg)
 
-- Watchman
-- Ọmọlúàbí
-- Take The Risk
-- TikTok
-- Something Is About To Happen
-- Haters
-- Does It Matter To Matter
-- Pastor or Hustler
-- Fore-runner’s Map
-- No Look Down
-- Wonder's Breeze
-- Covenant Of Isolation
+- [Watchman](https://cdn1.suno.ai/5c17dd10-1770-467a-947a-db773c72ec78.mp3)
+- [Ọmọlúàbí](https://cdn1.suno.ai/fb1daddf-1de4-4164-bb9d-113f9639d732.mp3)
+- [Take The Risk](https://cdn1.suno.ai/d3ec2b0a-6062-417f-a62c-4d746f7f4f57.mp3)
+- [TikTok](https://cdn1.suno.ai/d5669af3-5caf-49e2-aca4-47fbc73a6d25.mp3)
+- [Something Is About To Happen](https://cdn1.suno.ai/800b9280-4389-47f6-b20d-6aa7dd3298ad.mp3)
+- [Haters](https://cdn1.suno.ai/160aa857-a65f-4f60-9217-6045b2091183.mp3)
+- [Does It Matter To Matter](https://cdn1.suno.ai/c6e3b4e8-964c-48dc-8187-3005865cb00a.mp3)
+- [Pastor or Hustler](https://cdn1.suno.ai/a5a8c49a-6871-40b6-9054-36c81ed8be90.mp3)
+- [Fore-runner’s Map](https://cdn1.suno.ai/7356371a-b8f7-470a-87a3-dbe5c2916f72.mp3)
+- [No Look Down](https://cdn1.suno.ai/5ad4f8bc-4cef-4ad4-b847-c4f1b8147445.mp3)
+- [Wonder's Breeze](https://cdn1.suno.ai/4f81332a-d833-4dc9-9763-7db0dfde3610.mp3)
+- [Covenant Of Isolation](https://cdn1.suno.ai/7578528b-34c1-492c-9e97-df93216f0cc2.mp3)
 - [Ghostwriter](https://suno.com/s/RHUdAKZxJpiO6NPW)
 - [A Wa Good Gan](https://suno.com/s/nKEV7ZI53jTK0JpB)
 - [Stir Am Well](https://suno.com/s/K1NgmbeDWMdovyDW)

--- a/scripts/player.js
+++ b/scripts/player.js
@@ -1,6 +1,18 @@
 /* MUSIC PLAYER LOGIC */
     const audioPlayer = new Audio();
-    audioPlayer.crossOrigin = "anonymous";
+    function setCrossOrigin(element, url) {
+        try {
+            const host = new URL(url, window.location.origin).hostname;
+            const corsAllowedHosts = ['raw.githubusercontent.com', 'drive.google.com'];
+            if (corsAllowedHosts.some(h => host.endsWith(h))) {
+                element.crossOrigin = 'anonymous';
+            } else {
+                element.removeAttribute('crossorigin');
+            }
+        } catch (e) {
+            element.removeAttribute('crossorigin');
+        }
+    }
     const audioContext = new (window.AudioContext || window.webkitAudioContext)();
     let isAudioContextResumed = false;
 
@@ -143,7 +155,7 @@ let lastTrackIndex = 0;
         if (!track.duration) {
           const tempAudio = new Audio();
           tempAudio.preload = 'metadata';
-          tempAudio.crossOrigin = 'anonymous';
+          setCrossOrigin(tempAudio, track.src);
           tempAudio.src = track.src;
           tempAudio.addEventListener('loadedmetadata', () => {
             track.duration = tempAudio.duration;
@@ -204,7 +216,7 @@ async function checkStreamStatus(url) {
           }
         };
 
-        testAudio.crossOrigin = 'anonymous';
+        setCrossOrigin(testAudio, url);
         testAudio.preload = 'auto';
         testAudio.addEventListener('canplay', onCanPlay, { once: true });
         testAudio.addEventListener('error', onError, { once: true });
@@ -302,6 +314,7 @@ function selectTrack(src, title, index) {
       lastTrackIndex = index;
       const urlHost = new URL(src, window.location.origin).hostname;
       const isSunoHosted = urlHost.includes('suno');
+      setCrossOrigin(audioPlayer, src);
       audioPlayer.src = isSunoHosted ? src : `${src}?t=${Date.now()}`;
       audioPlayer.currentTime = 0;
       trackInfo.textContent = title;
@@ -327,7 +340,9 @@ function selectTrack(src, title, index) {
       console.log(`Loading track: ${title} from album: ${albums[currentAlbumIndex].name}`);
       currentTrackIndex = index;
       currentRadioIndex = -1;
-      audioPlayer.src = src;      audioPlayer.currentTime = 0;
+      setCrossOrigin(audioPlayer, src);
+      audioPlayer.src = src;
+      audioPlayer.currentTime = 0;
       trackInfo.textContent = title;
       trackArtist.textContent = `Artist: ${albums[currentAlbumIndex].artist || 'Omoluabi'}`;
       trackYear.textContent = 'Release Year: 2025';
@@ -358,7 +373,9 @@ function selectTrack(src, title, index) {
       lastTrackSrc = src;
       lastTrackTitle = title;
       lastTrackIndex = index;
-      audioPlayer.src = src;      audioPlayer.currentTime = 0;
+      setCrossOrigin(audioPlayer, src);
+      audioPlayer.src = src;
+      audioPlayer.currentTime = 0;
       trackInfo.textContent = title;
       trackArtist.textContent = '';
       trackYear.textContent = '';


### PR DESCRIPTION
## Summary
- handle cross-origin audio sources dynamically to avoid failed loads
- link previously unlinked Omoluabi catalogue tracks to their audio files

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68adff862ef4833296bf933053aa2dc5