### PR TITLE
fix: eliminate flash between rotating backgrounds

### DIFF
--- a/color-scheme.js
+++ b/color-scheme.js
@@ -19,7 +19,6 @@ function applyTheme() {
     .progress-bar div { background: ${themeColor}; }
     .install-btn { background: ${themeColor}; }
     #start-button { background-color: ${themeColor}; }
-    body { background-color: #f3e5f5; color: #000000; }
   `;
     document.head.appendChild(style);
     const metaTheme = document.querySelector('meta[name="theme-color"]');

--- a/index.css
+++ b/index.css
@@ -181,6 +181,7 @@ a {
     background-size: cover;
     background-repeat: no-repeat;
     background-position: center center;
+    background-color: #000;
     opacity: 0;
     transition: opacity 1s ease-in-out;
     z-index: -1;

--- a/style.css
+++ b/style.css
@@ -463,6 +463,7 @@ body {
     background-size: cover;
     background-repeat: no-repeat;
     background-position: center center;
+    background-color: #000;
     opacity: 0;
     transition: opacity 1s ease-in-out;
     z-index: -1;


### PR DESCRIPTION
## Summary
- prevent theme script from overriding page background color
- add black fallback to rotating background layers to avoid white flash

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b79ba23078833283916dcae7133f55