### PR TITLE
Add latest catalogue track notification

### DIFF
--- a/main.html
+++ b/main.html
@@ -716,6 +716,16 @@
     <div class="modal-content">
       <button class="close ripple shockwave" role="button" aria-label="Close track list" onclick="closeTrackList()">×</button>
       <h3 id="trackModalTitle">Choose A Track</h3>
+      <div id="latestTracksBanner" class="latest-tracks-banner" role="status" aria-live="polite" hidden>
+        <div class="latest-tracks-header">
+          <span class="latest-tracks-badge" aria-hidden="true">NEW</span>
+          <div class="latest-tracks-text">
+            <p class="latest-tracks-title">Fresh drop alert</p>
+            <p class="latest-tracks-copy" id="latestTracksCopy"></p>
+          </div>
+        </div>
+        <div class="latest-tracks-actions" id="latestTracksActions"></div>
+      </div>
       <div class="track-list">
         <!-- Dynamically populated -->
       </div>

--- a/scripts/data.js
+++ b/scripts/data.js
@@ -135,6 +135,7 @@ const albums = [
             { src: 'https://cdn1.suno.ai/5c17dd10-1770-467a-947a-db773c72ec78.mp3', title: 'Watchman' },
             { src: 'https://cdn1.suno.ai/fb1daddf-1de4-4164-bb9d-113f9639d732.mp3', title: 'Ọmọlúàbí' },
             { src: 'https://cdn1.suno.ai/d3ec2b0a-6062-417f-a62c-4d746f7f4f57.mp3', title: 'Take The Risk' },
+            { src: 'https://cdn1.suno.ai/08a939af-4823-4054-bef6-1b8420857d9c.mp3', title: 'Home That Looks Safe' },
             { src: 'https://cdn1.suno.ai/d5669af3-5caf-49e2-aca4-47fbc73a6d25.mp3', title: 'TikTok' },
             { src: 'https://cdn1.suno.ai/800b9280-4389-47f6-b20d-6aa7dd3298ad.mp3', title: 'Something Is About To Happen' },
             { src: 'https://cdn1.suno.ai/160aa857-a65f-4f60-9217-6045b2091183.mp3', title: 'Haters' },
@@ -169,6 +170,15 @@ const albums = [
         ]
       },
     ];
