### PR TITLE
feat: add separate Ariyo AI and Sabi Bible chatbots

### DIFF
--- a/main.html
+++ b/main.html
@@ -388,9 +388,10 @@
     .edge-panel-content {
         display: flex;
         flex-direction: column;
-        justify-content: space-around;
+        justify-content: flex-start;
         align-items: center;
-        height: 100%;
+        gap: 10px;
+        padding: 10px 0;
     }
     .tap-area {
         position: fixed;
@@ -721,8 +722,12 @@
 <div class="edge-panel" id="edgePanel">
     <div class="edge-panel-handle"></div>
     <div class="edge-panel-content">
+        <!-- Ariyo AI Floating Icon -->
+        <div class="chatbot-bubble-container" role="button" aria-label="Open Ariyo AI" onclick="openAriyoChatbot()">
+            <img src="icons/Ariyo.png" alt="Ariyo AI Icon" class="picture-game-float-icon" />
+        </div>
         <!-- Sabi Bible Floating Icon -->
-        <div class="chatbot-bubble-container" role="button" aria-label="Open Sabi Bible" onclick="openChatbot()">
+        <div class="chatbot-bubble-container" role="button" aria-label="Open Sabi Bible" onclick="openSabiBible()">
             <img src="icons/sabi-bible.png" alt="Sabi Bible Icon" class="picture-game-float-icon" />
         </div>
         <!-- Picture Game Floating Icon -->
@@ -748,11 +753,18 @@
     </div>
 </div>
 
+<!-- Ariyo AI Chatbot Container -->
+<div id="ariyoChatbotContainer" class="chatbot-container" role="dialog" aria-labelledby="ariyoChatbotTitle">
+    <button class="popup-close ripple shockwave" onclick="closeAriyoChatbot()">×</button>
+    <h3 id="ariyoChatbotTitle" class="modal-title">Àríyò AI</h3>
+    <iframe src="ariyo-ai-chat.html" style="border: none; width: 100%; height: 100%;"></iframe>
+</div>
+
 <!-- Sabi Bible Chatbot Container -->
-<div id="chatbotContainer" class="chatbot-container" role="dialog" aria-labelledby="chatbotTitle">
-    <button class="popup-close ripple shockwave" onclick="closeChatbot()">×</button>
-    <h3 id="chatbotTitle" class="modal-title">Sabi Bible</h3>
-    <iframe src='https://interfaces.zapier.com/embed/chatbot/cm7ve7fdl002jlclh8y1n6n1y' allow='clipboard-write *' style="border: none; width: 100%; height: 100%;"></iframe>
+<div id="sabiBibleContainer" class="chatbot-container" role="dialog" aria-labelledby="sabiBibleTitle">
+    <button class="popup-close ripple shockwave" onclick="closeSabiBible()">×</button>
+    <h3 id="sabiBibleTitle" class="modal-title">Sabi Bible</h3>
+    <iframe src="sabi-bible.html" style="border: none; width: 100%; height: 100%;"></iframe>
 </div>
 
 <!-- Picture Game Container -->

--- a/sabi-bible.html
+++ b/sabi-bible.html
@@ -3,10 +3,10 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Ariyo AI Chatbot</title>
+  <title>Sabi Bible Chatbot</title>
   <script async type='module' src='https://interfaces.zapier.com/assets/web-components/zapier-interfaces/zapier-interfaces.esm.js'></script>
 </head>
 <body>
-  <zapier-interfaces-chatbot-embed is-popup='false' chatbot-id='cm7s2oyu2000b3vmuwcwkj9kn' height='600px' width='400px'></zapier-interfaces-chatbot-embed>
+  <zapier-interfaces-chatbot-embed is-popup='false' chatbot-id='cm7ve7fdl002jlclh8y1n6n1y' height='600px' width='400px'></zapier-interfaces-chatbot-embed>
 </body>
 </html>

--- a/scripts/ui.js
+++ b/scripts/ui.js
@@ -216,7 +216,8 @@ let pictureGameContainer,
     aboutModalContainer,
     connectFourContainer,
     cyclePrecisionContainer,
-    chatbotContainer;
+    ariyoChatbotContainer,
+    sabiBibleContainer;
 
 document.addEventListener('DOMContentLoaded', () => {
     pictureGameContainer = document.getElementById('pictureGameContainer');
@@ -225,7 +226,8 @@ document.addEventListener('DOMContentLoaded', () => {
     aboutModalContainer = document.getElementById('aboutModalContainer');
     connectFourContainer = document.getElementById('connectFourContainer');
     cyclePrecisionContainer = document.getElementById('cyclePrecisionContainer');
-    chatbotContainer = document.getElementById('chatbotContainer');
+    ariyoChatbotContainer = document.getElementById('ariyoChatbotContainer');
+    sabiBibleContainer = document.getElementById('sabiBibleContainer');
 });
 
 function isAnyPanelOpen() {
@@ -235,7 +237,8 @@ function isAnyPanelOpen() {
         wordSearchContainer,
         connectFourContainer,
         cyclePrecisionContainer,
-        chatbotContainer,
+        ariyoChatbotContainer,
+        sabiBibleContainer,
         aboutModalContainer
     ].some(el => el && el.style.display === 'block');
 }
@@ -268,13 +271,23 @@ function closeAboutModal() {
     updateEdgePanelBehavior();
 }
 
-function openChatbot() {
-    chatbotContainer.style.display = 'block';
+function openAriyoChatbot() {
+    ariyoChatbotContainer.style.display = 'block';
     updateEdgePanelBehavior();
 }
 
-function closeChatbot() {
-    chatbotContainer.style.display = 'none';
+function closeAriyoChatbot() {
+    ariyoChatbotContainer.style.display = 'none';
+    updateEdgePanelBehavior();
+}
+
+function openSabiBible() {
+    sabiBibleContainer.style.display = 'block';
+    updateEdgePanelBehavior();
+}
+
+function closeSabiBible() {
+    sabiBibleContainer.style.display = 'none';
     updateEdgePanelBehavior();
 }
 


### PR DESCRIPTION
## Summary
- Restore distinct Ariyo AI and Sabi Bible chatbot pages
- Show Ariyo AI and Sabi Bible icons in edge panel without overlap
- Wire up new open/close logic for both chatbots

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b96aab9d5883329aa77e5706274a85