### PR TITLE
Fix edge panel launchers to load correct apps

### DIFF
--- a/main.html
+++ b/main.html
@@ -807,35 +807,35 @@
     <div class="edge-panel-handle"></div>
     <div class="edge-panel-content">
         <!-- Ariyo AI Floating Icon -->
-        <div class="chatbot-bubble-container edge-panel-launcher" role="button" aria-label="Open Ariyo AI" aria-controls="ariyoChatbotContainer" tabindex="0" data-open-target="ariyoChatbotContainer">
+        <div class="chatbot-bubble-container edge-panel-launcher" role="button" aria-label="Open Ariyo AI" aria-controls="ariyoChatbotContainer" tabindex="0" data-open-target="ariyoChatbotContainer" data-open-src="apps/ariyo-ai-chat/ariyo-ai-chat.html">
             <img src="https://raw.githubusercontent.com/Omoluabi1003/Ariyo-AI/main/Ariyo%20AI%20icon.png" alt="Ariyo AI Icon" class="picture-game-float-icon" />
         </div>
         <!-- Sabi Bible Floating Icon -->
-        <div class="chatbot-bubble-container edge-panel-launcher" role="button" aria-label="Open Sabi Bible" aria-controls="sabiBibleContainer" tabindex="0" data-open-target="sabiBibleContainer">
+        <div class="chatbot-bubble-container edge-panel-launcher" role="button" aria-label="Open Sabi Bible" aria-controls="sabiBibleContainer" tabindex="0" data-open-target="sabiBibleContainer" data-open-src="apps/sabi-bible/sabi-bible.html">
             <img src="https://raw.githubusercontent.com/Omoluabi1003/Ariyo-AI/main/Sabi%20Bible%20icon.png" alt="Sabi Bible Icon" class="picture-game-float-icon" />
         </div>
         <!-- Omoluabi YouTube Floating Icon -->
-        <div class="youtube-bubble-container edge-panel-launcher" role="button" aria-label="Open Omoluabi Paul's YouTube" aria-controls="youtubeModalContainer" tabindex="0" data-open-target="youtubeModalContainer">
+        <div class="youtube-bubble-container edge-panel-launcher" role="button" aria-label="Open Omoluabi Paul's YouTube" aria-controls="youtubeModalContainer" tabindex="0" data-open-target="youtubeModalContainer" data-open-src="https://www.youtube.com/embed/videoseries?list=UUzkQQysk1Afxsc-bRh1mYpg">
             <img src="icons/youtube.svg" alt="Omoluabi Paul YouTube Channel" class="picture-game-float-icon" />
         </div>
         <!-- Picture Game Floating Icon -->
-        <div class="picture-game-bubble-container edge-panel-launcher" role="button" aria-label="Open Picture Game" aria-controls="pictureGameContainer" tabindex="0" data-open-target="pictureGameContainer">
+        <div class="picture-game-bubble-container edge-panel-launcher" role="button" aria-label="Open Picture Game" aria-controls="pictureGameContainer" tabindex="0" data-open-target="pictureGameContainer" data-open-src="apps/picture-game/picture-game.html">
             <img src="https://raw.githubusercontent.com/Omoluabi1003/Ariyo-AI/main/Ara%20icon.png" alt="Picture Game Icon" class="picture-game-float-icon" />
         </div>
         <!-- Omoluabi Tetris Floating Icon -->
-        <div class="tetris-bubble-container edge-panel-launcher" role="button" aria-label="Open Omoluabi Tetris" aria-controls="tetrisGameContainer" tabindex="0" data-open-target="tetrisGameContainer">
+        <div class="tetris-bubble-container edge-panel-launcher" role="button" aria-label="Open Omoluabi Tetris" aria-controls="tetrisGameContainer" tabindex="0" data-open-target="tetrisGameContainer" data-open-src="apps/tetris/tetris.html">
             <img src="icons/tetris.svg" alt="Omoluabi Tetris Game Icon" class="picture-game-float-icon" />
         </div>
         <!-- Omoluabi Word Search Floating Icon -->
-        <div class="word-search-bubble-container edge-panel-launcher" role="button" aria-label="Open Omoluabi Word Search" aria-controls="wordSearchContainer" tabindex="0" data-open-target="wordSearchContainer">
+        <div class="word-search-bubble-container edge-panel-launcher" role="button" aria-label="Open Omoluabi Word Search" aria-controls="wordSearchContainer" tabindex="0" data-open-target="wordSearchContainer" data-open-src="apps/word-search/word-search.html">
             <img src="icons/word-search.svg" alt="Omoluabi Word Search Game Icon" class="picture-game-float-icon" />
         </div>
         <!-- Ara Connect-4 Floating Icon -->
