### PR TITLE
Fix TikTok embed feed to render in web app

### DIFF
--- a/apps/tiktok/tiktok.css
+++ b/apps/tiktok/tiktok.css
@@ -15,9 +15,9 @@ body {
 }
 
 .tiktok-main {
-    width: min(90vw, 720px);
+    width: min(92vw, 760px);
     margin: auto;
-    padding: clamp(1.5rem, 4vw, 2.5rem);
+    padding: clamp(1.5rem, 4vw, 2.75rem);
     border-radius: 24px;
     background: rgba(255, 255, 255, 0.85);
     box-shadow: 0 20px 60px rgba(15, 23, 42, 0.18);
@@ -26,7 +26,7 @@ body {
 
 @media (prefers-color-scheme: dark) {
     .tiktok-main {
-        background: rgba(15, 23, 42, 0.75);
+        background: rgba(15, 23, 42, 0.78);
         color: #f8fafc;
         box-shadow: 0 20px 60px rgba(2, 6, 23, 0.6);
     }
@@ -38,34 +38,91 @@ body {
 }
 
 .tiktok-header h1 {
-    font-size: clamp(1.8rem, 3vw, 2.3rem);
-    margin-bottom: 0.5rem;
+    font-size: clamp(1.8rem, 3vw, 2.4rem);
+    margin-bottom: 0.6rem;
 }
 
 .tiktok-header p {
     margin: 0;
-    font-size: clamp(1rem, 2.3vw, 1.1rem);
+    font-size: clamp(1rem, 2.3vw, 1.12rem);
     line-height: 1.5;
 }
 
 .tiktok-embed-area {
     display: flex;
     justify-content: center;
-    position: relative;
-    overflow: hidden;
 }
 
-.tiktok-embed {
-    width: 100% !important;
-    max-width: 640px;
-    min-width: 320px;
+.tiktok-feed-shell {
+    position: relative;
+    width: min(100%, 420px);
+    aspect-ratio: 9 / 16;
+    border-radius: 24px;
+    overflow: hidden;
+    background: #000;
+    box-shadow: 0 18px 48px rgba(15, 23, 42, 0.28);
+}
+
+.tiktok-embed-frame {
+    width: 100%;
+    height: 100%;
+    border: none;
+    display: block;
+}
+
+.tiktok-embed-loading {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-direction: column;
+    gap: 0.75rem;
+    background: linear-gradient(160deg, rgba(15, 23, 42, 0.8), rgba(30, 64, 175, 0.65));
+    color: #f8fafc;
+    font-size: 0.95rem;
+    text-align: center;
+    transition: opacity 0.35s ease, visibility 0.35s ease;
+}
+
+.tiktok-embed-loading.is-hidden {
+    opacity: 0;
+    visibility: hidden;
+}
+
+.tiktok-spinner {
+    width: 3rem;
+    height: 3rem;
+    border-radius: 50%;
+    border: 3px solid rgba(148, 163, 184, 0.6);
+    border-top-color: #38bdf8;
+    animation: tiktok-spin 1.1s linear infinite;
+}
+
+@keyframes tiktok-spin {
+    from {
+        transform: rotate(0deg);
+    }
+    to {
+        transform: rotate(360deg);
+    }
 }
 
 .tiktok-fallback,
 .tiktok-noscript {
     text-align: center;
-    margin-top: 1.5rem;
-    font-size: 0.95rem;
+    margin-top: 1.75rem;
+    font-size: 0.98rem;
+    line-height: 1.55;
+    color: inherit;
+}
+
+.tiktok-fallback {
+    display: none;
+}
+
+.tiktok-fallback.is-visible {
+    display: block;
 }
 
 .tiktok-fallback a,
@@ -80,4 +137,25 @@ body {
 .tiktok-fallback a:focus,
 .tiktok-noscript a:focus {
     text-decoration: underline;
+}
+
+.tiktok-embed-loading.has-error {
+    background: rgba(15, 23, 42, 0.88);
+}
+
+.tiktok-embed-loading.has-error .tiktok-spinner {
+    animation: none;
+    border-color: rgba(148, 163, 184, 0.3);
+    border-top-color: #f97316;
+}
+
+.tiktok-loading-text {
+    max-width: 16ch;
+}
+
+@media (max-width: 480px) {
+    .tiktok-feed-shell {
+        width: min(100%, 360px);
+        border-radius: 20px;
+    }
 }

--- a/apps/tiktok/tiktok.html
+++ b/apps/tiktok/tiktok.html
@@ -23,20 +23,76 @@
             <p>Enjoy the latest uploads without leaving Àríyò AI. The feed below streams straight from TikTok.</p>
         </header>
         <section class="tiktok-embed-area" aria-label="Embedded TikTok feed">
-            <blockquote class="tiktok-embed" cite="https://www.tiktok.com/@omoluabi1003" data-unique-id="omoluabi1003" data-embed-type="creator" data-height="720" data-disable-focus="true">
-                <section>
-                    <a target="_blank" rel="noopener noreferrer" href="https://www.tiktok.com/@omoluabi1003">@omoluabi1003</a>
-                </section>
-            </blockquote>
+            <div class="tiktok-feed-shell">
+                <iframe
+                    class="tiktok-embed-frame"
+                    src="https://www.tiktok.com/embed/@omoluabi1003"
+                    title="Omoluabi Paul TikTok feed"
+                    loading="lazy"
+                    referrerpolicy="strict-origin-when-cross-origin"
+                    allow="autoplay; clipboard-write; encrypted-media; picture-in-picture; web-share"
+                    allowfullscreen>
+                </iframe>
+                <div class="tiktok-embed-loading" role="status" aria-live="polite">
+                    <span class="tiktok-spinner" aria-hidden="true"></span>
+                    <span class="tiktok-loading-text">Loading the TikTok feed…</span>
+                </div>
+            </div>
             <noscript>
                 <p class="tiktok-noscript">JavaScript is required to display the TikTok feed. You can still <a href="https://www.tiktok.com/@omoluabi1003" target="_blank" rel="noopener noreferrer">open Omoluabi Paul on TikTok</a>.</p>
             </noscript>
         </section>
-        <p class="tiktok-fallback">If the embedded feed does not load, <a href="https://www.tiktok.com/@omoluabi1003" target="_blank" rel="noopener noreferrer">open the profile on TikTok</a>.</p>
+        <p class="tiktok-fallback" role="alert">
+            We couldn't load the embedded feed. <a href="https://www.tiktok.com/@omoluabi1003" target="_blank" rel="noopener noreferrer">Open Omoluabi Paul on TikTok</a> instead.
+        </p>
     </main>
-    <script async src="https://www.tiktok.com/embed.js"></script>
     <script src="../../color-scheme.js"></script>
     <script>changeColorScheme();</script>
     <script src="../../prevent-zoom.js"></script>
+    <script>
+        const tiktokFrame = document.querySelector('.tiktok-embed-frame');
+        const loadingState = document.querySelector('.tiktok-embed-loading');
+        const fallbackNotice = document.querySelector('.tiktok-fallback');
+        let fallbackShown = false;
+
+        function hideLoading() {
+            loadingState?.classList.add('is-hidden');
+        }
+
+        function showFallback() {
+            if (fallbackShown) {
+                return;
+            }
+
+            fallbackShown = true;
+
+            if (loadingState) {
+                loadingState.classList.add('has-error');
+                const loadingText = loadingState.querySelector('.tiktok-loading-text');
+                if (loadingText) {
+                    loadingText.textContent = 'The TikTok feed is taking longer than expected to load.';
+                }
+            }
+
+            fallbackNotice?.classList.add('is-visible');
+        }
+
+        if (tiktokFrame) {
+            tiktokFrame.addEventListener('load', () => {
+                tiktokFrame.dataset.ready = 'true';
+                hideLoading();
+            });
+
+            tiktokFrame.addEventListener('error', () => {
+                showFallback();
+            });
+
+            window.setTimeout(() => {
+                if (!tiktokFrame.dataset.ready) {
+                    showFallback();
+                }
+            }, 12000);
+        }
+    </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- replace the TikTok blockquote embed with a direct iframe feed so the creator timeline renders inside the app
- add responsive styling, loading state, and fallback messaging to match the TikTok look and handle failures gracefully

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ed70b371388332834ee3729f2fff6c