### PR TITLE
Embed Ariyo AI chatbot via iframe

### DIFF
--- a/ariyo-ai-chat.html
+++ b/ariyo-ai-chat.html
@@ -4,9 +4,8 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Ariyo AI Chatbot</title>
-  <script async type='module' src='https://interfaces.zapier.com/assets/web-components/zapier-interfaces/zapier-interfaces.esm.js'></script>
 </head>
 <body>
-  <zapier-interfaces-chatbot-embed is-popup='false' chatbot-id='cm7s2oyu2000b3vmuwcwkj9kn' height='600px' width='400px'></zapier-interfaces-chatbot-embed>
+  <iframe src='https://interfaces.zapier.com/embed/chatbot/cm7s2oyu2000b3vmuwcwkj9kn' height='600px' width='400px' allow='clipboard-write *' style="border: none;"></iframe>
 </body>
 </html>

--- a/main.html
+++ b/main.html
@@ -47,7 +47,6 @@
 
   <!-- Animations & Chat -->
   <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.2/gsap.min.js" defer integrity="sha384-d+vyQ0dYcymoP8ndq2hW7FGC50nqGdXUEgoOUGxbbkAJwZqL7h+jKN0GGgn9hFDS" crossorigin="anonymous"></script>
-  <script async type='module' src='https://interfaces.zapier.com/assets/web-components/zapier-interfaces/zapier-interfaces.esm.js'></script>
 
 
   <style>
@@ -294,7 +293,7 @@
       display: none;
       z-index: 10001;
     }
-      .chatbot-container zapier-interfaces-chatbot-embed {
+      .chatbot-container iframe {
         display: block;
         width: 100%;
         height: 100%;
@@ -302,21 +301,6 @@
         border-radius: 10px;
       }
 
-    /* Position chatbot button so it doesn't cover shuffle control */
-    #chatbotEmbed {
-      position: fixed;
-      bottom: calc(1rem + env(safe-area-inset-bottom));
-      right: 1rem;
-      z-index: 10001;
-    }
-
-    /* On smaller screens move the chatbot button to the left */
-    @media (max-width: 768px) {
-      #chatbotEmbed {
-        left: 1rem;
-        right: auto;
-      }
-    }
     #tetrisGameContainer {
       height: calc(100vh - (140px + env(safe-area-inset-bottom)));
       overflow-y: auto;
@@ -737,6 +721,10 @@
 <div class="edge-panel" id="edgePanel">
     <div class="edge-panel-handle"></div>
     <div class="edge-panel-content">
+        <!-- Ariyo AI Floating Icon -->
+        <div class="chatbot-bubble-container" role="button" aria-label="Open Ariyo AI" onclick="openChatbot()">
+            <img src="chatbot.png" alt="Ariyo AI Icon" class="picture-game-float-icon" />
+        </div>
         <!-- Picture Game Floating Icon -->
         <div class="picture-game-bubble-container" role="button" aria-label="Open Picture Game" onclick="openPictureGame()">
             <img src="https://raw.githubusercontent.com/Omoluabi1003/Ariyo-AI/main/Ara%20icon.png" alt="Picture Game Icon" class="picture-game-float-icon" />
@@ -760,8 +748,12 @@
     </div>
 </div>
 
-<!-- Chatbot Embeds -->
-<zapier-interfaces-chatbot-embed id='chatbotEmbed' is-popup='true' chatbot-id='cm7s2oyu2000b3vmuwcwkj9kn'></zapier-interfaces-chatbot-embed>
+<!-- Ariyo AI Chatbot Container -->
+<div id="chatbotContainer" class="chatbot-container" role="dialog" aria-labelledby="chatbotTitle">
+    <button class="popup-close ripple shockwave" onclick="closeChatbot()">×</button>
+    <h3 id="chatbotTitle" class="modal-title">Ariyo AI</h3>
+    <iframe src='https://interfaces.zapier.com/embed/chatbot/cm7s2oyu2000b3vmuwcwkj9kn' allow='clipboard-write *' style="border: none; width: 100%; height: 100%;"></iframe>
+</div>
 
 <!-- Picture Game Container -->
 <div id="pictureGameContainer" class="chatbot-container" role="dialog" aria-labelledby="pictureGameTitle">

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -628,7 +628,7 @@
 
     // Dynamic Edge Panel Height
     const edgePanelContent = document.querySelector('.edge-panel-content');
