### PR TITLE
Add logo to main page header

### DIFF
--- a/main.html
+++ b/main.html
@@ -78,6 +78,13 @@
       box-shadow: 0px 5px 15px rgba(0,0,0,0.3);
       background: linear-gradient(135deg, var(--theme-color), #000);
       position: relative;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+    .header-logo {
+      height: 40px;
+      margin-right: 10px;
     }
     .share-button {
       position: absolute;
@@ -583,6 +590,7 @@
 
 <body>
   <div class="header">
+    <img src="Logo.jpg" alt="Ariyo AI Logo" class="header-logo" />
     Àríyò AI Studio
     <button class="share-button" aria-label="Share this page" onclick="shareContent()">
       <i class="fas fa-share-alt"></i>


### PR DESCRIPTION
## Summary
- display Ariyo AI logo alongside the main header
- center header content with flex styling for logo alignment

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bba3a0225083328323338255d286bc