### PR TITLE
feat: fade background transitions

### DIFF
--- a/index.css
+++ b/index.css
@@ -170,3 +170,18 @@ a {
         opacity: 0;
     }
 }
+
+/* Layers used for rotating background images */
+.background-layer {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-size: cover;
+    background-repeat: no-repeat;
+    background-position: center center;
+    opacity: 0;
+    transition: opacity 1s ease-in-out;
+    z-index: -1;
+}

--- a/style.css
+++ b/style.css
@@ -452,3 +452,18 @@ body {
         width: 90%;
     }
 }
+
+/* Layers used for rotating background images */
+.background-layer {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-size: cover;
+    background-repeat: no-repeat;
+    background-position: center center;
+    opacity: 0;
+    transition: opacity 1s ease-in-out;
+    z-index: -1;
+}


### PR DESCRIPTION
## Summary
- crossfade between rotating background images to remove white flashes
- add shared background-layer styling for index and main pages

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b798d917408332803c8b12b0ee2f53