### PR TITLE
Add Envy track to Omoluabi Production Catalogue

### DIFF
--- a/Omoluabi_Production_Catalogue.md
+++ b/Omoluabi_Production_Catalogue.md
@@ -33,3 +33,4 @@
 - [Moore’s Law](https://suno.com/s/iFtc3kKNJegGFVcN)
 - [Her Daughter's Father](https://suno.com/s/SO1sQiwoprmyz5oz)
 - [Same Ni](https://suno.com/s/PGWO82Zq1B7ur40J)
+- [Envy](https://suno.com/s/0IWYQ7LLnvJwVseh)

--- a/scripts/data.js
+++ b/scripts/data.js
@@ -162,7 +162,8 @@ const albums = [
             { src: 'https://cdn1.suno.ai/471dc968-d463-435c-8c3d-85f0d4556d8f.mp3', title: 'Pass The Baton' },
             { src: 'https://cdn1.suno.ai/891af5b2-b1fe-4db2-9c99-e1b1a15697a2.mp3', title: 'Moore’s Law' },
             { src: 'https://cdn1.suno.ai/b35932ed-2188-4780-a919-f5327317915b.mp3', title: "Her Daughter's Father" },
-            { src: 'https://cdn1.suno.ai/473edd61-d1ba-4bad-8014-7302cd1a9b71.mp3', title: 'Same Ni' }
+            { src: 'https://cdn1.suno.ai/473edd61-d1ba-4bad-8014-7302cd1a9b71.mp3', title: 'Same Ni' },
+            { src: 'https://cdn1.suno.ai/553eefd4-54ba-4b73-ba02-4df85bfb5bb0.mp3', title: 'Envy' }
         ]
       },
     ];


### PR DESCRIPTION
## Summary
- add link for new track "Envy" to the Omoluabi production catalogue
- ensure "Envy" appears in the track modal by adding it to album data

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c65d1fbc70833281e38d26bff63b62