### PR TITLE
Ensure chatbots fit in viewport

### DIFF
--- a/ariyo-ai-chat.html
+++ b/ariyo-ai-chat.html
@@ -5,8 +5,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Ariyo AI Chatbot</title>
   <script async type='module' src='https://interfaces.zapier.com/assets/web-components/zapier-interfaces/zapier-interfaces.esm.js'></script>
+  <style>
+    html, body {
+      height: 100%;
+      margin: 0;
+    }
+  </style>
 </head>
 <body>
-  <zapier-interfaces-chatbot-embed is-popup='false' chatbot-id='cm7s2oyu2000b3vmuwcwkj9kn' height='100vh' width='100%'></zapier-interfaces-chatbot-embed>
+  <zapier-interfaces-chatbot-embed is-popup='false' chatbot-id='cm7s2oyu2000b3vmuwcwkj9kn' height='100%' width='100%'></zapier-interfaces-chatbot-embed>
 </body>
 </html>

--- a/main.html
+++ b/main.html
@@ -280,12 +280,12 @@
     .track-list a:hover, .album-list a:hover, .radio-list a:hover { background-color: var(--theme-color); }
       .chatbot-container, #aboutModalContainer {
       position: fixed;
+      top: 0;
       bottom: calc(80px + env(safe-area-inset-bottom));
       left: 50%;
       transform: translateX(-50%);
       width: 90%;
       max-width: 600px;
-      height: 70vh;
       border-radius: 10px;
       box-shadow: 0px 4px 10px rgba(0,0,0,0.3);
       background: white;

--- a/sabi-bible.html
+++ b/sabi-bible.html
@@ -5,8 +5,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Sabi Bible Chatbot</title>
   <script async type='module' src='https://interfaces.zapier.com/assets/web-components/zapier-interfaces/zapier-interfaces.esm.js'></script>
+  <style>
+    html, body {
+      height: 100%;
+      margin: 0;
+    }
+  </style>
 </head>
 <body>
-  <zapier-interfaces-chatbot-embed is-popup='false' chatbot-id='cm7ve7fdl002jlclh8y1n6n1y' height='100vh' width='100%'></zapier-interfaces-chatbot-embed>
+  <zapier-interfaces-chatbot-embed is-popup='false' chatbot-id='cm7ve7fdl002jlclh8y1n6n1y' height='100%' width='100%'></zapier-interfaces-chatbot-embed>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Prevent chatbot popups from exceeding the viewport by anchoring them to the top and bottom of the screen.
- Allow embedded Ariyo AI and Sabi Bible chatbots to fill their containers with full-height layouts.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b9766286b88332a37fd6ab7a9126dd