### PR TITLE
Reduce edge panel icon size

### DIFF
--- a/main.html
+++ b/main.html
@@ -384,8 +384,8 @@
         right: 0;
     }
       .picture-game-float-icon, .cycle-precision-float-icon {
-      width: 50px;
-      height: 50px;
+      width: 40px;
+      height: 40px;
       border-radius: 50%;
       box-shadow: 0px 4px 10px rgba(0,0,0,0.3);
       animation: float 3s ease-in-out infinite;


### PR DESCRIPTION
## Summary
- Shrink edge panel icons to reduce visual footprint

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bafdb40e288332bc79e9769e3e777b