### PR TITLE
fix: delay playback until ready

### DIFF
--- a/scripts/player.js
+++ b/scripts/player.js
@@ -487,7 +487,6 @@ function selectTrack(src, title, index, rebuildQueue = true) {
           if (shuffleMode && rebuildQueue) {
             buildShuffleQueue();
           }
-          playMusic();
         })
         .catch(err => {
           console.error('Error fetching track:', err);
@@ -533,7 +532,6 @@ function selectTrack(src, title, index, rebuildQueue = true) {
       handleAudioLoad(src, title, true);
       updateMediaSession();
       showNowPlayingToast(title);
-      playMusic();
       document.getElementById('main-content').innerHTML = '';
     }
 
@@ -562,9 +560,9 @@ function selectTrack(src, title, index, rebuildQueue = true) {
       audioPlayer.removeEventListener('error', onError);
 
       const playTimeout = setTimeout(() => {
-        console.warn(`Timeout: ${title} failed to buffer within 5 seconds, retrying...`);
+        console.warn(`Timeout: ${title} is taking a while to buffer, retrying...`);
         retryTrackWithDelay();
-      }, 5000);
+      }, 15000);
 
       function onProgress() {
         if (audioPlayer.buffered.length > 0 && audioPlayer.duration) {
@@ -682,7 +680,12 @@ function selectTrack(src, title, index, rebuildQueue = true) {
           trackInfo.textContent = 'Audio format not supported.';
           break;
         default:
-          trackInfo.textContent = 'An unknown error occurred.';
+          // Handle cases where error.code is undefined (e.g. DOMException from play())
+          if (error.name === 'NotAllowedError') {
+            trackInfo.textContent = 'Playback was blocked. Please interact with the page.';
+          } else {
+            trackInfo.textContent = 'Playback failed. Please try again.';
+          }
           break;
       }
     }
@@ -783,9 +786,6 @@ function selectTrack(src, title, index, rebuildQueue = true) {
             currentTrackIndex
           );
         }
-        setTimeout(() => {
-          playMusic();
-        }, 1000);
       }
     });
 


### PR DESCRIPTION
## Summary
- start playing tracks and radio only after audio can play
- extend buffering timeout to reduce premature retries
- show clearer message when playback is blocked

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc118404008332a908e4405db5c0cf