### PR TITLE
Adjust modal placement for mobile

### DIFF
--- a/main.html
+++ b/main.html
@@ -239,6 +239,11 @@
       overflow-y: auto;
       border-radius: 10px;
     }
+    @media (max-width: 768px) {
+      .modal-content {
+        margin: 15% auto; /* Lower modal on smaller screens */
+      }
+    }
     .modal-title {
       margin-top: 0;
       text-align: center;

--- a/style.css
+++ b/style.css
@@ -378,6 +378,12 @@ body {
     position: relative; /* Needed for sticky elements inside */
 }
 
+@media (max-width: 768px) {
+    .modal-content {
+        margin: 15% auto; /* Lower modal on smaller screens */
+    }
+}
+
 
 .close {
     color: #aaa;


### PR DESCRIPTION
## Summary
- Lower modals opened from the edge panel on small screens by increasing top margin
- Apply responsive rule in both global and inline styles so modals appear lower on mobile devices

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bcb6b06c3c83329af16a72f649e279