### PR TITLE
Add resilience and fallbacks to edge panel apps

### DIFF
--- a/apps/ariyo-ai-chat/ariyo-ai-chat.html
+++ b/apps/ariyo-ai-chat/ariyo-ai-chat.html
@@ -24,5 +24,65 @@
 </head>
 <body>
   <zapier-interfaces-chatbot-embed is-popup='false' chatbot-id='cm7s2oyu2000b3vmuwcwkj9kn'></zapier-interfaces-chatbot-embed>
+  <script>
+    (function () {
+      const PANEL_ID = 'ariyoChatbotContainer';
+      const SOURCE = 'edge-panel-app';
+
+      const targetOrigin = (() => {
+        try {
+          if (document.referrer) {
+            return new URL(document.referrer).origin;
+          }
+          if (window.location && window.location.origin) {
+            return window.location.origin;
+          }
+        } catch (error) {
+          /* ignore and fall back to wildcard */
+        }
+        return '*';
+      })();
+
+      function postStatus(status, reason) {
+        if (!window.parent || window.parent === window) return;
+        const payload = { source: SOURCE, panelId: PANEL_ID, status };
+        if (reason) {
+          payload.reason = reason;
+        }
+        window.parent.postMessage(payload, targetOrigin);
+      }
+
+      function monitorEmbed() {
+        if (!window.customElements || typeof window.customElements.whenDefined !== 'function') {
+          postStatus('error', 'unsupported-browser');
+          return;
+        }
+
+        let readyTimeout = setTimeout(() => {
+          if (!window.customElements.get('zapier-interfaces-chatbot-embed')) {
+            postStatus('error', 'component-unavailable');
+          }
+        }, 10000);
+
+        window.customElements.whenDefined('zapier-interfaces-chatbot-embed').then(() => {
+          clearTimeout(readyTimeout);
+          const embed = document.querySelector('zapier-interfaces-chatbot-embed');
+          if (embed) {
+            postStatus('ready');
+          } else {
+            postStatus('error', 'missing-embed');
+          }
+        }).catch(() => {
+          postStatus('error', 'component-unavailable');
+        });
+      }
+
+      if (document.readyState === 'complete') {
+        monitorEmbed();
+      } else {
+        window.addEventListener('load', monitorEmbed, { once: true });
+      }
+    })();
+  </script>
 </body>
 </html>

--- a/apps/sabi-bible/sabi-bible.html
+++ b/apps/sabi-bible/sabi-bible.html
@@ -24,5 +24,65 @@
 </head>
 <body>
   <zapier-interfaces-chatbot-embed is-popup='false' chatbot-id='cm7ve7fdl002jlclh8y1n6n1y'></zapier-interfaces-chatbot-embed>
+  <script>
+    (function () {
+      const PANEL_ID = 'sabiBibleContainer';
+      const SOURCE = 'edge-panel-app';
+
+      const targetOrigin = (() => {
+        try {
+          if (document.referrer) {
+            return new URL(document.referrer).origin;
+          }
+          if (window.location && window.location.origin) {
+            return window.location.origin;
+          }
+        } catch (error) {
+          /* ignore */
+        }
+        return '*';
+      })();
+
+      function postStatus(status, reason) {
+        if (!window.parent || window.parent === window) return;
+        const payload = { source: SOURCE, panelId: PANEL_ID, status };
+        if (reason) {
+          payload.reason = reason;
+        }
+        window.parent.postMessage(payload, targetOrigin);
+      }
+
+      function monitorEmbed() {
+        if (!window.customElements || typeof window.customElements.whenDefined !== 'function') {
+          postStatus('error', 'unsupported-browser');
+          return;
+        }
+
+        let readyTimeout = setTimeout(() => {
+          if (!window.customElements.get('zapier-interfaces-chatbot-embed')) {
+            postStatus('error', 'component-unavailable');
+          }
+        }, 10000);
+
+        window.customElements.whenDefined('zapier-interfaces-chatbot-embed').then(() => {
+          clearTimeout(readyTimeout);
+          const embed = document.querySelector('zapier-interfaces-chatbot-embed');
+          if (embed) {
+            postStatus('ready');
+          } else {
+            postStatus('error', 'missing-embed');
+          }
+        }).catch(() => {
+          postStatus('error', 'component-unavailable');
+        });
+      }
+
+      if (document.readyState === 'complete') {
+        monitorEmbed();
+      } else {
+        window.addEventListener('load', monitorEmbed, { once: true });
+      }
+    })();
+  </script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -27,7 +27,7 @@ body {
     --modal-inline-padding: clamp(1rem, 6vw, 3rem);
 }
 
-.news-banner {
+.news-banner { 
     position: fixed;
     bottom: 0;
     left: 0;
@@ -40,6 +40,69 @@ body {
     z-index: 10000;
     white-space: nowrap;
     overflow: hidden;
+}
+
+/* Edge panel app loading feedback */
+.chatbot-container .panel-status-overlay {
+    display: none;
+    position: absolute;
+    inset: 0;
+    background: rgba(6, 16, 34, 0.85);
+    color: #fff;
+    padding: 1.5rem;
+    border-radius: inherit;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    flex-direction: column;
+    gap: 1rem;
+    z-index: 101;
+    backdrop-filter: blur(6px);
+    pointer-events: auto;
+}
+
+.chatbot-container .panel-status-overlay.visible {
+    display: flex;
+}
+
+.chatbot-container .panel-status-overlay .panel-status-spinner {
+    width: 44px;
+    height: 44px;
+    border-radius: 50%;
+    border: 4px solid rgba(255, 255, 255, 0.35);
+    border-top-color: var(--theme-color);
+    animation: panel-status-spin 1s linear infinite;
+}
+
+.chatbot-container .panel-status-overlay.loading .panel-status-actions {
+    display: none;
+}
+
+.chatbot-container .panel-status-overlay.error .panel-status-spinner {
+    display: none;
+}
+
+.chatbot-container .panel-status-overlay .panel-status-actions {
+    display: none;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 0.75rem;
+}
+
+.chatbot-container .panel-status-overlay.error .panel-status-actions {
+    display: flex;
+}
+
+.chatbot-container .panel-status-overlay .panel-status-link {
+    color: #fff;
+    font-weight: 600;
+    text-decoration: underline;
+}
+
+@keyframes panel-status-spin {
+    to {
+        transform: rotate(360deg);
+    }
 }
 
 .news-banner::after {


### PR DESCRIPTION
## Summary
- add handshake messages to the Ariyo AI and Sabi Bible iframe apps so the host page knows when they are ready or timed out
- surface loading and error overlays with retry controls plus YouTube fallback links inside the edge panel containers
- style the new overlay states so they remain legible over the embedded apps without blocking the close button

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ed64ddc59c8332b63895115b5ecb3c