### PR TITLE
Fix background layering to restore rotating backgrounds

### DIFF
--- a/index.css
+++ b/index.css
@@ -41,6 +41,7 @@ body {
     padding: 2rem;
     border-radius: 15px;
     position: relative;
+    z-index: 1;
     color: #fff; /* Ensure overlay text is white */
 }
 
@@ -177,7 +178,7 @@ a {
     width: 100%;
     height: 100%;
     overflow: hidden;
-    z-index: -1;
+    z-index: 0;
     pointer-events: none;
 }
 


### PR DESCRIPTION
## Summary
- Ensure background container sits above page root by removing negative z-index.
- Keep overlay visible by raising its stacking order above the background.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b86e3b65948332afaa1cbd04436b68