### PR TITLE
Fix chatbot modals not displaying

### DIFF
--- a/main.html
+++ b/main.html
@@ -295,6 +295,7 @@
     }
     .chatbot-container zapier-interfaces-chatbot-embed,
     .sabi-bible-container zapier-interfaces-chatbot-embed {
+      display: block;
       width: 100%;
       height: 100%;
       border: none;


### PR DESCRIPTION
## Summary
- ensure chatbot and Sabi Bible embeds display as block elements so they fill the modal container

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b88a965eac8332bf0494752edce9e5