### PR TITLE
Show Dirty Dancing release year in player

### DIFF
--- a/scripts/data.js
+++ b/scripts/data.js
@@ -63,6 +63,7 @@ const albums = [
         name: 'Dirty Dancing- Original Soundtrack From The Vestron Motion Picture',
         artist: 'Various Artists',
         cover: `${BASE_URL}Dirty%20Dancing.jpg`,
+        releaseYear: 1987,
         tracks: [
           { src: `${DD_URL}01%20The%20Time%20Of%20My%20Life.mp3`, title: "(I've Had) The Time Of My Life" },
           { src: `${DD_URL}02%20Be%20My%20Baby.mp3`, title: 'Be My Baby' },

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -423,8 +423,9 @@
           audioPlayer.src = track.src;
           trackInfo.textContent = track.title;
           trackArtist.textContent = `Artist: ${albums[currentAlbumIndex].artist || 'Omoluabi'}`;
-          trackYear.textContent = 'Release Year: 2025';
-           trackAlbum.textContent = `Album: ${albums[currentAlbumIndex].name}`; // Display album name
+          const year = albums[currentAlbumIndex].releaseYear || 2025;
+          trackYear.textContent = `Release Year: ${year}`;
+          trackAlbum.textContent = `Album: ${albums[currentAlbumIndex].name}`; // Display album name
           cacheButton.style.display = 'block'; // Show for tracks
           audioPlayer.addEventListener('loadedmetadata', () => {
             audioPlayer.currentTime = savedState.playbackPosition;

--- a/scripts/player.js
+++ b/scripts/player.js
@@ -319,7 +319,8 @@ function selectTrack(src, title, index) {
       audioPlayer.currentTime = 0;
       trackInfo.textContent = title;
       trackArtist.textContent = `Artist: ${albums[currentAlbumIndex].artist || 'Omoluabi'}`;
-      trackYear.textContent = 'Release Year: 2025';
+      const year = albums[currentAlbumIndex].releaseYear || 2025;
+      trackYear.textContent = `Release Year: ${year}`;
       trackAlbum.textContent = `Album: ${albums[currentAlbumIndex].name}`; // Display album name
       albumCover.src = albums[currentAlbumIndex].cover; // Ensure album cover updates
       loadLyrics(albums[currentAlbumIndex].tracks[currentTrackIndex].lrc);
@@ -345,7 +346,8 @@ function selectTrack(src, title, index) {
       audioPlayer.currentTime = 0;
       trackInfo.textContent = title;
       trackArtist.textContent = `Artist: ${albums[currentAlbumIndex].artist || 'Omoluabi'}`;
-      trackYear.textContent = 'Release Year: 2025';
+      const year = albums[currentAlbumIndex].releaseYear || 2025;
+      trackYear.textContent = `Release Year: ${year}`;
       trackAlbum.textContent = `Album: ${albums[currentAlbumIndex].name}`; // Display album name
       stopMusic();
       loadingSpinner.style.display = 'block';


### PR DESCRIPTION
## Summary
- add 1987 release year to Dirty Dancing album data
- display album release year in player and restore logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae53061edc8332aee00e470180f76b