### PR TITLE
Add shuffle queue with next track preview

### DIFF
--- a/main.html
+++ b/main.html
@@ -657,6 +657,7 @@
     <p class="track-details" id="trackAlbum"></p> <!-- Added for album display -->
     <p class="track-duration" id="trackDuration">0:00 / 0:00</p>
     <p id="shuffleStatusInfo" class="track-details" style="font-style: italic;"></p> <!-- New shuffle status display -->
+    <p id="nextTrackInfo" class="track-details" style="font-style: italic;"></p>
     <input
       type="range"
       id="seekBar"

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -452,6 +452,7 @@
           shuffleBtn.textContent = '🔀 Off';
           shuffleStatusInfo.textContent = 'Shuffle: Off';
         }
+        buildShuffleQueue();
         console.log('Player restored from saved state:', savedState);
       } else {
         // Default state for a new session if no saved state
@@ -459,6 +460,7 @@
         shuffleMode = false;
         document.getElementById('shuffleStatusInfo').textContent = 'Shuffle: Off';
         document.querySelector(".music-controls.icons-only button[aria-label='Toggle shuffle']").textContent = '🔀 Off';
+        buildShuffleQueue();
         selectAlbum(0);
         console.log('No saved state found, initialized with default');
       }

--- a/scripts/ui.js
+++ b/scripts/ui.js
@@ -154,6 +154,8 @@ function toggleShuffle() {
   // If we are in radio mode, shuffle only has on/off states
   if (currentRadioIndex !== -1) {
     shuffleMode = !shuffleMode;
+    shuffleQueue = [];
+    updateNextTrackInfo();
     if (shuffleMode) {
       shuffleBtn.textContent = '🔀 Radio';
       shuffleStatusInfo.textContent = 'Shuffle: On (Radio)';
@@ -172,18 +174,22 @@ function toggleShuffle() {
       shuffleBtn.textContent = '🔀 Album';
       shuffleStatusInfo.textContent = 'Shuffle: On (Album)';
       console.log('Shuffle mode: Album');
+      buildShuffleQueue();
     } else if (shuffleScope === 'album') {
       shuffleScope = 'all';
       shuffleMode = true;
       shuffleBtn.textContent = '🔀 All';
       shuffleStatusInfo.textContent = 'Shuffle: On (All Tracks)';
       console.log('Shuffle mode: All');
+      buildShuffleQueue();
     } else { // shuffleScope === 'all'
       shuffleScope = 'off';
       shuffleMode = false;
       shuffleBtn.textContent = '🔀 Off';
       shuffleStatusInfo.textContent = 'Shuffle: Off';
       console.log('Shuffle mode: Off');
+      shuffleQueue = [];
+      updateNextTrackInfo();
     }
   }
   savePlayerState();


### PR DESCRIPTION
## Summary
- show upcoming track in the UI while shuffle is on
- create and manage a shuffle queue across albums
- build shuffle queue on player load and when toggling shuffle modes

## Testing
- `node --check scripts/player.js`
- `node --check scripts/ui.js`
- `node --check scripts/main.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b35561b5d88332a7edb01dac2ab7d9