### PR TITLE
Remove Noupe embed scripts

### DIFF
--- a/index.html
+++ b/index.html
@@ -212,6 +212,5 @@
     </script>
     <script src="user-tracking.js"></script>
     <script src="prevent-zoom.js"></script>
-    <script src="https://www.noupe.com/embed/019934871d487c14970af529da9dd6f6329a.js"></script>
 </body>
 </html>

--- a/main.html
+++ b/main.html
@@ -857,6 +857,5 @@
         }).join('');
     });
   </script>
-  <script src="https://www.noupe.com/embed/019934871d487c14970af529da9dd6f6329a.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- remove external Noupe embed script from landing page
- drop Noupe embed from main page leaving watermark script

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1aeb2cc148332bcdf05faa3b8c1d4