### PR TITLE
Move countdown to landing page and update banner messaging

### DIFF
--- a/index.css
+++ b/index.css
@@ -47,6 +47,26 @@ body {
     50%, 100% { opacity: 0; }
 }
 
+.countdown {
+    text-align: center;
+    margin: 0.5rem 0;
+    font-size: clamp(1rem, 4vw, 1.8rem);
+    font-family: 'Roboto', sans-serif;
+    font-weight: bold;
+    padding: 0.2rem 0.5rem;
+    border-radius: 4px;
+}
+
+.countdown.red-on-black {
+    color: #ff0000;
+    background-color: #000;
+}
+
+.countdown.black-on-red {
+    color: #000;
+    background-color: #ff0000;
+}
+
 .overlay {
     background-color: rgba(0, 0, 0, 0.7);
     padding: 2rem;

--- a/index.html
+++ b/index.html
@@ -31,6 +31,7 @@
     <div class="overlay">
         <h1>Welcome to Àríyò AI</h1>
         <p>Your smart Naija assistant.</p>
+        <div id="countdown" class="countdown red-on-black"></div>
         <div class="tour-container">
             <div class="tour-column">
                 <div class="tour-step" id="step1">🎧 Listen to Naija music</div>
@@ -177,6 +178,29 @@
             }
 
             type();
+
+            const countdownEl = document.getElementById('countdown');
+            const releaseDate = new Date('2025-09-05T00:00:00');
+
+            function updateCountdown() {
+                const now = new Date();
+                const diff = releaseDate - now;
+
+                if (diff <= 0) {
+                    countdownEl.textContent = 'TERMS OF AGREEMENT is out now!';
+                    return;
+                }
+
+                const days = Math.floor(diff / (1000 * 60 * 60 * 24));
+                const hours = Math.floor((diff / (1000 * 60 * 60)) % 24);
+                const minutes = Math.floor((diff / (1000 * 60)) % 60);
+                const seconds = Math.floor((diff / 1000) % 60);
+
+                countdownEl.textContent = `TERMS OF AGREEMENT drops in ${days}d ${hours}h ${minutes}m ${seconds}s`;
+            }
+
+            updateCountdown();
+            setInterval(updateCountdown, 1000);
         });
     </script>
     <script src="color-scheme.js"></script>

--- a/main.html
+++ b/main.html
@@ -624,8 +624,6 @@
     </button>
   </div>
 
-  <div id="countdown" class="countdown red-on-black"></div>
-
   <div class="container">
     <div class="sidebar">
       <input type="text" id="searchInput" class="search-bar" list="searchSuggestions" placeholder="Search tracks or stations..." aria-label="Search tracks or radio stations">
@@ -878,8 +876,8 @@
     document.addEventListener('DOMContentLoaded', () => {
       const banner = document.getElementById('news-banner');
       const messages = [
-        "Mark your calendar—my next album, TERMS OF AGREEMENT, drops on September 5, 2025.",
-        "Can't wait for you to hear what's coming. Stay tuned!"
+        "September 5th, 2025, SET THE DATE.",
+        "TERMS OF AGREEMENT ALBUM RELEASE"
       ];
       let messageIndex = 0;
       let charIndex = 0;
@@ -901,29 +899,6 @@
       }
 
       type();
-
-      const countdownEl = document.getElementById('countdown');
-      const releaseDate = new Date('2025-09-05T00:00:00');
-
-      function updateCountdown() {
-        const now = new Date();
-        const diff = releaseDate - now;
-
-        if (diff <= 0) {
-          countdownEl.textContent = 'TERMS OF AGREEMENT is out now!';
-          return;
-        }
-
-        const days = Math.floor(diff / (1000 * 60 * 60 * 24));
-        const hours = Math.floor((diff / (1000 * 60 * 60)) % 24);
-        const minutes = Math.floor((diff / (1000 * 60)) % 60);
-        const seconds = Math.floor((diff / 1000) % 60);
-
-        countdownEl.textContent = `TERMS OF AGREEMENT drops in ${days}d ${hours}h ${minutes}m ${seconds}s`;
-      }
-
-      updateCountdown();
-      setInterval(updateCountdown, 1000);
     });
   </script>
 </body>


### PR DESCRIPTION
## Summary
- Remove countdown from main page and display it on the landing page with compact styling
- Update main page banner to alternate between release date and album announcement

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b08dd5319c83328294abc7ba2c8aa0