### PR TITLE
Refresh theme with vibrant Naija palette

### DIFF
--- a/about.html
+++ b/about.html
@@ -8,7 +8,7 @@
   <meta name="apple-mobile-web-app-title" content="Àríyò AI" />
   <meta name="apple-touch-fullscreen" content="yes" />
   <link rel="apple-touch-icon" href="icons/Ariyo.png">
-  <meta name="theme-color" content="#8B5CF6" />
+  <meta name="theme-color" content="#12B76A" />
   <title>About - Àríyò AI</title>
   <meta name="description" content="Learn more about Àríyò AI, a smart Naija AI powered by Omoluabi. Discover our mission, our music, and our team." />
   <meta name="keywords" content="About Àríyò AI, Omoluabi, Paul A.K. Iyogun, Nigerian AI, AI music" />

--- a/color-scheme.css
+++ b/color-scheme.css
@@ -1,8 +1,8 @@
-/* Atlantic Dawn cool gradient theme */
+/* Vibrant Naija youth gradient theme */
 :root {
-  --theme-color: #8B5CF6;
-  --gradient-start: #4C1D95;
-  --gradient-end: #EC4899;
+  --theme-color: #12B76A;
+  --gradient-start: #047857;
+  --gradient-end: #FACC15;
 }
 
 body {

--- a/color-scheme.js
+++ b/color-scheme.js
@@ -3,9 +3,9 @@ function changeColorScheme() {
 }
 
 function applyTheme() {
-    const themeColor = '#8B5CF6';
-    const gradStart = '#4C1D95';
-    const gradEnd = '#EC4899';
+    const themeColor = '#12B76A';
+    const gradStart = '#047857';
+    const gradEnd = '#FACC15';
     const style = document.getElementById('theme-style') || document.createElement('style');
     style.id = 'theme-style';
     style.innerHTML = `

--- a/index.css
+++ b/index.css
@@ -34,13 +34,13 @@ body {
 }
 
 .countdown.red-on-black {
-    color: var(--theme-color, #8B5CF6);
+    color: var(--theme-color, #12B76A);
     background-color: #02140a;
 }
 
 .countdown.black-on-red {
     color: #02140a;
-    background-color: var(--theme-color, #8B5CF6);
+    background-color: var(--theme-color, #12B76A);
 }
 
 
@@ -304,8 +304,8 @@ a {
     animation: bounce 1s infinite;
     width: 36px;
     height: 36px;
-    fill: var(--theme-color, #8B5CF6);
-    stroke: var(--theme-color, #8B5CF6);
+    fill: var(--theme-color, #12B76A);
+    stroke: var(--theme-color, #12B76A);
 }
 .floating-watermarks {
     pointer-events: none;
@@ -393,7 +393,7 @@ a {
 #timer-progress {
     width: 100%;
     height: 100%;
-    background: linear-gradient(90deg, #4C1D95 0%, #8B5CF6 45%, #EC4899 100%);
+    background: linear-gradient(90deg, #047857 0%, #12B76A 45%, #FACC15 100%);
     position: relative;
     border-radius: inherit;
     box-shadow: inset 0 0 12px rgba(0, 0, 0, 0.25);

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
   <meta name="apple-mobile-web-app-title" content="Àríyò AI" />
   <meta name="apple-touch-fullscreen" content="yes" />
-  <meta name="theme-color" content="#8B5CF6" />
+  <meta name="theme-color" content="#12B76A" />
   <meta name="description" content="Àríyò AI by Paul A.K. Iyogun (Omoluabi) is a smart Nigerian music assistant featuring Ariyo AI." />
   <meta name="keywords" content="Paul Iyogun, Omoluabi, Àríyò AI, Ariyo, Nigerian music, Naija AI, AI chatbot, PWA" />
   <meta property="og:title" content="Àríyò AI - Smart Naija AI by Paul Iyogun" />

--- a/main.html
+++ b/main.html
@@ -10,7 +10,7 @@
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
   <meta name="apple-mobile-web-app-title" content="Àríyò AI">
   <meta name="apple-touch-fullscreen" content="yes">
-  <meta name="theme-color" content="#8B5CF6" />
+  <meta name="theme-color" content="#12B76A" />
   <link rel="manifest" href="manifest.json">
   <link rel="apple-touch-icon" href="icons/Ariyo.png">
   <meta name="description" content="Àríyò AI is a web-based music player that provides a unique and culturally-rich experience for users. It features a curated selection of Nigerian music and the Ariyo AI assistant." />

--- a/manifest.json
+++ b/manifest.json
@@ -32,6 +32,6 @@
   "start_url": "/",
   "scope": "/",
   "display": "standalone",
-  "theme_color": "#8B5CF6",
+  "theme_color": "#12B76A",
   "background_color": "#000000"
 }


### PR DESCRIPTION
## Summary
- swap the legacy purple/pink theme for a vibrant green and gold palette inspired by Nigerian youth
- align countdown, speaker icon, and timer progress styles with the refreshed theme variables
- update PWA metadata so installed experiences use the new signature color

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_6903af16b8108332b97da40beabed9eb