### PR TITLE
feat: keep audio playing when page hidden

### DIFF
--- a/index.html
+++ b/index.html
@@ -123,6 +123,23 @@
                     playAudio();
                 }
             });
+
+            // Attempt to keep audio playing even when the page is hidden
+            document.addEventListener('visibilitychange', () => {
+                if (isPlaying && document.visibilityState === 'hidden') {
+                    audio.play().catch(error => {
+                        console.log('Background playback prevented:', error);
+                    });
+                }
+            });
+
+            audio.addEventListener('pause', () => {
+                if (isPlaying && document.visibilityState === 'hidden') {
+                    audio.play().catch(error => {
+                        console.log('Background playback prevented:', error);
+                    });
+                }
+            });
         });
 
         document.querySelectorAll('.shockwave').forEach(button => {


### PR DESCRIPTION
## Summary
- Keep welcome audio playing when page visibility changes
- Automatically resume playback if audio pauses while hidden

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5b1e71df8833286cbd291b154ffd0