### PR TITLE
Add news banner for upcoming album release

### DIFF
--- a/index.css
+++ b/index.css
@@ -17,6 +17,19 @@ body {
     background-position: center;
 }
 
+.news-banner {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    background: #6a5acd;
+    color: #fff;
+    text-align: center;
+    padding: 0.3rem 0.5rem;
+    font-size: 0.8rem;
+    z-index: 1000;
+}
+
 .overlay {
     background-color: rgba(0, 0, 0, 0.7);
     padding: 2rem;

--- a/index.html
+++ b/index.html
@@ -28,6 +28,7 @@
     <link rel="apple-touch-icon" href="icons/Ariyo.png">
 </head>
 <body>
+    <div class="news-banner">Mark your calendar—my next album, TERMS OF AGREEMENT, drops on September 5, 2025. Can’t wait for you to hear what’s coming. Stay tuned!</div>
     <div class="overlay">
         <h1>Welcome to Àríyò AI</h1>
         <p>Your smart Naija assistant.</p>


### PR DESCRIPTION
## Summary
- Add slim fixed news banner announcing upcoming album drop
- Style banner to sit unobtrusively at top of page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68af9476dfe88332915481e26377780e