+
+const latestTracks = [
+  {
+    albumName: 'Omoluabi Production Catalogue',
+    title: 'Home That Looks Safe',
+    src: 'https://cdn1.suno.ai/08a939af-4823-4054-bef6-1b8420857d9c.mp3',
+    addedOn: '2024-05-06'
+  }
+];
 
 // Shuffle albums so they appear in a random order on each page load
 function shuffle(array) {

--- a/scripts/player.js
+++ b/scripts/player.js
@@ -397,6 +397,51 @@ function removeTrackFromPlaylist(index) {
       trackModalTitle.textContent = albums[albumIndex].name;
       trackListContainer.innerHTML = '';
 
+      const banner = document.getElementById('latestTracksBanner');
+      const bannerCopy = document.getElementById('latestTracksCopy');
+      const bannerActions = document.getElementById('latestTracksActions');
+      if (banner && bannerCopy && bannerActions) {
+        bannerActions.innerHTML = '';
+        if (Array.isArray(latestTracks) && latestTracks.length) {
+          const albumName = albums[albumIndex].name;
+          const albumHighlights = latestTracks.filter(track => track.albumName === albumName);
+          const announcementList = (albumHighlights.length ? albumHighlights : latestTracks)
+            .map(track => `“${track.title}”${albumHighlights.length ? '' : ` (${track.albumName})`}`)
+            .join(', ');
+          const intro = albumHighlights.length ? `New in ${albumName}` : 'Latest arrivals across Àríyò AI';
+          bannerCopy.textContent = `${intro}: ${announcementList}. Tap a button below to play instantly.`;
+          latestTracks.forEach(track => {
+            const button = document.createElement('button');
+            button.type = 'button';
+            button.className = 'latest-track-button';
+            button.textContent = `▶ Play “${track.title}”`;
+            button.setAttribute('aria-label', `Play the latest track ${track.title}`);
+            button.addEventListener('click', () => {
+              const albumIdx = albums.findIndex(album => album.name === track.albumName);
+              if (albumIdx === -1) {
+                return;
+              }
+              const trackIdx = albums[albumIdx].tracks.findIndex(albumTrack => albumTrack.title === track.title && albumTrack.src === track.src);
+              if (trackIdx === -1) {
+                pendingAlbumIndex = albumIdx;
+                currentAlbumIndex = albumIdx;
+                updateTrackListModal();
+                return;
+              }
+              currentAlbumIndex = albumIdx;
+              pendingAlbumIndex = null;
+              selectTrack(albums[albumIdx].tracks[trackIdx].src, albums[albumIdx].tracks[trackIdx].title, trackIdx);
+            });
+            bannerActions.appendChild(button);
+          });
+          banner.hidden = false;
+        } else {
+          banner.hidden = true;
+          bannerCopy.textContent = '';
+          bannerActions.innerHTML = '';
+        }
+      }
+
       // Build an array of track indices and shuffle them (except for playlist)
       let trackIndices = albums[albumIndex].tracks.map((_, i) => i);
       if (albumIndex !== playlistAlbumIndex) {

--- a/scripts/ui.js
+++ b/scripts/ui.js
@@ -31,6 +31,13 @@ function populateAlbumList() {
 
     const name = document.createElement('p');
     name.textContent = `Album ${index + 1}: ${album.name}`;
+    if (typeof latestTracks !== 'undefined' && latestTracks.some(track => track.albumName === album.name)) {
+      const badge = document.createElement('span');
+      badge.className = 'album-new-badge';
+      badge.textContent = 'NEW';
+      badge.title = 'Contains freshly added tracks';
+      name.appendChild(badge);
+    }
 
     const durationEl = document.createElement('p');
     durationEl.className = 'album-duration';

--- a/style.css
+++ b/style.css
@@ -514,6 +514,90 @@ body {
     flex: 1 1 auto;
 }
 
+.latest-tracks-banner {
+    border: 1px solid var(--theme-color);
+    background: rgba(14, 165, 233, 0.12);
+    border-radius: 12px;
+    padding: 1rem;
+    margin-bottom: 1rem;
+    display: none;
+    gap: 0.75rem;
+}
+
+.latest-tracks-banner:not([hidden]) {
+    display: flex;
+    flex-direction: column;
+}
+
+.latest-tracks-header {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+.latest-tracks-badge {
+    background: var(--theme-color);
+    color: #000;
+    font-weight: 700;
+    border-radius: 999px;
+    padding: 0.2rem 0.7rem;
+    font-size: clamp(0.65rem, 2vw, 0.75rem);
+    letter-spacing: 0.08em;
+    box-shadow: 0 0 10px rgba(14, 165, 233, 0.5);
+}
+
+.latest-tracks-text {
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+}
+
+.latest-tracks-title {
+    margin: 0;
+    font-size: clamp(0.9rem, 2.2vw, 1.1rem);
+    font-weight: 700;
+    text-transform: uppercase;
+    color: var(--theme-color);
+}
+
+.latest-tracks-copy {
+    margin: 0;
+    font-size: clamp(0.8rem, 2vw, 0.95rem);
+    color: #e0f4ff;
+}
+
+.latest-tracks-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+}
+
+.latest-track-button {
+    background: var(--theme-color);
+    border: none;
+    color: #000;
+    font-weight: 600;
+    border-radius: 999px;
+    padding: 0.5rem 1.1rem;
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+}
+
+.latest-track-button:hover,
+.latest-track-button:focus {
+    transform: translateY(-1px);
+    box-shadow: 0 4px 12px rgba(14, 165, 233, 0.5);
+    outline: none;
+}
+
+.latest-track-button:focus-visible {
+    outline: 2px solid #fff;
+    outline-offset: 2px;
+}
+
 @media (max-width: 768px) {
     .modal {
         padding: var(--modal-block-padding) clamp(0.75rem, 5vw, 1.5rem);
@@ -584,6 +668,20 @@ body {
 .album-info {
     display: flex;
     flex-direction: column;
+}
+
+.album-new-badge {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--theme-color);
+    color: #000;
+    border-radius: 999px;
+    padding: 0.1rem 0.5rem;
+    font-size: clamp(0.65rem, 2vw, 0.75rem);
+    font-weight: 700;
+    margin-left: 0.4rem;
+    box-shadow: 0 0 8px rgba(14, 165, 233, 0.45);
 }
 
 .album-info p {


### PR DESCRIPTION
## Summary
- add "Home That Looks Safe" to the Omoluabi Production Catalogue data set and mark it as a latest track
- surface a latest track banner inside the track modal with quick-play actions for recent releases and show badges on albums with new additions
- style the banner and album badge to match the existing theme

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68eb51e027508332bf74ca60641ce24c