### PR TITLE
Improve shuffle button legibility with numbered indicators

### DIFF
--- a/main.html
+++ b/main.html
@@ -646,7 +646,7 @@
       <button aria-label="Pause" onclick="pauseMusic()" title="Pause" aria-controls="audioPlayer" class="ripple shockwave">⏸</button>
       <button aria-label="Stop" onclick="stopMusic()" title="Stop" aria-controls="audioPlayer" class="ripple shockwave">⏹</button>
       <button aria-label="Next track" onclick="nextTrack()" title="Next track" aria-controls="audioPlayer" class="ripple shockwave">⏭</button>
-      <button aria-label="Toggle shuffle" onclick="toggleShuffle()" title="Toggle shuffle" aria-pressed="false" class="ripple shockwave">🔀</button>
+      <button aria-label="Toggle shuffle" onclick="toggleShuffle()" title="Toggle shuffle" aria-pressed="false" class="ripple shockwave shuffle-button">🔀</button>
     </div>
   </div>
 

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -423,17 +423,17 @@
         shuffleScope = savedState.shuffleScope;
 
         if (shuffleScope === 'album') {
-          shuffleBtn.textContent = '🔀 Album';
+          shuffleBtn.innerHTML = '🔀 <span class="shuffle-indicator">2</span>';
           shuffleStatusInfo.textContent = 'Shuffle: On (Album)';
         } else if (shuffleScope === 'all') {
-          shuffleBtn.textContent = '🔀 All';
+          shuffleBtn.innerHTML = '🔀 <span class="shuffle-indicator">3</span>';
           shuffleStatusInfo.textContent = 'Shuffle: On (All Tracks)';
         } else if (shuffleScope === 'repeat') {
           shuffleMode = false;
-          shuffleBtn.textContent = '🔂 One';
+          shuffleBtn.innerHTML = '🔂 <span class="shuffle-indicator">1</span>';
           shuffleStatusInfo.textContent = 'Repeat: On (Single Track)';
         } else { // off
-          shuffleBtn.textContent = '🔀 Off';
+          shuffleBtn.innerHTML = '🔀';
           shuffleStatusInfo.textContent = 'Shuffle: Off';
         }
         buildShuffleQueue();
@@ -443,7 +443,7 @@
         shuffleScope = 'off';
         shuffleMode = false;
         document.getElementById('shuffleStatusInfo').textContent = 'Shuffle: Off';
-        document.querySelector(".music-controls.icons-only button[aria-label='Toggle shuffle']").textContent = '🔀 Off';
+        document.querySelector(".music-controls.icons-only button[aria-label='Toggle shuffle']").innerHTML = '🔀';
         buildShuffleQueue();
         selectAlbum(0);
         console.log('No saved state found, initialized with default');

--- a/scripts/ui.js
+++ b/scripts/ui.js
@@ -163,11 +163,11 @@ function toggleShuffle() {
     shuffleQueue = [];
     updateNextTrackInfo();
     if (shuffleMode) {
-      shuffleBtn.textContent = '🔀 Radio';
+      shuffleBtn.innerHTML = '🔀 <span class="shuffle-indicator">R</span>';
       shuffleStatusInfo.textContent = 'Shuffle: On (Radio)';
       console.log('Shuffle mode: Radio');
     } else {
-      shuffleBtn.textContent = '🔀 Off';
+      shuffleBtn.innerHTML = '🔀';
       shuffleStatusInfo.textContent = 'Shuffle: Off';
       console.log('Shuffle mode: Off');
     }
@@ -177,21 +177,21 @@ function toggleShuffle() {
     if (shuffleScope === 'off') {
       shuffleScope = 'album';
       shuffleMode = true;
-      shuffleBtn.textContent = '🔀 Album';
+      shuffleBtn.innerHTML = '🔀 <span class="shuffle-indicator">2</span>';
       shuffleStatusInfo.textContent = 'Shuffle: On (Album)';
       console.log('Shuffle mode: Album');
       buildShuffleQueue();
     } else if (shuffleScope === 'album') {
       shuffleScope = 'all';
       shuffleMode = true;
-      shuffleBtn.textContent = '🔀 All';
+      shuffleBtn.innerHTML = '🔀 <span class="shuffle-indicator">3</span>';
       shuffleStatusInfo.textContent = 'Shuffle: On (All Tracks)';
       console.log('Shuffle mode: All');
       buildShuffleQueue();
     } else if (shuffleScope === 'all') {
       shuffleScope = 'repeat';
       shuffleMode = false;
-      shuffleBtn.textContent = '🔂 One';
+      shuffleBtn.innerHTML = '🔂 <span class="shuffle-indicator">1</span>';
       shuffleStatusInfo.textContent = 'Repeat: On (Single Track)';
       console.log('Repeat mode: Single Track');
       shuffleQueue = [];
@@ -199,7 +199,7 @@ function toggleShuffle() {
     } else { // shuffleScope === 'repeat'
       shuffleScope = 'off';
       shuffleMode = false;
-      shuffleBtn.textContent = '🔀 Off';
+      shuffleBtn.innerHTML = '🔀';
       shuffleStatusInfo.textContent = 'Shuffle: Off';
       console.log('Shuffle mode: Off');
       shuffleQueue = [];

--- a/style.css
+++ b/style.css
@@ -257,6 +257,19 @@ body {
     transform: none;
 }
 
+.music-controls.icons-only .shuffle-button {
+    font-size: 1rem;
+}
+
+.music-controls.icons-only .shuffle-button .shuffle-indicator {
+    font-weight: bold;
+    color: var(--theme-color);
+    text-shadow: -1px -1px 0 #fff,
+                 1px -1px 0 #fff,
+                 -1px 1px 0 #fff,
+                 1px 1px 0 #fff;
+}
+
 /* Futuristic play button styling */
 .music-controls.icons-only .play-button {
     position: relative;


### PR DESCRIPTION
## Summary
- Show numbered shuffle states for album, all tracks, and single-track repeat
- Add bold, white-outlined styling to shuffle indicators for improved readability
- Apply new shuffle button class and adjust restoration logic

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9e7a92c988332be8b7a240ba90f7f