### PR TITLE
Expand modal dialogs to full-height layout

### DIFF
--- a/main.html
+++ b/main.html
@@ -223,32 +223,35 @@
       display: none;
       position: fixed;
       z-index: 999;
-      left: 0;
-      top: 0;
+      inset: 0;
       width: 100%;
       height: 100%;
       overflow: auto;
       background-color: rgba(0,0,0,0.4);
-      padding-top: 70px; /* Push modal below header */
       box-sizing: border-box;
+      padding: var(--modal-block-padding) var(--modal-inline-padding);
+      align-items: stretch;
+      justify-content: center;
     }
     .modal-content {
       background-color: #fefefe;
-      margin: 0 auto;
+      margin: 0;
       padding: 1.5rem;
       border: 1px solid #888;
-      width: 90%;
-      max-width: 600px;
-      max-height: calc(var(--app-height, 100vh) - 120px);
+      width: min(100%, 600px);
+      max-height: calc(var(--app-height, 100vh) - 2 * var(--modal-block-padding));
       overflow-y: auto;
       border-radius: 10px;
+      display: flex;
+      flex-direction: column;
+      flex: 1 1 auto;
     }
     @media (max-width: 768px) {
       .modal {
-        padding-top: 80px; /* Extra space on smaller screens */
+        padding: var(--modal-block-padding) clamp(0.75rem, 5vw, 1.5rem);
       }
       .modal-content {
-        max-height: calc(var(--app-height, 100vh) - 140px);
+        width: 100%;
       }
     }
     .modal-title {
@@ -276,12 +279,11 @@
     .track-list a:hover, .album-list a:hover, .radio-list a:hover { background-color: var(--theme-color); }
       .chatbot-container, #aboutModalContainer {
       position: fixed;
-      top: 70px;
-      bottom: calc(80px + env(safe-area-inset-bottom));
+      top: var(--modal-block-padding);
+      bottom: calc(var(--modal-block-padding) + env(safe-area-inset-bottom));
       left: 50%;
       transform: translateX(-50%);
-      width: 90%;
-      max-width: 600px;
+      width: min(100%, 600px);
       border-radius: 10px;
       box-shadow: 0px 4px 10px rgba(0,0,0,0.3);
       background: white;
@@ -291,7 +293,7 @@
     }
     @media (max-width: 768px) {
       .chatbot-container, #aboutModalContainer {
-        top: 80px;
+        width: 94%;
       }
     }
       .chatbot-container iframe {

--- a/scripts/ui.js
+++ b/scripts/ui.js
@@ -64,7 +64,7 @@ function openAlbumList() {
 
       populateAlbumList();
 
-      modal.style.display = 'block';
+      modal.style.display = 'flex';
 
       gsap.fromTo(modalContent,
         { scale: 0.8, opacity: 0, y: 50 },
@@ -92,7 +92,7 @@ function openAlbumList() {
     function openTrackList() {
       updateTrackListModal();
       const modal = document.getElementById('trackModal');
-      modal.style.display = 'block';
+      modal.style.display = 'flex';
       gsap.fromTo(modal.querySelector('.modal-content'),
         { scale: 0.8, opacity: 0, y: 50 },
         { scale: 1, opacity: 1, y: 0, duration: 0.5, ease: "power2.out" }
@@ -122,7 +122,7 @@ function openAlbumList() {
       const modal = document.getElementById('radioModal');
       const modalContent = modal.querySelector('.modal-content');
 
-      modal.style.display = 'block';
+      modal.style.display = 'flex';
 
       gsap.fromTo(modalContent,
         { scale: 0.8, opacity: 0, y: 50 },

--- a/style.css
+++ b/style.css
@@ -22,6 +22,11 @@ body {
     text-shadow: 1px 1px 2px #000;
 }
 
+:root {
+    --modal-block-padding: clamp(1rem, 4vh, 2.5rem);
+    --modal-inline-padding: clamp(1rem, 6vw, 3rem);
+}
+
 .news-banner {
     position: fixed;
     bottom: 0;
@@ -355,38 +360,41 @@ body {
     display: none;
     position: fixed;
     z-index: 1001;
-    left: 0;
-    top: 0;
+    inset: 0;
     width: 100%;
     height: 100%;
     overflow: auto;
     background-color: rgba(0,0,0,0.4);
-    padding-top: 70px; /* Push modal below header */
     box-sizing: border-box;
+    padding: var(--modal-block-padding) var(--modal-inline-padding);
+    align-items: stretch;
+    justify-content: center;
 }
 
 
 .modal-content {
     background-color: #222;
-    margin: 0 auto; /* Center horizontally while allowing top padding to control offset */
+    margin: 0;
     padding: 1.5rem;
     border: 1px solid #888;
-    width: 80%; /* Reduce width */
-    max-width: 500px; /* Reduce max width */
-    max-height: calc(var(--app-height, 100vh) - 120px); /* Ensure full modal fits within viewport */
+    width: min(100%, 520px);
+    max-height: calc(var(--app-height, 100vh) - 2 * var(--modal-block-padding));
     overflow-y: auto;
     border-radius: 10px;
     color: #fff;
     position: relative; /* Needed for sticky elements inside */
+    display: flex;
+    flex-direction: column;
+    flex: 1 1 auto;
 }
 
 @media (max-width: 768px) {
     .modal {
-        padding-top: 80px; /* Extra space on smaller screens */
+        padding: var(--modal-block-padding) clamp(0.75rem, 5vw, 1.5rem);
     }
     .modal-content {
-        width: 90%;
-        max-height: calc(var(--app-height, 100vh) - 140px); /* Keep modal fully visible on mobile */
+        width: 100%;
+        max-height: calc(var(--app-height, 100vh) - 2 * var(--modal-block-padding));
     }
 }
 


### PR DESCRIPTION
## Summary
- allow shared modal styles to stretch across the full viewport with responsive padding
- update main page modal and about container rules to share the new spacing tokens
- switch modal open handlers to use flex layout so album, track and radio sheets fill the screen

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc1c63d2908332a4115f4c4de7da79