### PR TITLE
Lighten index overlay to reveal background

### DIFF
--- a/index.css
+++ b/index.css
@@ -37,7 +37,7 @@ body {
 }
 
 .overlay {
-    background-color: rgba(0, 0, 0, 0.7);
+    background-color: rgba(0, 0, 0, 0.1);
     padding: 2rem;
     border-radius: 15px;
     position: relative;


### PR DESCRIPTION
## Summary
- Reduce index overlay opacity to 0.1 so the background image shines through

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b8d3b1ce84833281030d756748e704