### PR TITLE
Smooth slideshow-style background transitions

### DIFF
--- a/index.css
+++ b/index.css
@@ -182,6 +182,7 @@ a {
     background-repeat: no-repeat;
     background-position: center center;
     opacity: 0;
-    transition: opacity 1s ease-in-out;
-    z-index: -1;
+    transition: opacity 2s ease-in-out;
+    z-index: -2;
+    pointer-events: none;
 }

--- a/style.css
+++ b/style.css
@@ -464,6 +464,7 @@ body {
     background-repeat: no-repeat;
     background-position: center center;
     opacity: 0;
-    transition: opacity 1s ease-in-out;
-    z-index: -1;
+    transition: opacity 2s ease-in-out;
+    z-index: -2;
+    pointer-events: none;
 }


### PR DESCRIPTION
## Summary
- Ensure background layers never reveal a dark flash by showing the next image beneath and fading the current layer out.
- Add CSS polish: slower 2s fade, proper z-index stacking, and pointer-events shielding for background layers.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b7a011013c8332a091668ca108ae98