### PR TITLE
Add looping news banner and album countdown

### DIFF
--- a/index.html
+++ b/index.html
@@ -167,6 +167,12 @@
                     banner.textContent += text.charAt(index);
                     index++;
                     setTimeout(type, 50);
+                } else {
+                    setTimeout(() => {
+                        banner.textContent = '';
+                        index = 0;
+                        type();
+                    }, 2000);
                 }
             }
 

--- a/main.html
+++ b/main.html
@@ -624,6 +624,8 @@
     </button>
   </div>
 
+  <div id="countdown" class="countdown"></div>
+
   <div class="container">
     <div class="sidebar">
       <input type="text" id="searchInput" class="search-bar" list="searchSuggestions" placeholder="Search tracks or stations..." aria-label="Search tracks or radio stations">
@@ -834,6 +836,8 @@
 <!-- 🎧 Now Playing Toast -->
   <div id="nowPlayingToast" role="status" aria-live="polite"></div>
 
+  <div id="news-banner" class="news-banner"></div>
+
   <script src="scripts/data.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/lyric-parser@1.0.1/dist/lyric.min.js"></script>
   <script src="scripts/player.js"></script>
@@ -868,6 +872,58 @@
             const r = Math.random();
             return `<span style="--i: ${i}; --x: ${x}; --y: ${y}; --r: ${r};">${letter}</span>`;
         }).join('');
+    });
+  </script>
+  <script>
+    document.addEventListener('DOMContentLoaded', () => {
+      const banner = document.getElementById('news-banner');
+      const messages = [
+        "Mark your calendar—my next album, TERMS OF AGREEMENT, drops on September 5, 2025.",
+        "Can't wait for you to hear what's coming. Stay tuned!"
+      ];
+      let messageIndex = 0;
+      let charIndex = 0;
+
+      function type() {
+        const text = messages[messageIndex];
+        if (charIndex < text.length) {
+          banner.textContent += text.charAt(charIndex);
+          charIndex++;
+          setTimeout(type, 50);
+        } else {
+          setTimeout(() => {
+            banner.textContent = '';
+            charIndex = 0;
+            messageIndex = (messageIndex + 1) % messages.length;
+            type();
+          }, 2000);
+        }
+      }
+
+      type();
+
+      const countdownEl = document.getElementById('countdown');
+      const releaseDate = new Date('2025-09-05T00:00:00');
+
+      function updateCountdown() {
+        const now = new Date();
+        const diff = releaseDate - now;
+
+        if (diff <= 0) {
+          countdownEl.textContent = 'TERMS OF AGREEMENT is out now!';
+          return;
+        }
+
+        const days = Math.floor(diff / (1000 * 60 * 60 * 24));
+        const hours = Math.floor((diff / (1000 * 60 * 60)) % 24);
+        const minutes = Math.floor((diff / (1000 * 60)) % 60);
+        const seconds = Math.floor((diff / 1000) % 60);
+
+        countdownEl.textContent = `TERMS OF AGREEMENT drops in ${days}d ${hours}h ${minutes}m ${seconds}s`;
+      }
+
+      updateCountdown();
+      setInterval(updateCountdown, 1000);
     });
   </script>
 </body>

--- a/style.css
+++ b/style.css
@@ -21,6 +21,42 @@ body {
     text-shadow: 1px 1px 2px #000;
 }
 
+.news-banner {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    background: #6a5acd;
+    color: #fff;
+    text-align: center;
+    padding: 0.3rem 0.5rem;
+    font-size: 0.8rem;
+    z-index: 10000;
+    white-space: nowrap;
+    overflow: hidden;
+}
+
+.news-banner::after {
+    content: '';
+    display: inline-block;
+    width: 2px;
+    height: 1em;
+    background: #fff;
+    margin-left: 2px;
+    animation: blink 0.8s steps(1, end) infinite;
+}
+
+@keyframes blink {
+    0%, 50% { opacity: 1; }
+    50%, 100% { opacity: 0; }
+}
+
+.countdown {
+    text-align: center;
+    margin: 0.5rem 0;
+    font-size: clamp(0.9rem, 2vw, 1rem);
+}
+
 /* Header Styles */
 .header {
     padding: calc(1rem + env(safe-area-inset-top)) 1rem 1rem;


### PR DESCRIPTION
## Summary
- Add CSS for news ticker banner and countdown
- Display countdown and looping announcement on media player page
- Loop banner text on landing page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68af99da04fc833299f030407b36bd87