### PR TITLE
Ensure chat input and greeting stay visible

### DIFF
--- a/ariyo-ai-chat.html
+++ b/ariyo-ai-chat.html
@@ -7,6 +7,6 @@
   <script async type='module' src='https://interfaces.zapier.com/assets/web-components/zapier-interfaces/zapier-interfaces.esm.js'></script>
 </head>
 <body>
-  <zapier-interfaces-chatbot-embed is-popup='false' chatbot-id='cm7s2oyu2000b3vmuwcwkj9kn' height='600px' width='400px'></zapier-interfaces-chatbot-embed>
+  <zapier-interfaces-chatbot-embed is-popup='false' chatbot-id='cm7s2oyu2000b3vmuwcwkj9kn' height='100vh' width='100%'></zapier-interfaces-chatbot-embed>
 </body>
 </html>

--- a/sabi-bible.html
+++ b/sabi-bible.html
@@ -7,6 +7,6 @@
   <script async type='module' src='https://interfaces.zapier.com/assets/web-components/zapier-interfaces/zapier-interfaces.esm.js'></script>
 </head>
 <body>
-  <zapier-interfaces-chatbot-embed is-popup='false' chatbot-id='cm7ve7fdl002jlclh8y1n6n1y' height='600px' width='400px'></zapier-interfaces-chatbot-embed>
+  <zapier-interfaces-chatbot-embed is-popup='false' chatbot-id='cm7ve7fdl002jlclh8y1n6n1y' height='100vh' width='100%'></zapier-interfaces-chatbot-embed>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Use full viewport height for Ariyò AI chatbot embed so its greeting and input field appear together
- Apply the same viewport-based sizing to Sabi Bible chatbot embed

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b97092dc3c83328113b7630c4d48e3