### PR TITLE
Add realistic vinyl grooves to album art

### DIFF
--- a/main.html
+++ b/main.html
@@ -648,6 +648,7 @@
             alt="Album Cover"
             onerror="this.onerror=null;this.src='Logo.jpg';"
           />
+          <span class="album-groove-overlay" aria-hidden="true"></span>
           <span class="turntable-label" aria-hidden="true"></span>
         </div>
         <span class="turntable-sheen" aria-hidden="true"></span>

--- a/style.css
+++ b/style.css
@@ -219,6 +219,7 @@ body {
 }
 
 .turntable-disc {
+    --album-size: 46%;
     position: relative;
     width: 86%;
     aspect-ratio: 1 / 1;
@@ -236,6 +237,7 @@ body {
 .turntable-sheen,
 .turntable-grooves,
 .album-cover,
+.album-groove-overlay,
 .turntable-label {
     position: absolute;
     border-radius: 50%;
@@ -247,7 +249,7 @@ body {
     background: linear-gradient(135deg, rgba(255, 255, 255, 0.32), rgba(255, 255, 255, 0) 45%);
     mix-blend-mode: screen;
     opacity: 0.35;
-    z-index: 5;
+    z-index: 6;
 }
 
 .turntable-grooves {
@@ -263,10 +265,11 @@ body {
 }
 
 .album-cover {
-    width: 46%;
+    width: var(--album-size);
     aspect-ratio: 1 / 1;
     object-fit: cover;
     border-radius: 50%;
+    clip-path: circle(50% at 50% 50%);
     display: block;
     top: 50%;
     left: 50%;
@@ -277,6 +280,31 @@ body {
     transition: transform 0.3s ease-in-out;
 }
 
+.album-groove-overlay {
+    position: absolute;
+    width: var(--album-size);
+    aspect-ratio: 1 / 1;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    border-radius: 50%;
+    pointer-events: none;
+    background:
+        radial-gradient(circle at 50% 45%, rgba(255, 255, 255, 0.28), rgba(255, 255, 255, 0) 62%),
+        repeating-radial-gradient(circle at center,
+            rgba(16, 16, 16, 0.4) 0px,
+            rgba(16, 16, 16, 0.4) 1.5px,
+            rgba(240, 240, 240, 0.12) 1.5px,
+            rgba(240, 240, 240, 0.12) 3.2px);
+    mix-blend-mode: soft-light;
+    opacity: 0.9;
+    filter: saturate(0.9) contrast(1.05);
+    z-index: 4;
+    box-shadow:
+        inset 0 0 18px rgba(0, 0, 0, 0.55),
+        inset 0 0 4px rgba(255, 255, 255, 0.15);
+}
+
 .turntable-label {
     width: 14%;
     aspect-ratio: 1 / 1;
@@ -285,7 +313,7 @@ body {
     transform: translate(-50%, -50%);
     background: radial-gradient(circle, #f5f5f5 0%, #d0d0d0 60%, #7f7f7f 100%);
     box-shadow: inset 0 0 6px rgba(0, 0, 0, 0.45);
-    z-index: 4;
+    z-index: 5;
 }
 
 .turntable-disc.spin {


### PR DESCRIPTION
## Summary
- add a dedicated groove overlay element inside the turntable to layer with the vinyl
- update the album art styling so the label area stays perfectly circular while grooves show through

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68db5e6d98a48332a24296e3e01db951