-        <div class="connect-four-bubble-container edge-panel-launcher" role="button" aria-label="Open Ara Connect-4" aria-controls="connectFourContainer" tabindex="0" data-open-target="connectFourContainer">
+        <div class="connect-four-bubble-container edge-panel-launcher" role="button" aria-label="Open Ara Connect-4" aria-controls="connectFourContainer" tabindex="0" data-open-target="connectFourContainer" data-open-src="apps/connect-four/connect-four.html">
             <img src="icons/connect-four.svg" alt="Ara Connect-4 Game Icon" class="picture-game-float-icon" />
         </div>
         <!-- Cycle Precision Floating Icon -->
-        <div class="cycle-precision-bubble-container edge-panel-launcher" role="button" aria-label="Open Cycle Precision" aria-controls="cyclePrecisionContainer" tabindex="0" data-open-target="cyclePrecisionContainer">
+        <div class="cycle-precision-bubble-container edge-panel-launcher" role="button" aria-label="Open Cycle Precision" aria-controls="cyclePrecisionContainer" tabindex="0" data-open-target="cyclePrecisionContainer" data-open-src="apps/cycle-precision/cycle-precision.html">
             <img src="icons/blood.svg" alt="Cycle Precision Icon" class="cycle-precision-float-icon" />
         </div>
     </div>
@@ -849,6 +849,7 @@
         <iframe
             class="youtube-frame"
             src="https://www.youtube.com/embed/videoseries?list=UUzkQQysk1Afxsc-bRh1mYpg"
+            data-default-src="https://www.youtube.com/embed/videoseries?list=UUzkQQysk1Afxsc-bRh1mYpg"
             title="Omoluabi Paul YouTube uploads"
             loading="lazy"
             referrerpolicy="strict-origin-when-cross-origin"
@@ -868,49 +869,49 @@
 <div id="ariyoChatbotContainer" class="chatbot-container" role="dialog" aria-labelledby="ariyoChatbotTitle">
     <button class="popup-close ripple shockwave" data-close-target="ariyoChatbotContainer" aria-label="Close Ariyo AI">×</button>
     <h3 id="ariyoChatbotTitle" class="modal-title">Àríyò AI</h3>
-    <iframe src="apps/ariyo-ai-chat/ariyo-ai-chat.html" style="border: none; width: 100%; height: 100%;"></iframe>
+    <iframe src="apps/ariyo-ai-chat/ariyo-ai-chat.html" data-default-src="apps/ariyo-ai-chat/ariyo-ai-chat.html" style="border: none; width: 100%; height: 100%;"></iframe>
 </div>
 
 <!-- Sabi Bible Chatbot Container -->
 <div id="sabiBibleContainer" class="chatbot-container" role="dialog" aria-labelledby="sabiBibleTitle">
     <button class="popup-close ripple shockwave" data-close-target="sabiBibleContainer" aria-label="Close Sabi Bible">×</button>
     <h3 id="sabiBibleTitle" class="modal-title">Sabi Bible</h3>
-    <iframe src="apps/sabi-bible/sabi-bible.html" style="border: none; width: 100%; height: 100%;"></iframe>
+    <iframe src="apps/sabi-bible/sabi-bible.html" data-default-src="apps/sabi-bible/sabi-bible.html" style="border: none; width: 100%; height: 100%;"></iframe>
 </div>
 
 <!-- Picture Game Container -->
 <div id="pictureGameContainer" class="chatbot-container" role="dialog" aria-labelledby="pictureGameTitle">
     <button class="popup-close ripple shockwave" data-close-target="pictureGameContainer" aria-label="Close Picture Game">×</button>
     <h3 id="pictureGameTitle" class="modal-title">Picture Game</h3>
-    <iframe src="apps/picture-game/picture-game.html" style="width: 100%; height: 100%; border: none;"></iframe>
+    <iframe src="apps/picture-game/picture-game.html" data-default-src="apps/picture-game/picture-game.html" style="width: 100%; height: 100%; border: none;"></iframe>
 </div>
 
 <!-- Omoluabi Tetris Container -->
 <div id="tetrisGameContainer" class="chatbot-container" role="dialog" aria-labelledby="tetrisGameTitle">
     <button class="popup-close ripple shockwave" data-close-target="tetrisGameContainer" aria-label="Close Omoluabi Tetris">×</button>
     <h3 id="tetrisGameTitle" class="modal-title">Omoluabi Tetris</h3>
-    <iframe src="apps/tetris/tetris.html" style="width: 100%; height: 100%; border: none;"></iframe>
+    <iframe src="apps/tetris/tetris.html" data-default-src="apps/tetris/tetris.html" style="width: 100%; height: 100%; border: none;"></iframe>
 </div>
 
 <!-- Omoluabi Word Search Container -->
 <div id="wordSearchContainer" class="chatbot-container" role="dialog" aria-labelledby="wordSearchTitle">
     <button class="popup-close ripple shockwave" data-close-target="wordSearchContainer" aria-label="Close Omoluabi Word Search">×</button>
     <h3 id="wordSearchTitle" class="modal-title">Omoluabi Word Search</h3>
