### PR TITLE
Center music controls and streamline styling

### DIFF
--- a/color-scheme.css
+++ b/color-scheme.css
@@ -11,7 +11,6 @@ body {
 
 .header { background: linear-gradient(135deg, var(--gradient-start), var(--gradient-end)); }
 .sidebar button { background: linear-gradient(135deg, var(--gradient-start), var(--gradient-end)); }
-.music-controls.icons-only button { background: var(--theme-color); }
 .track-list a:hover, .track-list .track-item:hover, .album-list a:hover, .radio-list a:hover { background-color: var(--theme-color); }
 .popup-close { background: var(--theme-color); }
 .retry-button { background: var(--theme-color); }

--- a/color-scheme.js
+++ b/color-scheme.js
@@ -12,7 +12,6 @@ function applyTheme() {
     :root { --theme-color: ${themeColor}; --gradient-start: ${gradStart}; --gradient-end: ${gradEnd}; }
     .header { background: linear-gradient(135deg, var(--gradient-start), var(--gradient-end)); }
     .sidebar button { background: linear-gradient(135deg, var(--gradient-start), var(--gradient-end)); }
-    .music-controls.icons-only button { background: ${themeColor}; }
     .track-list a:hover, .track-list .track-item:hover, .album-list a:hover, .radio-list a:hover { background-color: ${themeColor}; }
     .popup-close { background: ${themeColor}; }
     .retry-button { background: ${themeColor}; }

--- a/main.html
+++ b/main.html
@@ -203,30 +203,7 @@
       animation: spin 1s linear infinite;
       margin: 0 auto;
     }
-    .music-controls.icons-only {
-      margin-top: 0.6rem;
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      flex-wrap: wrap;
-      gap: 0.6rem;
-      padding-right: 4rem; /* Space for Zapier icon */
-    }
-    .music-controls.icons-only button {
-      background: var(--theme-color);
-      color: white;
-      border: none;
-      padding: 0.8rem;
-      border-radius: 25px;
-      cursor: pointer;
-      font-size: 0.9rem;
-      transition: transform 0.2s;
-      min-width: 48px;
-      min-height: 48px;
-      touch-action: manipulation;
-      pointer-events: auto;
-    }
-    .music-controls.icons-only button:hover { transform: scale(1.1); }
+    /* Music control styling handled in style.css */
     .track-info { margin-top: 0.6rem; font-size: clamp(0.9rem, 2.5vw, 1.1rem); }
     .track-duration { font-size: clamp(0.7rem, 1.8vw, 0.8rem); margin-top: 0.3rem; }
     #lyrics { margin-top: 0.6rem; max-height: 200px; overflow-y: auto; text-align: center; display: none; }
@@ -546,9 +523,7 @@
         border-radius: 0;
         max-width: 100%;
       }
-      .music-controls.icons-only {
-        flex-wrap: wrap;
-      }
+      /* Music control layout handled in style.css */
     }
 
     #nowPlayingToast {

--- a/style.css
+++ b/style.css
@@ -232,27 +232,29 @@ body {
     display: flex;
     justify-content: center;
     align-items: center;
-    flex-wrap: wrap;
-    gap: 0.6rem;
+    flex-wrap: nowrap;
+    gap: 0.4rem;
+    padding: 0;
 }
 
 .music-controls.icons-only button {
     background: transparent;
     color: var(--theme-color);
     border: 2px solid var(--theme-color);
-    padding: 0.8rem;
-    border-radius: 25px;
+    padding: 0;
+    border-radius: 15px;
     cursor: pointer;
-    font-size: 0.9rem;
+    font-size: 0.8rem;
     transition: background-color 0.2s, color 0.2s;
-    min-width: 48px;
-    min-height: 48px;
+    min-width: 40px;
+    min-height: 40px;
     touch-action: manipulation;
     pointer-events: auto;
 }
 
 .music-controls.icons-only button:hover {
     animation: gradient-glow 1.5s infinite alternate;
+    transform: none;
 }
 
 .track-info {
@@ -466,7 +468,7 @@ body {
         max-width: 100%;
     }
     .music-controls.icons-only {
-        flex-wrap: wrap;
+        flex-wrap: nowrap;
     }
     .modal-content {
         width: 90%;


### PR DESCRIPTION
## Summary
- Centered the music player controls by removing the extra right padding so the button group aligns properly in the layout
- Restyled control buttons with theme-colored borders and text, a transparent background, and no hover scaling for a cleaner edge-focused appearance

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9e272797483329fd21654268bc4b6