### PR TITLE
Enable Zapier chatbot popups from edge panel

### DIFF
--- a/main.html
+++ b/main.html
@@ -47,7 +47,7 @@
 
   <!-- Animations & Chat -->
   <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.2/gsap.min.js" defer integrity="sha384-d+vyQ0dYcymoP8ndq2hW7FGC50nqGdXUEgoOUGxbbkAJwZqL7h+jKN0GGgn9hFDS" crossorigin="anonymous"></script>
-  <script async type="module" src="https://interfaces.zapier.com/assets/web-components/zapier-interfaces/zapier-interfaces.esm.js" integrity="sha384-FgZSypff2BE9pQZIXz2MrNHujuZ0tfVYCzGZTgMgkRX4q7JLQkdI9sS8uVBk1h6A" crossorigin="anonymous"></script>
+  <script async type='module' src='https://interfaces.zapier.com/assets/web-components/zapier-interfaces/zapier-interfaces.esm.js'></script>
 
 
   <style>
@@ -725,11 +725,11 @@
     <div class="edge-panel-handle"></div>
     <div class="edge-panel-content">
         <!-- Ariyo AI Floating Icon & Comic Bubble -->
-        <div class="chatbot-bubble-container" role="button" aria-label="Open Ariyo AI" onclick="toggleChatbot()">
+        <div class="chatbot-bubble-container" role="button" aria-label="Open Ariyo AI" onclick="openChatbot()">
           <img src="https://raw.githubusercontent.com/Omoluabi1003/Ariyo-AI/main/chatbot.png" alt="Ariyo AI Icon" class="chatbot-float-icon" />
         </div>
         <!-- Sabi Bible Floating Icon & Comic Bubble -->
-        <div class="sabi-bible-bubble-container" role="button" aria-label="Open Sabi Bible" onclick="toggleSabiBible()">
+        <div class="sabi-bible-bubble-container" role="button" aria-label="Open Sabi Bible" onclick="openSabiBible()">
           <img src="Sabi%20Bible.png" alt="Sabi Bible Icon" class="sabi-bible-float-icon" />
         </div>
         <!-- Picture Game Floating Icon -->
@@ -755,33 +755,9 @@
     </div>
 </div>
 
-<!-- Ariyo AI Container -->
-<div class="chatbot-container" id="chatbotContainer" role="dialog" aria-labelledby="chatbotTitle">
-  <button class="popup-close ripple shockwave" role="button" aria-label="Close Ariyo AI" onclick="toggleChatbot()">×</button>
-  <h3 id="chatbotTitle" class="modal-title">Àríyò AI</h3>
-  <zapier-interfaces-chatbot-embed
-    is-popup="false"
-    chatbot-id="cm7s2oyu2000b3vmuwcwkj9kn"
-    height="100%"
-    width="100%"
-    title="Àríyò AI"
-    src="https://interfaces.zapier.com/embed/cm7s2oyu2000b3vmuwcwkj9kn?region=US&language=en-US&timezone=America/New_York">
-  </zapier-interfaces-chatbot-embed>
-</div>
-
-<!-- Sabi Bible Container -->
-<div class="sabi-bible-container" id="sabiBibleContainer" role="dialog" aria-labelledby="sabiBibleTitle">
-  <button class="popup-close ripple shockwave" role="button" aria-label="Close Sabi Bible" onclick="toggleSabiBible()">×</button>
-  <h3 id="sabiBibleTitle" class="modal-title">Sabi Bible Ariyo AI</h3>
-  <zapier-interfaces-chatbot-embed
-    is-popup="false"
-    chatbot-id="cm7ve7fdl002jlclh8y1n6n1y"
-    height="100%"
-    width="100%"
-    title="Sabi Bible Ariyo AI"
-    src="https://interfaces.zapier.com/embed/cm7ve7fdl002jlclh8y1n6n1y?region=US&language=en-US&timezone=America/New_York">
-  </zapier-interfaces-chatbot-embed>
-</div>
+<!-- Chatbot Embeds -->
+<zapier-interfaces-chatbot-embed id='chatbotEmbed' is-popup='true' chatbot-id='cm7s2oyu2000b3vmuwcwkj9kn'></zapier-interfaces-chatbot-embed>
+<zapier-interfaces-chatbot-embed id='sabiBibleEmbed' is-popup='true' chatbot-id='cm7ve7fdl002jlclh8y1n6n1y'></zapier-interfaces-chatbot-embed>
 
 <!-- Picture Game Container -->
 <div id="pictureGameContainer" class="chatbot-container" role="dialog" aria-labelledby="pictureGameTitle">

--- a/scripts/ui.js
+++ b/scripts/ui.js
@@ -210,8 +210,6 @@ function toggleShuffle() {
 }
 
     /* CHATBOT & SABI BIBLE TOGGLE WITH US SPOOFING */
-const chatbotContainer = document.getElementById('chatbotContainer');
-const sabiBibleContainer = document.getElementById('sabiBibleContainer');
 const pictureGameContainer = document.getElementById('pictureGameContainer');
 const tetrisGameContainer = document.getElementById('tetrisGameContainer');
 const wordSearchContainer = document.getElementById('wordSearchContainer');
@@ -220,9 +218,7 @@ const connectFourContainer = document.getElementById('connectFourContainer');
 const cyclePrecisionContainer = document.getElementById('cyclePrecisionContainer');
 
 function isAnyPanelOpen() {
-    return chatbotContainer.style.display === 'block' ||
-           sabiBibleContainer.style.display === 'block' ||
-           pictureGameContainer.style.display === 'block' ||
+    return pictureGameContainer.style.display === 'block' ||
            tetrisGameContainer.style.display === 'block' ||
            wordSearchContainer.style.display === 'block' ||
            connectFourContainer.style.display === 'block' ||
@@ -244,16 +240,18 @@ function updateEdgePanelBehavior() {
     }
 }
 
-function toggleChatbot() {
-    const isHidden = chatbotContainer.style.display === 'none' || !chatbotContainer.style.display;
-    chatbotContainer.style.display = isHidden ? 'block' : 'none';
-    updateEdgePanelBehavior();
+function openChatbot() {
+    const embed = document.getElementById('chatbotEmbed');
+    if (embed) {
+        embed.open();
+    }
 }
 
-function toggleSabiBible() {
-    const isHidden = sabiBibleContainer.style.display === 'none' || !sabiBibleContainer.style.display;
-    sabiBibleContainer.style.display = isHidden ? 'block' : 'none';
-    updateEdgePanelBehavior();
+function openSabiBible() {
+    const embed = document.getElementById('sabiBibleEmbed');
+    if (embed) {
+        embed.open();
+    }
 }
 
 function openAboutModal() {


### PR DESCRIPTION
## Summary
- Load Zapier Interfaces script without SRI hash
- Replace custom chatbot containers with popup-based embeds
- Wire edge-panel icons to open chatbots via new JS helpers

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b89a2932e88332a11f0e87b772ccf7