### PR TITLE
feat: add typing animation to banner

### DIFF
--- a/index.css
+++ b/index.css
@@ -19,7 +19,7 @@ body {
 
 .news-banner {
     position: fixed;
-    top: 0;
+    bottom: 0;
     left: 0;
     width: 100%;
     background: #6a5acd;
@@ -27,7 +27,24 @@ body {
     text-align: center;
     padding: 0.3rem 0.5rem;
     font-size: 0.8rem;
-    z-index: 1000;
+    z-index: 10000;
+    white-space: nowrap;
+    overflow: hidden;
+}
+
+.news-banner::after {
+    content: '';
+    display: inline-block;
+    width: 2px;
+    height: 1em;
+    background: #fff;
+    margin-left: 2px;
+    animation: blink 0.8s steps(1, end) infinite;
+}
+
+@keyframes blink {
+    0%, 50% { opacity: 1; }
+    50%, 100% { opacity: 0; }
 }
 
 .overlay {

--- a/index.html
+++ b/index.html
@@ -28,7 +28,6 @@
     <link rel="apple-touch-icon" href="icons/Ariyo.png">
 </head>
 <body>
-    <div class="news-banner">Mark your calendar—my next album, TERMS OF AGREEMENT, drops on September 5, 2025. Can’t wait for you to hear what’s coming. Stay tuned!</div>
     <div class="overlay">
         <h1>Welcome to Àríyò AI</h1>
         <p>Your smart Naija assistant.</p>
@@ -69,6 +68,8 @@
       <div class="watermark exploding-watermark" style="top: 15%; left: 85%;">Omoluabi Productions</div>
       <div class="watermark exploding-watermark" style="top: 75%; left: 5%;">Omoluabi Productions</div>
     </div>
+
+    <div id="news-banner" class="news-banner"></div>
 
     <script>
         document.querySelectorAll('.exploding-watermark').forEach(watermark => {
@@ -154,6 +155,23 @@
         gsap.set(steps, { opacity: 0 });
         gsap.set(steps[0], { opacity: 1 });
         setInterval(showNextStep, 3000);
+    </script>
+    <script>
+        document.addEventListener('DOMContentLoaded', () => {
+            const banner = document.getElementById('news-banner');
+            const text = "Mark your calendar—my next album, TERMS OF AGREEMENT, drops on September 5, 2025. Can’t wait for you to hear what’s coming. Stay tuned!";
+            let index = 0;
+
+            function type() {
+                if (index < text.length) {
+                    banner.textContent += text.charAt(index);
+                    index++;
+                    setTimeout(type, 50);
+                }
+            }
+
+            type();
+        });
     </script>
     <script src="color-scheme.js"></script>
     <script>


### PR DESCRIPTION
## Summary
- move news banner to page bottom and add typing animation
- style banner with blinking cursor

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af96fb170c833281691c91930e9aae