### PR TITLE
Fix background image layering on main page

### DIFF
--- a/background-rotator.js
+++ b/background-rotator.js
@@ -26,5 +26,5 @@ document.addEventListener('DOMContentLoaded', () => {
   layer.style.backgroundPosition = positions[selectedImage] || 'center center';
   layer.style.opacity = '1';
 
-  document.body.appendChild(layer);
+  document.body.prepend(layer);
 });

--- a/index.css
+++ b/index.css
@@ -184,6 +184,6 @@ a {
     background-position: center center;
     opacity: 0;
     transition: opacity 2s ease-in-out;
-    z-index: -1;
+    z-index: 0;
     pointer-events: none;
 }

--- a/style.css
+++ b/style.css
@@ -466,6 +466,6 @@ body {
     background-position: center center;
     opacity: 0;
     transition: opacity 2s ease-in-out;
-    z-index: -1;
+    z-index: 0;
     pointer-events: none;
 }


### PR DESCRIPTION
## Summary
- Ensure rotating background image appears by inserting background layer before page content
- Move background layer above page background and make it visible

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b7a57c2558833291a00c1fa4beaae2