### PR TITLE
Link Dirty Dancing tracks to GitHub sources

### DIFF
--- a/scripts/data.js
+++ b/scripts/data.js
@@ -1,6 +1,6 @@
 const BASE_URL = 'https://raw.githubusercontent.com/Omoluabi1003/Ariyo-AI/main/';
 const TOA_URL = 'https://raw.githubusercontent.com/Omoluabi1003/Terms-Of-Agreement/main/';
-const DRIVE_URL = 'https://drive.google.com/uc?export=download&id=';
+const DD_URL = 'https://raw.githubusercontent.com/Omoluabi1003/DD/main/';
 const albums = [
       {
         name: 'Kindness',
@@ -64,18 +64,18 @@ const albums = [
         artist: 'Various Artists',
         cover: `${BASE_URL}Dirty%20Dancing.jpg`,
         tracks: [
-          { src: `${DRIVE_URL}10Sj4C9EjL_oTC5BrUEO124F3IIJIIUJi`, title: "(I've Had) The Time Of My Life" },
-          { src: `${DRIVE_URL}15OZoamtswdbYjhjKpvUcQ3HK0MXq0_mQ`, title: 'Be My Baby' },
-          { src: `${DRIVE_URL}1VUl5XVXi5jjszQKFzMpSBvFCQrjDMs7j`, title: "She's Like The Wind" },
-          { src: `${DRIVE_URL}1JU2aOZt3mnj_wIa4Tzt6r57EkPQu5U7j`, title: 'Hungry Eyes' },
-          { src: `${DRIVE_URL}1fmZvd26VVRuON_KpsyCJLrY9CxwctUmc`, title: 'Stay' },
-          { src: `${DRIVE_URL}1PUecCtvYXO5jy8IYiPN7olDWnno39hHl`, title: 'Yes' },
-          { src: `${DRIVE_URL}1pau2Z86nwxk9ystblR1kbAF901EtuKLi`, title: "You Don't Own Me" },
-          { src: `${DRIVE_URL}1Tmb0pfUsx9HUVmTLppIpuxeuQGLIS64P`, title: 'Hey Baby' },
-          { src: `${DRIVE_URL}1N8gGmzP_vXIYCB9_AgifNLiZWK3rUNg0`, title: 'Overload' },
-          { src: `${DRIVE_URL}1kdywx21VMHJQ0SUEfEZa66-pxPxxv2GW`, title: 'Love Is Strange' },
-          { src: `${DRIVE_URL}1ttGd5IDKcmr5xkfKqFWI0Own18Q3zOE0`, title: 'Where Are You Tonight?' },
-          { src: `${DRIVE_URL}1Aba8QhFHZhgfbxDouD9ZwkCZvqJveXaM`, title: 'In The Still Of The Night' }
+          { src: `${DD_URL}01%20The%20Time%20Of%20My%20Life.mp3`, title: "(I've Had) The Time Of My Life" },
+          { src: `${DD_URL}02%20Be%20My%20Baby.mp3`, title: 'Be My Baby' },
+          { src: `${DD_URL}03%20She_s%20Like%20The%20Wind.mp3`, title: "She's Like The Wind" },
+          { src: `${DD_URL}04%20Hungry%20Eyes.mp3`, title: 'Hungry Eyes' },
+          { src: `${DD_URL}05%20Stay.mp3`, title: 'Stay' },
+          { src: `${DD_URL}06%20Yes.mp3`, title: 'Yes' },
+          { src: `${DD_URL}07%20You%20Don_t%20Own%20Me.mp3`, title: "You Don't Own Me" },
+          { src: `${DD_URL}08%20Hey%20Baby.mp3`, title: 'Hey Baby' },
+          { src: `${DD_URL}09%20Overload.mp3`, title: 'Overload' },
+          { src: `${DD_URL}10%20Love%20Is%20Strange.mp3`, title: 'Love Is Strange' },
+          { src: `${DD_URL}11%20Where%20Are%20You%20Tonight-.mp3`, title: 'Where Are You Tonight?' },
+          { src: `${DD_URL}12%20In%20The%20Still%20Of%20The%20Night.mp3`, title: 'In The Still Of The Night' }
         ]
       },
       {


### PR DESCRIPTION
## Summary
- Point Dirty Dancing album entries to MP3 files hosted in the `Omoluabi1003/DD` repository.
- Replace Google Drive IDs with direct GitHub raw URLs via new `DD_URL` constant.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae5046b5108332b6f697edf6abf931