### PR TITLE
Improve countdown readability and banner responsiveness

### DIFF
--- a/index.css
+++ b/index.css
@@ -25,8 +25,8 @@ body {
     background: #6a5acd;
     color: #fff;
     text-align: center;
-    padding: 0.3rem 0.5rem;
-    font-size: 0.8rem;
+    padding: 0.3rem clamp(0.5rem, 2vw, 1rem);
+    font-size: clamp(0.8rem, 2vw, 1rem);
     z-index: 10000;
     white-space: nowrap;
     overflow: hidden;

--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
   <meta name="twitter:image" content="https://raw.githubusercontent.com/Omoluabi1003/Ariyo-AI/main/icons/Ariyo.png" />
     <title>Welcome to Àríyò AI</title>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.2/gsap.min.js" defer integrity="sha384-d+vyQ0dYcymoP8ndq2hW7FGC50nqGdXUEgoOUGxbbkAJwZqL7h+jKN0GGgn9hFDS" crossorigin="anonymous"></script>
-    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&family=Roboto+Slab:wght@700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&family=Roboto:wght@400;700&family=Roboto+Slab:wght@700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="color-scheme.css">
     <link rel="stylesheet" href="index.css">
     <link rel="manifest" href="manifest.json">

--- a/main.html
+++ b/main.html
@@ -42,7 +42,7 @@
   </script>
 
   <!-- Fonts & Icons -->
-  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600&family=Montserrat:wght@400;700&family=Roboto+Slab:wght@700&display=swap" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600&family=Montserrat:wght@400;700&family=Roboto:wght@400;700&family=Roboto+Slab:wght@700&display=swap" rel="stylesheet" />
   <script src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/js/all.min.js" defer integrity="sha384-3ve3u7etWcm2heCe4TswfZSAYSg2jR/EJxRHuKM5foOiKS8IJL/xRlvmjCaHELBz" crossorigin="anonymous"></script>
 
   <!-- Animations & Chat -->

--- a/style.css
+++ b/style.css
@@ -29,8 +29,8 @@ body {
     background: #6a5acd;
     color: #fff;
     text-align: center;
-    padding: 0.3rem 0.5rem;
-    font-size: 0.8rem;
+    padding: 0.3rem clamp(0.5rem, 2vw, 1rem);
+    font-size: clamp(0.8rem, 2vw, 1rem);
     z-index: 10000;
     white-space: nowrap;
     overflow: hidden;
@@ -55,6 +55,8 @@ body {
     text-align: center;
     margin: 0.5rem 0;
     font-size: clamp(0.9rem, 2vw, 1rem);
+    font-family: 'Roboto', sans-serif;
+    color: #fff;
 }
 
 /* Header Styles */


### PR DESCRIPTION
## Summary
- Ensure countdown uses white Roboto font for better legibility
- Make slim news banner padding and font-size responsive across devices

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68af9c3a0dac833299fa7fc0b9daa6be