### PR TITLE
Fix YouTube embed by using channel uploads playlist

### DIFF
--- a/main.html
+++ b/main.html
@@ -848,7 +848,7 @@
     <div class="youtube-embed-wrapper">
         <iframe
             class="youtube-frame"
-            src="https://www.youtube.com/embed?listType=user_uploads&amp;list=omoluabipaul"
+            src="https://www.youtube.com/embed/videoseries?list=UUzkQQysk1Afxsc-bRh1mYpg"
             title="Omoluabi Paul YouTube uploads"
             loading="lazy"
             referrerpolicy="strict-origin-when-cross-origin"


### PR DESCRIPTION
## Summary
- point the embedded YouTube iframe at the Omoluabi Paul channel uploads playlist so the stream loads correctly in the modal

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68ed04113e388332b19f0386c2e443bb