### PR TITLE
Fix white flash during background transitions

### DIFF
--- a/background-rotator.js
+++ b/background-rotator.js
@@ -74,16 +74,22 @@ document.addEventListener('DOMContentLoaded', () => {
       const hiddenLayer = layers[1 - activeLayer];
       hiddenLayer.style.backgroundImage = `url('${nextInfo.img.src}')`;
       hiddenLayer.style.backgroundPosition = positions[nextInfo.src] || 'center center';
-      hiddenLayer.style.opacity = '1';
-      layers[activeLayer].style.opacity = '0';
 
-      activeLayer = 1 - activeLayer;
-      current = nextIndex;
-      if (current === 0) {
-        // Reshuffle for the next cycle
-        shuffleArray(images);
-      }
-      scheduleNextChange();
+      // Start the cross-fade on the next animation frame so the
+      // browser has time to apply the new background image. This
+      // prevents a momentary flash of the page's background color.
+      requestAnimationFrame(() => {
+        hiddenLayer.style.opacity = '1';
+        layers[activeLayer].style.opacity = '0';
+
+        activeLayer = 1 - activeLayer;
+        current = nextIndex;
+        if (current === 0) {
+          // Reshuffle for the next cycle
+          shuffleArray(images);
+        }
+        scheduleNextChange();
+      });
     };
 
     // If the image has already loaded, switch immediately.

--- a/color-scheme.js
+++ b/color-scheme.js
@@ -19,7 +19,7 @@ function applyTheme() {
     .progress-bar div { background: ${themeColor}; }
     .install-btn { background: ${themeColor}; }
     #start-button { background-color: ${themeColor}; }
-    body { background-color: #f3e5f5; color: #000000; }
+    body { color: #000000; }
   `;
     document.head.appendChild(style);
     const metaTheme = document.querySelector('meta[name="theme-color"]');


### PR DESCRIPTION
## Summary
- ensure cross-fade waits a frame after setting new background image
- stop theme script from forcing a light body background color

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b79ba23078833283916dcae7133f55