### PR TITLE
Add idle redirect timer to index page

### DIFF
--- a/index.html
+++ b/index.html
@@ -83,7 +83,10 @@
             }).join('');
         });
 
+        let autoEnterTimeout;
+
         function enterApp() {
+            clearTimeout(autoEnterTimeout);
             const enterIcon = document.querySelector('.enter-icon');
             enterIcon.classList.add('clicked');
             const audio = document.getElementById('welcomeAudio');
@@ -138,6 +141,9 @@
                       playAudio();
                   }
               });
+
+              const delay = (Math.random() * 15000) + 45000;
+              autoEnterTimeout = setTimeout(enterApp, delay);
 
               // Attempt to keep audio playing even when the page is hidden
               document.addEventListener('visibilitychange', () => {


### PR DESCRIPTION
## Summary
- Add invisible timer on landing page that automatically redirects to main page after 45–60 seconds of inactivity
- Ensure timer cancels on manual entry to prevent duplicate navigation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bf76b433f4833280b661bb1a3bd79c