### PR TITLE
Fix album art circle alignment on turntable

### DIFF
--- a/style.css
+++ b/style.css
@@ -266,6 +266,7 @@ body {
 
 .album-cover {
     width: var(--album-size);
+    height: var(--album-size);
     aspect-ratio: 1 / 1;
     object-fit: cover;
     border-radius: 50%;
@@ -283,6 +284,7 @@ body {
 .album-groove-overlay {
     position: absolute;
     width: var(--album-size);
+    height: var(--album-size);
     aspect-ratio: 1 / 1;
     top: 50%;
     left: 50%;


### PR DESCRIPTION
## Summary
- set explicit height on the main album cover and overlay so the artwork matches the vinyl's circular frame

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68db5ff2ec888332af4a6532a948bd9a