-    <iframe src="apps/word-search/word-search.html" style="width: 100%; height: 100%; border: none;"></iframe>
+    <iframe src="apps/word-search/word-search.html" data-default-src="apps/word-search/word-search.html" style="width: 100%; height: 100%; border: none;"></iframe>
 </div>
 
 <!-- Ara Connect-4 Container -->
 <div id="connectFourContainer" class="chatbot-container" role="dialog" aria-labelledby="connectFourTitle">
     <button class="popup-close ripple shockwave" data-close-target="connectFourContainer" aria-label="Close Ara Connect-4">×</button>
     <h3 id="connectFourTitle" class="modal-title">Ara Connect-4</h3>
-    <iframe src="apps/connect-four/connect-four.html" style="width: 100%; height: 100%; border: none;"></iframe>
+    <iframe src="apps/connect-four/connect-four.html" data-default-src="apps/connect-four/connect-four.html" style="width: 100%; height: 100%; border: none;"></iframe>
 </div>
 
 <!-- Cycle Precision Container -->
 <div id="cyclePrecisionContainer" class="chatbot-container" role="dialog" aria-labelledby="cyclePrecisionTitle">
     <button class="popup-close ripple shockwave" data-close-target="cyclePrecisionContainer" aria-label="Close Cycle Precision">×</button>
     <h3 id="cyclePrecisionTitle" class="modal-title">Cycle Precision</h3>
-    <iframe src="apps/cycle-precision/cycle-precision.html" style="width: 100%; height: 100%; border: none;"></iframe>
+    <iframe src="apps/cycle-precision/cycle-precision.html" data-default-src="apps/cycle-precision/cycle-precision.html" style="width: 100%; height: 100%; border: none;"></iframe>
 </div>
 
 
@@ -918,7 +919,7 @@
 <div id="aboutModalContainer" class="chatbot-container" role="dialog" aria-labelledby="aboutModalTitle">
     <button class="popup-close ripple shockwave" data-close-target="aboutModalContainer" aria-label="Close About Us">×</button>
     <h3 id="aboutModalTitle" class="modal-title">About Us</h3>
-    <iframe src="about.html" title="About Us" style="width: 100%; height: 100%; border: none;"></iframe>
+    <iframe src="about.html" data-default-src="about.html" title="About Us" style="width: 100%; height: 100%; border: none;"></iframe>
 </div>
 
 <!-- Share QR Code Modal -->

--- a/scripts/ui.js
+++ b/scripts/ui.js
@@ -240,11 +240,11 @@ document.addEventListener('DOMContentLoaded', () => {
         const targetId = trigger.getAttribute('data-open-target');
         if (!targetId) return;
 
-        trigger.addEventListener('click', () => openPanel(targetId));
+        trigger.addEventListener('click', () => openPanel(targetId, trigger));
         trigger.addEventListener('keydown', (event) => {
             if (event.key === 'Enter' || event.key === ' ') {
                 event.preventDefault();
-                openPanel(targetId);
+                openPanel(targetId, trigger);
             }
         });
     });
@@ -287,7 +287,34 @@ function updateEdgePanelBehavior() {
     }
 }
 
-function openPanel(targetId) {
+function syncPanelSource(panel, trigger) {
+    if (!panel) return;
+
+    const iframe = panel.querySelector('iframe');
+    if (!iframe) return;
+
+    let desiredSrc = null;
+
+    if (trigger) {
+        desiredSrc = trigger.getAttribute('data-open-src');
+    }
+
+    if (!desiredSrc) {
+        desiredSrc = iframe.getAttribute('data-default-src');
+    }
+
+    if (!desiredSrc) return;
+
+    const loadedSrc = iframe.getAttribute('data-loaded-src') || iframe.getAttribute('src') || '';
+    if (loadedSrc !== desiredSrc) {
+        iframe.setAttribute('src', desiredSrc);
+        iframe.setAttribute('data-loaded-src', desiredSrc);
+    } else if (!iframe.hasAttribute('data-loaded-src') && loadedSrc) {
+        iframe.setAttribute('data-loaded-src', loadedSrc);
+    }
+}
+
+function openPanel(targetId, trigger = null) {
     const panel = getPanelElement(targetId);
     if (!panel) return;
 
@@ -297,6 +324,8 @@ function openPanel(targetId) {
             iframe.src = 'about.html';
         }
     }
+
+    syncPanelSource(panel, trigger);
 
     panel.style.display = 'block';
     updateEdgePanelBehavior();


### PR DESCRIPTION
## Summary
- add explicit app sources to each edge panel launcher so the proper iframe is loaded when icons are tapped
- add a panel source synchronizer that reuses default iframe URLs, fixing mismatched content when modals reopen

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ed607f3dcc8332960b570825321c3e