### PR TITLE
Add cross-fading rotating background images

### DIFF
--- a/background-rotator.js
+++ b/background-rotator.js
@@ -1,6 +1,3 @@
-// Displays a single background image for index and main pages.
-// The image changes monthly, cycling through six options.
-
 document.addEventListener('DOMContentLoaded', () => {
   const images = [
     'Naija AI1.png',
@@ -11,20 +8,41 @@ document.addEventListener('DOMContentLoaded', () => {
     'Naija AI6.png'
   ];
 
-  const positions = {
-    'Naija AI4.png': 'center 20%',
-    'Naija AI5.png': 'center 20%',
-    'Naija AI6.png': 'center 20%'
-  };
+  // Preload images to avoid flashes during transitions
+  images.forEach(src => {
+    const img = new Image();
+    img.src = src;
+  });
 
-  const month = new Date().getMonth();
-  const selectedImage = images[month % images.length];
+  const bg1 = document.getElementById('bg1');
+  const bg2 = document.getElementById('bg2');
+  if (!bg1 || !bg2) return; // Only run on pages with the background container
 
-  const layer = document.createElement('div');
-  layer.className = 'background-layer';
-  layer.style.backgroundImage = `url('${selectedImage}')`;
-  layer.style.backgroundPosition = positions[selectedImage] || 'center center';
-  layer.style.opacity = '1';
+  const layers = [bg1, bg2];
+  let activeIndex = 0; // index of currently visible layer
+  let imageIndex = 0;  // index in images array
 
-  document.body.prepend(layer);
+  // Initialize first image
+  layers[activeIndex].style.backgroundImage = `url('${images[imageIndex]}')`;
+  layers[activeIndex].style.opacity = 1;
+
+  function switchBackground() {
+    // Next image index
+    imageIndex = (imageIndex + 1) % images.length;
+    const nextLayerIndex = 1 - activeIndex;
+    const nextLayer = layers[nextLayerIndex];
+    const currentLayer = layers[activeIndex];
+
+    // Set next image and trigger cross fade
+    nextLayer.style.backgroundImage = `url('${images[imageIndex]}')`;
+    nextLayer.style.opacity = 1;
+    currentLayer.style.opacity = 0;
+
+    // Swap active layer
+    activeIndex = nextLayerIndex;
+  }
+
+  // Change background every 2 minutes
+  setInterval(switchBackground, 120000);
 });
+

--- a/index.css
+++ b/index.css
@@ -13,9 +13,6 @@ body {
     height: 100vh;
     text-align: center;
     position: relative;
-    background-image: url('Naija AI1.png');
-    background-size: cover;
-    background-position: center;
     transition: background-color 0.5s ease-in-out;
 }
 
@@ -172,9 +169,21 @@ a {
     }
 }
 
-/* Layers used for rotating background images */
-.background-layer {
+/* Fullscreen background container */
+#background-container {
     position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    overflow: hidden;
+    z-index: -1;
+    pointer-events: none;
+}
+
+/* Individual background layers */
+.bg-image {
+    position: absolute;
     top: 0;
     left: 0;
     width: 100%;
@@ -184,6 +193,10 @@ a {
     background-position: center center;
     opacity: 0;
     transition: opacity 2s ease-in-out;
-    z-index: 0;
-    pointer-events: none;
+}
+
+/* Initial visible layer */
+#bg1 {
+    opacity: 1;
+    background-image: url('Naija AI1.png');
 }

--- a/index.html
+++ b/index.html
@@ -28,6 +28,10 @@
     <link rel="apple-touch-icon" href="icons/Ariyo.png">
 </head>
 <body>
+    <div id="background-container">
+        <div id="bg1" class="bg-image"></div>
+        <div id="bg2" class="bg-image"></div>
+    </div>
     <div class="overlay">
         <h1>Welcome to Àríyò AI</h1>
         <p>Your smart Naija assistant.</p>


### PR DESCRIPTION
## Summary
- Cycle six hero backgrounds with cross-fade and two-layer container
- Preload images and switch every two minutes on pages with background container
- Add CSS for full-screen background layers and initial image

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b864a546ac8332a174f3f9b36778cd