### PR TITLE
Remove redundant chatbot icon from edge panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 - **Ariyo AI:** Interact with the Ariyo AI assistant for assistance and entertainment.
 - **PWA:** Install the application on your device for offline access and a native-like experience.
 - **Radio:** Listen to a variety of Nigerian and international radio stations.
-- **Edge Panel:** Quick-access icons for Ariyo AI, Picture Game, Omoluabi Tetris, Omoluabi Word Search, Ara Connect-4, and Cycle Precision.
+- **Edge Panel:** Quick-access icons for Picture Game, Omoluabi Tetris, Omoluabi Word Search, Ara Connect-4, and Cycle Precision.
 - **Games:** Play mini-games like Picture Game, Omoluabi Tetris, Word Search, and Ara Connect-4.
   - Picture Game
   - Omoluabi Tetris

--- a/index.html
+++ b/index.html
@@ -47,7 +47,7 @@
             </div>
         </div>
          <div style="font-size: 0.8rem; margin-top: 1rem; font-weight: bold;">Use the speaker icon to toggle sound</div>
-        <p style="font-size: 0.8rem; margin-top: 0.5rem;">Edge panel offers quick access to Ariyo AI, Picture Game, Omoluabi Tetris, Omoluabi Word Search, Ara Connect-4, and Cycle Precision.</p>
+        <p style="font-size: 0.8rem; margin-top: 0.5rem;">Edge panel offers quick access to Picture Game, Omoluabi Tetris, Omoluabi Word Search, Ara Connect-4, and Cycle Precision.</p>
         <div id="speaker-container" style="position: absolute; top: 1rem; right: 1rem; cursor: pointer;">
             <svg id="speaker-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon icon-tabler icons-tabler-outline icon-tabler-volume-off ripple shockwave"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M15 8a5 5 0 0 1 0 8" /><path d="M17.7 5a9 9 0 0 1 0 14" /><path d="M6 15h-2a1 1 0 0 1 -1 -1v-4a1 1 0 0 1 1 -1h2l3.5 -4.5a.8 .8 0 0 1 1.5 .5v14a.8 .8 0 0 1 -1.5 .5l-3.5 -4.5" /><path d="M12 12l0 .01" /></svg>
         </div>

--- a/main.html
+++ b/main.html
@@ -404,7 +404,7 @@
     .tap-area.right {
         right: 0;
     }
-      .chatbot-float-icon, .picture-game-float-icon, .cycle-precision-float-icon {
+      .picture-game-float-icon, .cycle-precision-float-icon {
       width: 50px;
       height: 50px;
       border-radius: 50%;
@@ -546,9 +546,6 @@
       }
       .music-controls.icons-only {
         flex-wrap: wrap;
-      }
-      .chatbot-bubble-container {
-        bottom: calc(15rem + env(safe-area-inset-bottom));
       }
     }
 
@@ -723,10 +720,6 @@
 <div class="edge-panel" id="edgePanel">
     <div class="edge-panel-handle"></div>
     <div class="edge-panel-content">
-        <!-- Ariyo AI Floating Icon & Comic Bubble -->
-        <div class="chatbot-bubble-container" role="button" aria-label="Open Ariyo AI" onclick="openChatbot()">
-          <img src="https://raw.githubusercontent.com/Omoluabi1003/Ariyo-AI/main/chatbot.png" alt="Ariyo AI Icon" class="chatbot-float-icon" />
-        </div>
         <!-- Picture Game Floating Icon -->
         <div class="picture-game-bubble-container" role="button" aria-label="Open Picture Game" onclick="openPictureGame()">
             <img src="https://raw.githubusercontent.com/Omoluabi1003/Ariyo-AI/main/Ara%20icon.png" alt="Picture Game Icon" class="picture-game-float-icon" />

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -628,7 +628,7 @@
 
     // Dynamic Edge Panel Height
     const edgePanelContent = document.querySelector('.edge-panel-content');
-    const icons = edgePanelContent.querySelectorAll('.chatbot-bubble-container, .picture-game-bubble-container, .tetris-bubble-container, .word-search-bubble-container, .connect-four-bubble-container, .cycle-precision-bubble-container');
+    const icons = edgePanelContent.querySelectorAll('.picture-game-bubble-container, .tetris-bubble-container, .word-search-bubble-container, .connect-four-bubble-container, .cycle-precision-bubble-container');
     const iconHeight = 50; // height of each icon
     const iconSpacing = 20; // spacing between icons
     const panelPadding = 20; // top and bottom padding of the panel

--- a/scripts/ui.js
+++ b/scripts/ui.js
@@ -216,6 +216,7 @@ const wordSearchContainer = document.getElementById('wordSearchContainer');
 const aboutModalContainer = document.getElementById('aboutModalContainer');
 const connectFourContainer = document.getElementById('connectFourContainer');
 const cyclePrecisionContainer = document.getElementById('cyclePrecisionContainer');
+const chatbotEmbed = document.getElementById('chatbotEmbed');
 
 function isAnyPanelOpen() {
     return pictureGameContainer.style.display === 'block' ||
@@ -231,7 +232,7 @@ window.spoofedLocation = {country:"US",timezone:"America/New_York",language:"en-
 console.log("US Spoof Active:", window.spoofedLocation);
 
 function updateEdgePanelBehavior() {
-    chatbotWindowOpen = isAnyPanelOpen();
+    chatbotWindowOpen = isAnyPanelOpen() || chatbotWindowOpen;
     if (chatbotWindowOpen) {
         closeEdgePanel();
         clearInterval(autoPopOutInterval);
@@ -239,23 +240,6 @@ function updateEdgePanelBehavior() {
         autoPopOutEdgePanel();
     }
 }
-
-function openChatbot() {
-    const embed = document.getElementById('chatbotEmbed');
-    if (embed) {
-        embed.open();
-        chatbotWindowOpen = true;
-        closeEdgePanel();
-        clearInterval(autoPopOutInterval);
-        const onClose = () => {
-            chatbotWindowOpen = false;
-            updateEdgePanelBehavior();
-            embed.removeEventListener('close', onClose);
-        };
-        embed.addEventListener('close', onClose);
-    }
-}
-
 
 function openAboutModal() {
     const iframe = aboutModalContainer.querySelector('iframe');
@@ -398,6 +382,18 @@ function closeCyclePrecision() {
     /* AUTO POP-OUT/RETRACT EDGE PANEL */
     let chatbotWindowOpen = false;
     let autoPopOutInterval;
+
+    if (chatbotEmbed) {
+        chatbotEmbed.addEventListener('open', () => {
+            chatbotWindowOpen = true;
+            closeEdgePanel();
+            clearInterval(autoPopOutInterval);
+        });
+        chatbotEmbed.addEventListener('close', () => {
+            chatbotWindowOpen = false;
+            updateEdgePanelBehavior();
+        });
+    }
 
     function autoPopOutEdgePanel() {
         if (chatbotWindowOpen || edgePanel.classList.contains('visible')) return;


### PR DESCRIPTION
## Summary
- Drop Ariyo AI shortcut from the edge panel and rely on the Zapier embed's pop‑out icon
- Update edge panel scripts to track Zapier chatbot open/close events and adjust panel height
- Refresh documentation and UI text to reflect new edge panel contents

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b8a70f881c833283b9b18cab90b080