### PR TITLE
Refresh color theme to Atlantic Dawn palette

### DIFF
--- a/about.html
+++ b/about.html
@@ -8,7 +8,7 @@
   <meta name="apple-mobile-web-app-title" content="Àríyò AI" />
   <meta name="apple-touch-fullscreen" content="yes" />
   <link rel="apple-touch-icon" href="icons/Ariyo.png">
-  <meta name="theme-color" content="#4169E1" />
+  <meta name="theme-color" content="#0EA5E9" />
   <title>About - Àríyò AI</title>
   <meta name="description" content="Learn more about Àríyò AI, a smart Naija AI powered by Omoluabi. Discover our mission, our music, and our team." />
   <meta name="keywords" content="About Àríyò AI, Omoluabi, Paul A.K. Iyogun, Nigerian AI, AI music" />

--- a/color-scheme.css
+++ b/color-scheme.css
@@ -1,8 +1,8 @@
-/* Lagos Sunset warm gradient theme */
+/* Atlantic Dawn cool gradient theme */
 :root {
-  --theme-color: #F97316;
-  --gradient-start: #F97316;
-  --gradient-end: #C026D3;
+  --theme-color: #0EA5E9;
+  --gradient-start: #0EA5E9;
+  --gradient-end: #6366F1;
 }
 
 body {

--- a/color-scheme.js
+++ b/color-scheme.js
@@ -3,9 +3,9 @@ function changeColorScheme() {
 }
 
 function applyTheme() {
-    const themeColor = '#F97316';
-    const gradStart = '#F97316';
-    const gradEnd = '#C026D3';
+    const themeColor = '#0EA5E9';
+    const gradStart = '#0EA5E9';
+    const gradEnd = '#6366F1';
     const style = document.getElementById('theme-style') || document.createElement('style');
     style.id = 'theme-style';
     style.innerHTML = `

--- a/index.css
+++ b/index.css
@@ -5,7 +5,11 @@
 body {
     margin: 0;
     font-family: 'Montserrat', sans-serif;
-    background-color: #000;
+    background-color: #020617;
+    background-image:
+        radial-gradient(120% 120% at 15% 20%, rgba(14, 165, 233, 0.38), rgba(2, 6, 23, 0.92) 65%),
+        radial-gradient(120% 120% at 85% 25%, rgba(99, 102, 241, 0.35), rgba(2, 6, 23, 0.95) 60%),
+        radial-gradient(150% 140% at 50% 85%, rgba(45, 212, 191, 0.22), rgba(2, 6, 23, 0.95) 70%);
     color: #f7f9ff;
     text-shadow: 0 12px 35px rgba(0, 0, 0, 0.65);
     display: flex;
@@ -16,7 +20,7 @@ body {
     box-sizing: border-box;
     text-align: center;
     position: relative;
-    transition: background-color 0.5s ease-in-out;
+    transition: background 0.5s ease-in-out, background-color 0.5s ease-in-out;
 }
 
 .countdown {
@@ -30,18 +34,18 @@ body {
 }
 
 .countdown.red-on-black {
-    color: #ff0000;
-    background-color: #000;
+    color: var(--theme-color, #0EA5E9);
+    background-color: #020617;
 }
 
 .countdown.black-on-red {
-    color: #000;
-    background-color: #ff0000;
+    color: #020617;
+    background-color: var(--theme-color, #0EA5E9);
 }
 
 
 .overlay {
-    background: rgba(8, 14, 32, 0.65);
+    background: rgba(7, 14, 32, 0.7);
     backdrop-filter: blur(18px);
     padding: clamp(1.5rem, 5vw, 2.75rem);
     border-radius: 24px;
@@ -54,7 +58,7 @@ body {
     flex-direction: column;
     gap: clamp(1.5rem, 4vw, 2.5rem);
     box-shadow: 0 35px 70px rgba(0, 0, 0, 0.45);
-    border: 1px solid rgba(255, 255, 255, 0.08);
+    border: 1px solid rgba(14, 165, 233, 0.18);
 }
 
 h1, p, .feature-card, footer {
@@ -74,7 +78,7 @@ p {
 }
 
 a {
-    color: #fbeaff;
+    color: #7dd3fc;
 }
 
 .hero-header {
@@ -87,7 +91,7 @@ a {
     text-transform: uppercase;
     letter-spacing: 0.35rem;
     font-size: 0.75rem;
-    color: rgba(255, 255, 255, 0.65);
+    color: rgba(14, 165, 233, 0.75);
     font-weight: 700;
 }
 
@@ -119,8 +123,8 @@ a {
     justify-content: center;
     gap: 0.45rem;
     padding: 0.85rem 1.1rem;
-    background: linear-gradient(135deg, rgba(96, 165, 250, 0.2), rgba(192, 132, 252, 0.6));
-    border: 1px solid rgba(255, 255, 255, 0.25);
+    background: linear-gradient(135deg, rgba(14, 165, 233, 0.28), rgba(99, 102, 241, 0.6));
+    border: 1px solid rgba(14, 165, 233, 0.35);
     border-radius: 18px;
     cursor: pointer;
     transition: transform 0.3s ease, box-shadow 0.3s ease;
@@ -129,7 +133,7 @@ a {
 
 .enter-button:hover {
     transform: translateY(-4px) scale(1.02);
-    box-shadow: 0 18px 30px rgba(45, 75, 168, 0.35);
+    box-shadow: 0 18px 30px rgba(14, 165, 233, 0.35);
 }
 
 .enter-button.clicked {
@@ -172,14 +176,14 @@ a {
 }
 
 .feature-card {
-    background: rgba(20, 32, 64, 0.55);
-    border: 1px solid rgba(255, 255, 255, 0.12);
+    background: rgba(8, 31, 54, 0.6);
+    border: 1px solid rgba(14, 165, 233, 0.15);
     border-radius: 18px;
     padding: clamp(1rem, 3vw, 1.35rem);
     display: flex;
     flex-direction: column;
     gap: 0.65rem;
-    box-shadow: 0 20px 35px rgba(0, 0, 0, 0.35);
+    box-shadow: 0 20px 35px rgba(7, 12, 27, 0.55);
     transition: transform 0.3s ease, border-color 0.3s ease, box-shadow 0.3s ease;
     opacity: 0.82;
 }
@@ -187,8 +191,8 @@ a {
 .feature-card:hover,
 .feature-card.feature-active {
     transform: translateY(-6px);
-    border-color: rgba(255, 255, 255, 0.35);
-    box-shadow: 0 25px 40px rgba(51, 102, 204, 0.35);
+    border-color: rgba(14, 165, 233, 0.45);
+    box-shadow: 0 25px 40px rgba(14, 165, 233, 0.35);
     opacity: 1;
 }
 
@@ -300,8 +304,8 @@ a {
     animation: bounce 1s infinite;
     width: 36px;
     height: 36px;
-    fill: red;
-    stroke: red;
+    fill: var(--theme-color, #0EA5E9);
+    stroke: var(--theme-color, #0EA5E9);
 }
 .floating-watermarks {
     pointer-events: none;
@@ -377,7 +381,7 @@ a {
     transform: translateX(-50%);
     width: min(420px, 90vw);
     height: 10px;
-    background: rgba(255, 255, 255, 0.12);
+    background: rgba(14, 165, 233, 0.15);
     z-index: 10000;
     border-radius: 999px;
     overflow: hidden;
@@ -389,7 +393,7 @@ a {
 #timer-progress {
     width: 100%;
     height: 100%;
-    background: linear-gradient(90deg, #ff6b6b 0%, #fbbf24 40%, #4ade80 100%);
+    background: linear-gradient(90deg, #0EA5E9 0%, #2DD4BF 45%, #6366F1 100%);
     position: relative;
     border-radius: inherit;
     box-shadow: inset 0 0 12px rgba(0, 0, 0, 0.25);

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
   <meta name="apple-mobile-web-app-title" content="Àríyò AI" />
   <meta name="apple-touch-fullscreen" content="yes" />
-  <meta name="theme-color" content="#4169E1" />
+  <meta name="theme-color" content="#0EA5E9" />
   <meta name="description" content="Àríyò AI by Paul A.K. Iyogun (Omoluabi) is a smart Nigerian music assistant featuring Ariyo AI." />
   <meta name="keywords" content="Paul Iyogun, Omoluabi, Àríyò AI, Ariyo, Nigerian music, Naija AI, AI chatbot, PWA" />
   <meta property="og:title" content="Àríyò AI - Smart Naija AI by Paul Iyogun" />

--- a/main.html
+++ b/main.html
@@ -10,7 +10,7 @@
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
   <meta name="apple-mobile-web-app-title" content="Àríyò AI">
   <meta name="apple-touch-fullscreen" content="yes">
-  <meta name="theme-color" content="#4169E1" />
+  <meta name="theme-color" content="#0EA5E9" />
   <link rel="manifest" href="manifest.json">
   <link rel="apple-touch-icon" href="icons/Ariyo.png">
   <meta name="description" content="Àríyò AI is a web-based music player that provides a unique and culturally-rich experience for users. It features a curated selection of Nigerian music and the Ariyo AI assistant." />


### PR DESCRIPTION
## Summary
- swap the previous warm gradient for a cool Atlantic Dawn palette in the shared color scheme assets
- restyle landing page accents (background, CTA, feature cards, timer, speaker icon) to match the refreshed colorway
- align meta theme-color tags across entry points to provide consistent browser chrome coloring

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e186cfe8d883328dc3d4b27ba56bcc