### PR TITLE
Add Same Ni track to Omoluabi catalogue

### DIFF
--- a/Omoluabi_Production_Catalogue.md
+++ b/Omoluabi_Production_Catalogue.md
@@ -32,3 +32,4 @@
 - [Pass The Baton](https://cdn1.suno.ai/471dc968-d463-435c-8c3d-85f0d4556d8f.mp3)
 - [Moore’s Law](https://suno.com/s/iFtc3kKNJegGFVcN)
 - [Her Daughter's Father](https://suno.com/s/SO1sQiwoprmyz5oz)
+- [Same Ni](https://suno.com/s/PGWO82Zq1B7ur40J)

--- a/scripts/data.js
+++ b/scripts/data.js
@@ -161,7 +161,8 @@ const albums = [
             { src: 'https://cdn1.suno.ai/f7f72dd2-12cd-4568-b831-f745973fa063.mp3', title: 'Destiny No Dey Wait' },
             { src: 'https://cdn1.suno.ai/471dc968-d463-435c-8c3d-85f0d4556d8f.mp3', title: 'Pass The Baton' },
             { src: 'https://cdn1.suno.ai/891af5b2-b1fe-4db2-9c99-e1b1a15697a2.mp3', title: 'Moore’s Law' },
-            { src: 'https://cdn1.suno.ai/b35932ed-2188-4780-a919-f5327317915b.mp3', title: "Her Daughter's Father" }
+            { src: 'https://cdn1.suno.ai/b35932ed-2188-4780-a919-f5327317915b.mp3', title: "Her Daughter's Father" },
+            { src: 'https://cdn1.suno.ai/473edd61-d1ba-4bad-8014-7302cd1a9b71.mp3', title: 'Same Ni' }
         ]
       },
     ];


### PR DESCRIPTION
## Summary
- add Suno track "Same Ni" to Omoluabi Production Catalogue album so it shows in the track modal
- document "Same Ni" in the Omoluabi Production Catalogue markdown listing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b7fa95555c8332ba9a88c025c1819d