### PR TITLE
feat: switch theme to purple

### DIFF
--- a/color-scheme.css
+++ b/color-scheme.css
@@ -1,8 +1,8 @@
-/* Professional blue color scheme */
+/* Vibrant purple color scheme */
 :root {
-  --theme-color: #1565c0;
+  --theme-color: #8e44ad;
   --gradient-start: var(--theme-color);
-  --gradient-end: #003c8f;
+  --gradient-end: #4a148c;
 }
 
 body {

--- a/color-scheme.js
+++ b/color-scheme.js
@@ -3,9 +3,9 @@ function changeColorScheme() {
 }
 
 function applyTheme() {
-    const themeColor = '#1565c0';
+    const themeColor = '#8e44ad';
     const gradStart = themeColor;
-    const gradEnd = '#003c8f';
+    const gradEnd = '#4a148c';
     const style = document.getElementById('theme-style') || document.createElement('style');
     style.id = 'theme-style';
     style.innerHTML = `
@@ -19,7 +19,7 @@ function applyTheme() {
     .progress-bar div { background: ${themeColor}; }
     .install-btn { background: ${themeColor}; }
     #start-button { background-color: ${themeColor}; }
-    body { background-color: #e3f2fd; color: #000000; }
+    body { background-color: #f3e5f5; color: #000000; }
   `;
     document.head.appendChild(style);
     const metaTheme = document.querySelector('meta[name="theme-color"]');

--- a/tetris-color-scheme.css
+++ b/tetris-color-scheme.css
@@ -1,11 +1,11 @@
 :root {
     --background-color: #000;
     --text-color: #fff;
-    --theme-color: #1565c0;
+    --theme-color: #8e44ad;
 }
 
 body.light {
     --background-color: #fff;
     --text-color: #000;
-    --theme-color: #1e88e5;
+    --theme-color: #b39ddb;
 }


### PR DESCRIPTION
## Summary
- replace primary blue theme with vibrant purple across color schemes
- update gradients and backgrounds to match new palette

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af85bd04348332aa1dabc04b03a6bb