### PR TITLE
Add countdown timer bar to index page

### DIFF
--- a/index.css
+++ b/index.css
@@ -201,3 +201,19 @@ a {
     opacity: 1;
     background-image: url('Naija AI1.png');
 }
+
+#timer-bar {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 5px;
+    background-color: #ff0000;
+    z-index: 10000;
+}
+
+#timer-progress {
+    width: 100%;
+    height: 100%;
+    background-color: #4169E1;
+}

--- a/index.html
+++ b/index.html
@@ -28,6 +28,7 @@
     <link rel="apple-touch-icon" href="icons/Ariyo.png">
 </head>
 <body>
+    <div id="timer-bar"><div id="timer-progress"></div></div>
     <div id="background-container">
         <div id="bg1" class="bg-image"></div>
         <div id="bg2" class="bg-image"></div>
@@ -84,9 +85,11 @@
         });
 
         let autoEnterTimeout;
+        let countdownEndTimeout;
 
         function enterApp() {
             clearTimeout(autoEnterTimeout);
+            clearTimeout(countdownEndTimeout);
             const enterIcon = document.querySelector('.enter-icon');
             enterIcon.classList.add('clicked');
             const audio = document.getElementById('welcomeAudio');
@@ -142,8 +145,16 @@
                   }
               });
 
-              const delay = (Math.random() * 15000) + 45000;
-              autoEnterTimeout = setTimeout(enterApp, delay);
+              const timerProgress = document.getElementById('timer-progress');
+              const countdownDuration = 10; // seconds
+              timerProgress.style.transition = `width ${countdownDuration}s linear`;
+              setTimeout(() => {
+                  timerProgress.style.width = '0%';
+              }, 100);
+
+              countdownEndTimeout = setTimeout(() => {
+                  autoEnterTimeout = setTimeout(enterApp, 3000);
+              }, countdownDuration * 1000);
 
               // Attempt to keep audio playing even when the page is hidden
               document.addEventListener('visibilitychange', () => {


### PR DESCRIPTION
## Summary
- Add fixed timer bar to index page that shifts from blue to red as it counts down
- Automatically redirect to `main.html` three seconds after the countdown finishes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bf7872b45483328ca496693604c0f4