### PR TITLE
Use Playlist.jpg as playlist cover art

### DIFF
--- a/scripts/data.js
+++ b/scripts/data.js
@@ -186,10 +186,10 @@ function loadUserPlaylist() {
         track.lrc = track.src.replace(/\.mp3$/, '.lrc');
       }
     });
-    albums.push({ name: 'My Playlist', cover: `${BASE_URL}Logo.jpg`, tracks: stored });
+    albums.push({ name: 'My Playlist', cover: `${BASE_URL}Playlist.jpg`, tracks: stored });
     window.playlistAlbumIndex = albums.length - 1;
   } catch (e) {
-    albums.push({ name: 'My Playlist', cover: `${BASE_URL}Logo.jpg`, tracks: [] });
+    albums.push({ name: 'My Playlist', cover: `${BASE_URL}Playlist.jpg`, tracks: [] });
     window.playlistAlbumIndex = albums.length - 1;
   }
 }


### PR DESCRIPTION
## Summary
- Use dedicated `Playlist.jpg` image as the cover for the user-generated playlist.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb0514bb0c833297610eb7a9db984a