### PR TITLE
Add single-track repeat option

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -448,6 +448,10 @@
         } else if (shuffleScope === 'all') {
           shuffleBtn.textContent = '🔀 All';
           shuffleStatusInfo.textContent = 'Shuffle: On (All Tracks)';
+        } else if (shuffleScope === 'repeat') {
+          shuffleMode = false;
+          shuffleBtn.textContent = '🔂 One';
+          shuffleStatusInfo.textContent = 'Repeat: On (Single Track)';
         } else { // off
           shuffleBtn.textContent = '🔀 Off';
           shuffleStatusInfo.textContent = 'Shuffle: Off';

--- a/scripts/player.js
+++ b/scripts/player.js
@@ -42,7 +42,7 @@
 const lyricsContainer = document.getElementById('lyrics');
 let lyricLines = [];
 let shuffleMode = false; // True if any shuffle is active
-let shuffleScope = 'off'; // 'off', 'album', 'all'
+let shuffleScope = 'off'; // 'off', 'album', 'all', 'repeat'
 let isFirstPlay = true;
 let lastTrackSrc = '';
 let lastTrackTitle = '';
@@ -684,7 +684,14 @@ function selectTrack(src, title, index, rebuildQueue = true) {
       audioPlayer.removeEventListener('timeupdate', updateTrackTime);
       manageVinylRotation();
       if (currentRadioIndex === -1) { // Only if not playing a radio station
-        if (shuffleMode) {
+        if (shuffleScope === 'repeat') {
+          selectTrack(
+            albums[currentAlbumIndex].tracks[currentTrackIndex].src,
+            albums[currentAlbumIndex].tracks[currentTrackIndex].title,
+            currentTrackIndex,
+            false
+          );
+        } else if (shuffleMode) {
           if (shuffleQueue.length === 0) {
             buildShuffleQueue();
           }

--- a/scripts/ui.js
+++ b/scripts/ui.js
@@ -166,7 +166,7 @@ function toggleShuffle() {
       console.log('Shuffle mode: Off');
     }
   }
-  // If we are in album/track mode, cycle through off, album, all
+  // If we are in album/track mode, cycle through off, album, all, repeat one
   else {
     if (shuffleScope === 'off') {
       shuffleScope = 'album';
@@ -182,7 +182,15 @@ function toggleShuffle() {
       shuffleStatusInfo.textContent = 'Shuffle: On (All Tracks)';
       console.log('Shuffle mode: All');
       buildShuffleQueue();
-    } else { // shuffleScope === 'all'
+    } else if (shuffleScope === 'all') {
+      shuffleScope = 'repeat';
+      shuffleMode = false;
+      shuffleBtn.textContent = '🔂 One';
+      shuffleStatusInfo.textContent = 'Repeat: On (Single Track)';
+      console.log('Repeat mode: Single Track');
+      shuffleQueue = [];
+      updateNextTrackInfo();
+    } else { // shuffleScope === 'repeat'
       shuffleScope = 'off';
       shuffleMode = false;
       shuffleBtn.textContent = '🔀 Off';


### PR DESCRIPTION
## Summary
- extend shuffle button to cycle through single-track repeat mode
- repeat current track when it ends
- restore repeat mode from saved player state

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5f3b0ec408332b35dcf6d86be3a92