### PR TITLE
Align track modals with desired height

### DIFF
--- a/main.html
+++ b/main.html
@@ -239,6 +239,7 @@
       padding: 1.5rem;
       border: 1px solid #888;
       width: min(100%, 600px);
+      height: calc(var(--app-height, 100vh) - 2 * var(--modal-block-padding));
       max-height: calc(var(--app-height, 100vh) - 2 * var(--modal-block-padding));
       overflow-y: auto;
       border-radius: 10px;
@@ -252,6 +253,8 @@
       }
       .modal-content {
         width: 100%;
+        height: calc(var(--app-height, 100vh) - 2 * var(--modal-block-padding));
+        max-height: calc(var(--app-height, 100vh) - 2 * var(--modal-block-padding));
       }
     }
     .modal-title {

--- a/style.css
+++ b/style.css
@@ -443,6 +443,7 @@ body {
     padding: 1.5rem;
     border: 1px solid #888;
     width: min(100%, 520px);
+    height: calc(var(--app-height, 100vh) - 2 * var(--modal-block-padding));
     max-height: calc(var(--app-height, 100vh) - 2 * var(--modal-block-padding));
     overflow-y: auto;
     border-radius: 10px;
@@ -459,6 +460,7 @@ body {
     }
     .modal-content {
         width: 100%;
+        height: calc(var(--app-height, 100vh) - 2 * var(--modal-block-padding));
         max-height: calc(var(--app-height, 100vh) - 2 * var(--modal-block-padding));
     }
 }


### PR DESCRIPTION
## Summary
- set modal content panels to use the full viewport height minus modal padding for consistent sizing
- mirror the same height rules in the inline stylesheet fallback used by main.html

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d9c0143e9c8332be7d6092e7b51c53