-    const icons = edgePanelContent.querySelectorAll('.picture-game-bubble-container, .tetris-bubble-container, .word-search-bubble-container, .connect-four-bubble-container, .cycle-precision-bubble-container');
+    const icons = edgePanelContent.querySelectorAll('.chatbot-bubble-container, .picture-game-bubble-container, .tetris-bubble-container, .word-search-bubble-container, .connect-four-bubble-container, .cycle-precision-bubble-container');
     const iconHeight = 50; // height of each icon
     const iconSpacing = 20; // spacing between icons
     const panelPadding = 20; // top and bottom padding of the panel

--- a/scripts/ui.js
+++ b/scripts/ui.js
@@ -216,7 +216,7 @@ const wordSearchContainer = document.getElementById('wordSearchContainer');
 const aboutModalContainer = document.getElementById('aboutModalContainer');
 const connectFourContainer = document.getElementById('connectFourContainer');
 const cyclePrecisionContainer = document.getElementById('cyclePrecisionContainer');
-const chatbotEmbed = document.getElementById('chatbotEmbed');
+const chatbotContainer = document.getElementById('chatbotContainer');
 
 function isAnyPanelOpen() {
     return pictureGameContainer.style.display === 'block' ||
@@ -224,6 +224,7 @@ function isAnyPanelOpen() {
            wordSearchContainer.style.display === 'block' ||
            connectFourContainer.style.display === 'block' ||
            cyclePrecisionContainer.style.display === 'block' ||
+           chatbotContainer.style.display === 'block' ||
            aboutModalContainer.style.display === 'block';
 }
 
@@ -232,7 +233,7 @@ window.spoofedLocation = {country:"US",timezone:"America/New_York",language:"en-
 console.log("US Spoof Active:", window.spoofedLocation);
 
 function updateEdgePanelBehavior() {
-    chatbotWindowOpen = isAnyPanelOpen() || chatbotWindowOpen;
+    chatbotWindowOpen = isAnyPanelOpen();
     if (chatbotWindowOpen) {
         closeEdgePanel();
         clearInterval(autoPopOutInterval);
@@ -252,6 +253,16 @@ function openAboutModal() {
 
 function closeAboutModal() {
     aboutModalContainer.style.display = 'none';
+    updateEdgePanelBehavior();
+}
+
+function openChatbot() {
+    chatbotContainer.style.display = 'block';
+    updateEdgePanelBehavior();
+}
+
+function closeChatbot() {
+    chatbotContainer.style.display = 'none';
     updateEdgePanelBehavior();
 }
 
@@ -382,18 +393,6 @@ function closeCyclePrecision() {
     /* AUTO POP-OUT/RETRACT EDGE PANEL */
     let chatbotWindowOpen = false;
     let autoPopOutInterval;
-
-    if (chatbotEmbed) {
-        chatbotEmbed.addEventListener('open', () => {
-            chatbotWindowOpen = true;
-            closeEdgePanel();
-            clearInterval(autoPopOutInterval);
-        });
-        chatbotEmbed.addEventListener('close', () => {
-            chatbotWindowOpen = false;
-            updateEdgePanelBehavior();
-        });
-    }
 
     function autoPopOutEdgePanel() {
         if (chatbotWindowOpen || edgePanel.classList.contains('visible')) return;


### PR DESCRIPTION
## Summary
- Replace Zapier web component with iframe embed for Ariyo AI chatbot
- Add chatbot icon and modal in edge panel with corresponding open/close logic
- Clean up legacy chatbot styles and update edge panel sizing script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b8cae2e8e883328d3e00fed2e3d7a5