### PR TITLE
Protect media controls from Zapier icon overlap

### DIFF
--- a/main.html
+++ b/main.html
@@ -211,6 +211,7 @@
       align-items: center;
       flex-wrap: wrap;
       gap: 0.6rem;
+      padding-right: 4rem; /* Space for Zapier icon */
     }
     .music-controls.icons-only button {
       background: var(--theme-color);

--- a/style.css
+++ b/style.css
@@ -234,6 +234,7 @@ body {
     align-items: center;
     flex-wrap: wrap;
     gap: 0.6rem;
+    padding-right: 4rem; /* Space for Zapier icon */
 }
 
 .music-controls.icons-only button {


### PR DESCRIPTION
## Summary
- Add right padding to music control bar so the Zapier chatbot button no longer covers the shuffle control
- Mirror padding in `main.html` and `style.css`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b8acc4d7048332849e13bd24df6849