### PR TITLE
feat: update header font

### DIFF
--- a/index.css
+++ b/index.css
@@ -31,7 +31,7 @@ h1, p, .tour-step, footer {
 
 h1 {
     font-size: 2.5rem;
-    font-family: 'Montserrat', sans-serif;
+    font-family: 'Roboto Slab', 'Montserrat', sans-serif;
 }
 
 p {

--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
   <meta name="twitter:image" content="https://raw.githubusercontent.com/Omoluabi1003/Ariyo-AI/main/icons/Ariyo.png" />
     <title>Welcome to Àríyò AI</title>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.2/gsap.min.js" defer integrity="sha384-d+vyQ0dYcymoP8ndq2hW7FGC50nqGdXUEgoOUGxbbkAJwZqL7h+jKN0GGgn9hFDS" crossorigin="anonymous"></script>
-    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&family=Roboto+Slab:wght@700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="color-scheme.css">
     <link rel="stylesheet" href="index.css">
     <link rel="manifest" href="manifest.json">


### PR DESCRIPTION
## Summary
- switch 'Welcome to Àríyò AI' header to Roboto Slab font for distinctive styling
- load Roboto Slab alongside Montserrat in index page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af8729bdb08332b918139422e6aa71