### PR TITLE
Center edge panel icons to avoid mobile side button overlap

### DIFF
--- a/main.html
+++ b/main.html
@@ -386,10 +386,11 @@
     .edge-panel-content {
         display: flex;
         flex-direction: column;
-        justify-content: flex-start;
+        justify-content: center;
         align-items: center;
         gap: 10px;
-        padding: 10px 0;
+        padding: 20px 0;
+        height: 100%;
     }
     .tap-area {
         position: fixed;

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -636,8 +636,8 @@
     // Dynamic Edge Panel Height
     const edgePanelContent = document.querySelector('.edge-panel-content');
     const icons = edgePanelContent.querySelectorAll('.chatbot-bubble-container, .picture-game-bubble-container, .tetris-bubble-container, .word-search-bubble-container, .connect-four-bubble-container, .cycle-precision-bubble-container');
-    const iconHeight = 50; // height of each icon
-    const iconSpacing = 20; // spacing between icons
+    const iconHeight = 40; // height of each icon matches CSS
+    const iconSpacing = 10; // spacing between icons matches CSS gap
     const panelPadding = 20; // top and bottom padding of the panel
     const panelHeight = (icons.length * iconHeight) + ((icons.length - 1) * iconSpacing) + (2 * panelPadding);
     document.getElementById('edgePanel').style.height = `${panelHeight}px`;


### PR DESCRIPTION
## Summary
- Vertically center edge panel icons and expand padding to keep them clear of device side buttons.
- Correct dynamic height calculation to use actual icon size and spacing.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c00ebf0b688332a47f581a1e0cd72f