### PR TITLE
feat: restore Sabi Bible chatbot

### DIFF
--- a/ariyo-ai-chat.html
+++ b/ariyo-ai-chat.html
@@ -3,9 +3,9 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Ariyo AI Chatbot</title>
+  <title>Sabi Bible</title>
 </head>
 <body>
-  <iframe src='https://interfaces.zapier.com/embed/chatbot/cm7s2oyu2000b3vmuwcwkj9kn' height='600px' width='400px' allow='clipboard-write *' style="border: none;"></iframe>
+  <iframe src='https://interfaces.zapier.com/embed/chatbot/cm7ve7fdl002jlclh8y1n6n1y' height='600px' width='400px' allow='clipboard-write *' style="border: none;"></iframe>
 </body>
 </html>

--- a/main.html
+++ b/main.html
@@ -721,9 +721,9 @@
 <div class="edge-panel" id="edgePanel">
     <div class="edge-panel-handle"></div>
     <div class="edge-panel-content">
-        <!-- Ariyo AI Floating Icon -->
-        <div class="chatbot-bubble-container" role="button" aria-label="Open Ariyo AI" onclick="openChatbot()">
-            <img src="chatbot.png" alt="Ariyo AI Icon" class="picture-game-float-icon" />
+        <!-- Sabi Bible Floating Icon -->
+        <div class="chatbot-bubble-container" role="button" aria-label="Open Sabi Bible" onclick="openChatbot()">
+            <img src="chatbot.png" alt="Sabi Bible Icon" class="picture-game-float-icon" />
         </div>
         <!-- Picture Game Floating Icon -->
         <div class="picture-game-bubble-container" role="button" aria-label="Open Picture Game" onclick="openPictureGame()">
@@ -748,11 +748,11 @@
     </div>
 </div>
 
-<!-- Ariyo AI Chatbot Container -->
+<!-- Sabi Bible Chatbot Container -->
 <div id="chatbotContainer" class="chatbot-container" role="dialog" aria-labelledby="chatbotTitle">
     <button class="popup-close ripple shockwave" onclick="closeChatbot()">×</button>
-    <h3 id="chatbotTitle" class="modal-title">Ariyo AI</h3>
-    <iframe src='https://interfaces.zapier.com/embed/chatbot/cm7s2oyu2000b3vmuwcwkj9kn' allow='clipboard-write *' style="border: none; width: 100%; height: 100%;"></iframe>
+    <h3 id="chatbotTitle" class="modal-title">Sabi Bible</h3>
+    <iframe src='https://interfaces.zapier.com/embed/chatbot/cm7ve7fdl002jlclh8y1n6n1y' allow='clipboard-write *' style="border: none; width: 100%; height: 100%;"></iframe>
 </div>
 
 <!-- Picture Game Container -->


### PR DESCRIPTION
## Summary
- replace Ariyo AI chat with Sabi Bible in edge panel and standalone page
- update iframe source to new Zapier chatbot URL

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b8ce7e8670833286cc4795098581fc