### PR TITLE
Restore edge panel access and clear hero background

### DIFF
--- a/index.css
+++ b/index.css
@@ -45,8 +45,7 @@ body {
 
 
 .overlay {
-    background: rgba(6, 24, 16, 0.74);
-    backdrop-filter: blur(18px);
+    background: linear-gradient(150deg, rgba(6, 24, 16, 0.9), rgba(6, 24, 16, 0.78));
     padding: clamp(1.5rem, 5vw, 2.75rem);
     border-radius: 24px;
     position: relative;
@@ -411,7 +410,6 @@ a {
     overflow: hidden;
     box-shadow: 0 25px 45px rgba(0, 0, 0, 0.35);
     border: 1px solid rgba(255, 255, 255, 0.25);
-    backdrop-filter: blur(14px);
 }
 
 #timer-progress {

--- a/main.html
+++ b/main.html
@@ -275,8 +275,8 @@
     }
     @media (max-width: 900px) {
       :root {
-        --edge-panel-handle-width: 44px;
-        --edge-panel-visible-gap: 14px;
+        --edge-panel-handle-width: clamp(38px, 8vw, 48px);
+        --edge-panel-visible-gap: clamp(0.65rem, 4vw, 1.35rem);
       }
       .container {
         padding: 0 1rem 0.5rem;
@@ -312,55 +312,33 @@
         background: rgba(0, 0, 0, 0.45);
       }
       .edge-panel {
-        width: min(92vw, 360px);
-        right: -360px;
-        border-radius: 20px;
-        top: auto;
-        bottom: calc(6.5rem + env(safe-area-inset-bottom));
+        width: min(86vw, 320px);
+        right: -320px;
+        border-radius: 24px 0 0 24px;
+        top: calc(env(safe-area-inset-top) + 16px);
+        bottom: auto;
       }
       .edge-panel.visible {
         right: clamp(0.5rem, 5vw, 1.5rem);
       }
-      .edge-panel-handle {
-        top: 0;
-        left: 50%;
-        transform: translate(-50%, -100%);
-        width: clamp(140px, 52vw, 200px);
-        height: 52px;
-        border-radius: 18px 18px 0 0;
-        flex-direction: row;
-        gap: 0.5rem;
-        font-size: 0.75rem;
-        letter-spacing: 0.05em;
+      .edge-panel[data-position='peek'] .edge-panel-handle {
+        transform: translate(-48%, -50%);
       }
-      .edge-panel-handle::after {
-        content: 'Quick hub';
-        writing-mode: initial;
-        transform: none;
+      .edge-panel[data-position='collapsed'] .edge-panel-handle {
+        transform: translate(-60%, -50%);
+      }
+      .edge-panel-handle {
+        width: var(--edge-panel-handle-width);
+        height: clamp(120px, 36vh, 200px);
+        gap: 0.25rem;
       }
       .edge-panel-content {
-        flex-direction: row;
+        flex-direction: column;
         align-items: stretch;
         gap: 0.75rem;
-        overflow-x: auto;
-        overflow-y: hidden;
-        scroll-snap-type: x proximity;
-        padding: 1rem;
-      }
-      .edge-panel-content::-webkit-scrollbar {
-        height: 6px;
-      }
-      .edge-panel-content::-webkit-scrollbar-thumb {
-        background: rgba(18, 183, 106, 0.6);
-        border-radius: 999px;
-      }
-      .edge-panel-item {
-        flex: 0 0 clamp(180px, 68vw, 240px);
-        scroll-snap-align: start;
-        min-height: 120px;
-      }
-      .edge-panel-item:hover {
-        transform: translateY(-4px);
+        overflow-x: hidden;
+        overflow-y: auto;
+        padding: 1.05rem;
       }
     }
     .album-cover {
@@ -539,60 +517,91 @@
         right: -220px;
         transform: none;
         width: clamp(220px, 32vw, 280px);
-        background-color: rgba(0, 0, 0, 0.72);
-        border-radius: 18px 0 0 18px;
-        transition: right 0.3s ease-in-out, box-shadow 0.3s ease-in-out;
+        background: linear-gradient(160deg, rgba(8, 31, 22, 0.92), rgba(3, 15, 10, 0.88));
+        border-radius: 24px 0 0 24px;
+        transition: right 0.3s ease-in-out, box-shadow 0.3s ease-in-out, background 0.3s ease-in-out;
         z-index: 10000;
-        box-shadow: 0 18px 40px rgba(0, 0, 0, 0.45);
+        box-shadow: 0 22px 46px rgba(0, 0, 0, 0.55);
         display: flex;
         flex-direction: column;
-        overflow: hidden;
+        overflow: visible;
         max-height: min(
           var(--edge-panel-max-height),
           calc(
             var(--app-height, 100vh) - env(safe-area-inset-top) - env(safe-area-inset-bottom) - var(--edge-panel-bottom-guard) - var(--edge-panel-top-offset)
           )
         );
-        backdrop-filter: blur(4px);
+        border: 1px solid rgba(255, 255, 255, 0.12);
+        backdrop-filter: blur(12px) saturate(140%);
     }
     .edge-panel.visible {
-        box-shadow: 0 18px 46px rgba(0, 0, 0, 0.55);
+        box-shadow: 0 26px 52px rgba(0, 0, 0, 0.6);
         right: var(--edge-panel-visible-gap);
+    }
+    .edge-panel[data-position='collapsed'] {
+        opacity: 0.95;
+    }
+    .edge-panel[data-position='peek'] {
+        box-shadow: 0 22px 48px rgba(0, 0, 0, 0.55);
     }
     .edge-panel-handle {
         position: absolute;
         top: 50%;
-        left: calc(var(--edge-panel-handle-width) * -0.5);
-        transform: translate(-50%, -50%);
+        left: 0;
+        transform: translate(-58%, -50%);
         width: var(--edge-panel-handle-width);
-        height: clamp(110px, 30vh, 180px);
-        background: linear-gradient(180deg, rgba(255,255,255,0.85), rgba(18,183,106,0.85));
-        border-radius: 16px 0 0 16px;
+        height: clamp(120px, 32vh, 190px);
+        background: linear-gradient(200deg, rgba(255, 255, 255, 0.88), rgba(18, 183, 106, 0.92));
+        border-radius: 999px 0 0 999px;
         cursor: pointer;
         display: flex;
         flex-direction: column;
         justify-content: center;
         align-items: center;
-        gap: 0.35rem;
-        color: rgba(12, 34, 25, 0.95);
+        gap: 0.3rem;
+        color: rgba(12, 34, 25, 0.92);
         text-transform: uppercase;
         font-weight: 600;
         letter-spacing: 0.08em;
         font-size: 0.7rem;
+        box-shadow: 0 14px 30px rgba(0, 0, 0, 0.38);
+        border: 1px solid rgba(255, 255, 255, 0.35);
+        background-clip: padding-box;
+        transition: transform 0.3s ease, box-shadow 0.3s ease, opacity 0.3s ease;
     }
     .edge-panel-handle:focus-visible {
         outline: 3px solid rgba(255, 255, 255, 0.9);
         outline-offset: 3px;
     }
+    .edge-panel-handle:hover {
+        box-shadow: 0 18px 36px rgba(0, 0, 0, 0.42);
+    }
+    .edge-panel.visible .edge-panel-handle {
+        transform: translate(-32%, -50%);
+        box-shadow: 0 18px 36px rgba(0, 0, 0, 0.45);
+    }
+    .edge-panel[data-position='peek'] .edge-panel-handle {
+        transform: translate(-46%, -50%);
+    }
+    .edge-panel[data-position='collapsed'] .edge-panel-handle {
+        transform: translate(-58%, -50%);
+        opacity: 0.9;
+    }
     .edge-panel-handle::before {
-        content: '☰';
-        font-size: 1.2rem;
-        line-height: 1;
+        content: '';
+        display: block;
+        width: 8px;
+        height: 46%;
+        border-radius: 999px;
+        background: linear-gradient(180deg, rgba(12, 34, 25, 0.25), rgba(12, 34, 25, 0.65));
+        box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.45);
     }
     .edge-panel-handle::after {
-        content: 'Hub';
+        content: 'Apps';
         writing-mode: vertical-rl;
         transform: rotate(180deg);
+        font-size: 0.65rem;
+        letter-spacing: 0.18em;
     }
     .edge-panel-content {
         display: flex;

--- a/scripts/ui.js
+++ b/scripts/ui.js
@@ -766,7 +766,7 @@ function closeCyclePrecision() {
     let initialX;
     let initialRight;
     let EDGE_PANEL_VISIBLE_X = 16;
-    let EDGE_PANEL_HIDDEN_X = -160;
+    let EDGE_PANEL_COLLAPSED_X = -160;
     let EDGE_PANEL_PEEK_X = -32;
 
     const computeEdgePanelOffsets = () => {
@@ -775,8 +775,12 @@ function closeCyclePrecision() {
         const handleRect = edgePanelHandle.getBoundingClientRect();
         const baseGap = window.innerWidth <= 900 ? Math.max(Math.round(window.innerWidth * 0.03), 10) : 16;
         EDGE_PANEL_VISIBLE_X = baseGap;
-        EDGE_PANEL_HIDDEN_X = Math.round(-(panelRect.width - handleRect.width - 4));
-        EDGE_PANEL_PEEK_X = Math.round(EDGE_PANEL_VISIBLE_X - (handleRect.width + 16));
+
+        const handleExposure = Math.max(Math.round(handleRect.width * 0.6), 14);
+        const minCollapsed = baseGap - handleExposure;
+        EDGE_PANEL_COLLAPSED_X = Math.max(minCollapsed, baseGap - (panelRect.width - 28));
+
+        EDGE_PANEL_PEEK_X = Math.min(Math.round(baseGap - (handleRect.width + 12)), EDGE_PANEL_COLLAPSED_X - 12);
     };
 
     const applyEdgePanelPosition = (state) => {
@@ -793,9 +797,9 @@ function closeCyclePrecision() {
                 edgePanel.style.right = `${EDGE_PANEL_VISIBLE_X}px`;
                 break;
             default:
+                edgePanel.dataset.position = 'collapsed';
                 edgePanel.classList.remove('visible');
-                delete edgePanel.dataset.position;
-                edgePanel.style.right = `${EDGE_PANEL_HIDDEN_X}px`;
+                edgePanel.style.right = `${EDGE_PANEL_COLLAPSED_X}px`;
                 break;
         }
     };
@@ -811,13 +815,13 @@ function closeCyclePrecision() {
         if (!edgePanelHandle.getAttribute('aria-label')) {
             edgePanelHandle.setAttribute('aria-label', 'Toggle Quick Launch hub');
         }
-        applyEdgePanelPosition('hidden');
+        applyEdgePanelPosition('collapsed');
 
         const toggleEdgePanelVisibility = () => {
             if (edgePanel.dataset.position === 'peek') {
                 applyEdgePanelPosition('visible');
             } else if (edgePanel.classList.contains('visible')) {
-                applyEdgePanelPosition('hidden');
+                applyEdgePanelPosition('collapsed');
             } else {
                 applyEdgePanelPosition('visible');
             }
@@ -843,9 +847,9 @@ function closeCyclePrecision() {
                 isDragging = false;
                 edgePanel.style.transition = 'right 0.3s ease-in-out, box-shadow 0.3s ease-in-out';
                 const finalRight = parseInt(window.getComputedStyle(edgePanel).right, 10);
-                const threshold = (EDGE_PANEL_HIDDEN_X + EDGE_PANEL_VISIBLE_X) / 2;
+                const threshold = (EDGE_PANEL_COLLAPSED_X + EDGE_PANEL_VISIBLE_X) / 2;
                 if (finalRight < threshold) {
-                    applyEdgePanelPosition('hidden');
+                    applyEdgePanelPosition('collapsed');
                 } else {
                     applyEdgePanelPosition('visible');
                 }
@@ -871,7 +875,7 @@ function closeCyclePrecision() {
             } else if (edgePanel.classList.contains('visible')) {
                 applyEdgePanelPosition('visible');
             } else {
-                applyEdgePanelPosition('hidden');
+                applyEdgePanelPosition('collapsed');
             }
         });
 
@@ -882,13 +886,13 @@ function closeCyclePrecision() {
             } else if (edgePanel.classList.contains('visible')) {
                 applyEdgePanelPosition('visible');
             } else {
-                applyEdgePanelPosition('hidden');
+                applyEdgePanelPosition('collapsed');
             }
         });
     }
 
     function closeEdgePanel() {
-        applyEdgePanelPosition('hidden');
+        applyEdgePanelPosition('collapsed');
     }
 
 
@@ -906,7 +910,7 @@ function closeCyclePrecision() {
 
             setTimeout(() => {
                 if (!chatbotWindowOpen) {
-                    applyEdgePanelPosition('hidden');
+                    applyEdgePanelPosition('collapsed');
                 }
             }, 5000);
         }, 2000);


### PR DESCRIPTION
## Summary
- refresh the main edge panel visuals and handle behaviour so it mirrors a Samsung-style vertical launcher and stays accessible when collapsed
- stop the landing overlay from blurring the rotating hero backgrounds to preserve their detail

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6904893e594883329f94c31b2fd0738b