### PR TITLE
Switch to Lagos Sunset palette

### DIFF
--- a/color-scheme.css
+++ b/color-scheme.css
@@ -1,8 +1,8 @@
-/* Vibrant royal blue color scheme */
+/* Lagos Sunset warm gradient theme */
 :root {
-  --theme-color: #4169E1;
-  --gradient-start: var(--theme-color);
-  --gradient-end: #27408B;
+  --theme-color: #F97316;
+  --gradient-start: #F97316;
+  --gradient-end: #C026D3;
 }
 
 body {

--- a/color-scheme.js
+++ b/color-scheme.js
@@ -3,9 +3,9 @@ function changeColorScheme() {
 }
 
 function applyTheme() {
-    const themeColor = '#4169E1';
-    const gradStart = themeColor;
-    const gradEnd = '#27408B';
+    const themeColor = '#F97316';
+    const gradStart = '#F97316';
+    const gradEnd = '#C026D3';
     const style = document.getElementById('theme-style') || document.createElement('style');
     style.id = 'theme-style';
     style.innerHTML = `
@@ -18,7 +18,7 @@ function applyTheme() {
     .progress-bar div { background: ${themeColor}; }
     .install-btn { background: ${themeColor}; }
     #start-button { background-color: ${themeColor}; }
-    body { color: #000000; }
+    body { color: #F8FAFC; }
   `;
     document.head.appendChild(style);
     const metaTheme = document.querySelector('meta[name="theme-color"]');


### PR DESCRIPTION
## Summary
- update the theme variables to use the warm Lagos Sunset gradient
- align the runtime color scheme script with the new palette and keep text legible on the dark canvas

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cf51bd15e083329bfea1c8824fc6eb