### PR TITLE
Center edge panel and automate client updates

### DIFF
--- a/privacy.html
+++ b/privacy.html
@@ -75,7 +75,7 @@
       <ul>
         <li><strong>Visit analytics:</strong> when you open Àríyò AI we create a random ID in your browser’s <code>localStorage</code> so we can count unique visitors. We send anonymous visit totals to <a href="https://countapi.xyz/">CountAPI</a> and, only for new visitors, a short notification via <a href="https://formsubmit.co/">FormSubmit</a>. No names, emails, or IP addresses are stored by us.</li>
         <li><strong>Chat prompts:</strong> Àríyò AI chat and Sabi Bible run inside Zapier-hosted bots. Anything you type in those panels is processed and stored by Zapier according to their <a href="https://zapier.com/privacy">privacy policy</a>. We do not keep a copy of your conversations.</li>
-        <li><strong>Embedded media:</strong> Radio stations, Suno audio files, and YouTube videos stream directly from their respective hosts. Those providers may log standard metadata (IP address, device type, play counts) when media loads.</li>
+        <li><strong>Embedded media:</strong> Radio stations, AI-generated audio files, and YouTube videos stream directly from their respective hosts. Those providers may log standard metadata (IP address, device type, play counts) when media loads.</li>
       </ul>
     </section>
 
@@ -103,7 +103,7 @@
         <li><strong>Zapier</strong> for chatbot hosting.</li>
         <li><strong>CountAPI</strong> for aggregate visit counters.</li>
         <li><strong>FormSubmit</strong> to notify the creator about brand-new visitors.</li>
-        <li><strong>YouTube, Suno, and curated radio streams</strong> for media playback.</li>
+        <li><strong>YouTube, AI music hosts, and curated radio streams</strong> for media playback.</li>
       </ul>
       <p>Each service has its own privacy commitments. Review their policies if you want the full details.</p>
     </section>


### PR DESCRIPTION
## Summary
- add a helper for track fetch URLs to avoid host-specific logic in the player
- center the edge panel vertically and auto-adjust its position based on viewport height
- ensure service worker updates trigger automatic reloads and remove visible references to Suno in privacy copy

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_69040d6c9f788332a0b84fa41e171698