### PR TITLE
Reorder shuffle cycle

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -422,16 +422,16 @@
         shuffleMode = savedState.shuffleMode;
         shuffleScope = savedState.shuffleScope;
 
-        if (shuffleScope === 'album') {
+        if (shuffleScope === 'repeat') {
+          shuffleMode = false;
+          shuffleBtn.innerHTML = '🔂 <span class="shuffle-indicator">1</span>';
+          shuffleStatusInfo.textContent = 'Repeat: On (Single Track)';
+        } else if (shuffleScope === 'album') {
           shuffleBtn.innerHTML = '🔀 <span class="shuffle-indicator">2</span>';
           shuffleStatusInfo.textContent = 'Shuffle: On (Album)';
         } else if (shuffleScope === 'all') {
           shuffleBtn.innerHTML = '🔀 <span class="shuffle-indicator">3</span>';
           shuffleStatusInfo.textContent = 'Shuffle: On (All Tracks)';
-        } else if (shuffleScope === 'repeat') {
-          shuffleMode = false;
-          shuffleBtn.innerHTML = '🔂 <span class="shuffle-indicator">1</span>';
-          shuffleStatusInfo.textContent = 'Repeat: On (Single Track)';
         } else { // off
           shuffleBtn.innerHTML = '🔀';
           shuffleStatusInfo.textContent = 'Shuffle: Off';

--- a/scripts/ui.js
+++ b/scripts/ui.js
@@ -172,9 +172,17 @@ function toggleShuffle() {
       console.log('Shuffle mode: Off');
     }
   }
-  // If we are in album/track mode, cycle through off, album, all, repeat one
+  // If we are in album/track mode, cycle through off, repeat one, album, all
   else {
     if (shuffleScope === 'off') {
+      shuffleScope = 'repeat';
+      shuffleMode = false;
+      shuffleBtn.innerHTML = '🔂 <span class="shuffle-indicator">1</span>';
+      shuffleStatusInfo.textContent = 'Repeat: On (Single Track)';
+      console.log('Repeat mode: Single Track');
+      shuffleQueue = [];
+      updateNextTrackInfo();
+    } else if (shuffleScope === 'repeat') {
       shuffleScope = 'album';
       shuffleMode = true;
       shuffleBtn.innerHTML = '🔀 <span class="shuffle-indicator">2</span>';
@@ -188,15 +196,7 @@ function toggleShuffle() {
       shuffleStatusInfo.textContent = 'Shuffle: On (All Tracks)';
       console.log('Shuffle mode: All');
       buildShuffleQueue();
-    } else if (shuffleScope === 'all') {
-      shuffleScope = 'repeat';
-      shuffleMode = false;
-      shuffleBtn.innerHTML = '🔂 <span class="shuffle-indicator">1</span>';
-      shuffleStatusInfo.textContent = 'Repeat: On (Single Track)';
-      console.log('Repeat mode: Single Track');
-      shuffleQueue = [];
-      updateNextTrackInfo();
-    } else { // shuffleScope === 'repeat'
+    } else { // shuffleScope === 'all'
       shuffleScope = 'off';
       shuffleMode = false;
       shuffleBtn.innerHTML = '🔀';


### PR DESCRIPTION
## Summary
- Cycle shuffle modes in numeric order: repeat (1), album shuffle (2), all tracks (3)
- Align saved-state restoration with new shuffle order

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b9e968dbac833283d4c0d3e85d3cfd