### PR TITLE
Align edge app modals with track modal offset

### DIFF
--- a/main.html
+++ b/main.html
@@ -274,7 +274,7 @@
     .track-list a:hover, .album-list a:hover, .radio-list a:hover { background-color: var(--theme-color); }
       .chatbot-container, #aboutModalContainer {
       position: fixed;
-      top: 0;
+      top: 70px;
       bottom: calc(80px + env(safe-area-inset-bottom));
       left: 50%;
       transform: translateX(-50%);
@@ -286,6 +286,11 @@
       overflow-y: auto;
       display: none;
       z-index: 10001;
+    }
+    @media (max-width: 768px) {
+      .chatbot-container, #aboutModalContainer {
+        top: 80px;
+      }
     }
       .chatbot-container iframe {
         display: block;


### PR DESCRIPTION
## Summary
- Lower edge-panel app popouts to align with track modal by setting a 70px top offset and 80px on small screens

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bd4f4e383083329a51797616d88887