### PR TITLE
Tuck edge panel and refresh footer

### DIFF
--- a/main.html
+++ b/main.html
@@ -53,9 +53,9 @@
   <style>
     :root {
       --glass-blur: 0px;
-      --edge-panel-top-offset: clamp(28px, 5vh, 60px);
-      --edge-panel-bottom-guard: clamp(12rem, 38vh, 16rem);
-      --edge-panel-max-height: 78vh;
+      --edge-panel-top-offset: clamp(18px, 4vh, 48px);
+      --edge-panel-bottom-guard: clamp(8rem, 30vh, 12rem);
+      --edge-panel-max-height: 88vh;
       --edge-panel-handle-width: clamp(22px, 5vw, 30px);
       --edge-panel-visible-gap: clamp(12px, 3vw, 18px);
     }
@@ -618,7 +618,17 @@
         padding: clamp(14px, 2.5vh, 18px) clamp(12px, 2vw, 16px);
         flex: 1;
         overflow-y: auto;
-        max-height: calc(var(--edge-panel-max-height) - 28px);
+        max-height: min(
+          calc(var(--edge-panel-max-height) - 28px),
+          calc(
+            var(--app-height, 100vh)
+            - env(safe-area-inset-top)
+            - env(safe-area-inset-bottom)
+            - var(--edge-panel-top-offset)
+            - clamp(5rem, 18vh, 7rem)
+          )
+        );
+        overscroll-behavior: contain;
         scrollbar-gutter: stable;
     }
     .tap-area {
@@ -1047,8 +1057,7 @@
   </div>
 
   <footer class="app-footer">
-    <p>&copy; 2024 Omoluabi Productions. Crafted in Naija with love. <a href="privacy.html">Privacy &amp; data use</a></p>
-    <p class="last-updated" aria-live="polite">Last updated: October 2025</p>
+    <p>&copy; 2024 Omoluabi Productions. <a href="privacy.html">Privacy &amp; data use</a></p>
   </footer>
 
   <!-- Music Player -->

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -572,7 +572,6 @@
 
     // Initialize player
     initializePlayer();
-    autoPopOutEdgePanel();
 
     // Save state before unloading
     window.addEventListener('beforeunload', savePlayerState);

--- a/scripts/ui.js
+++ b/scripts/ui.js
@@ -549,9 +549,6 @@ function updateEdgePanelBehavior() {
     chatbotWindowOpen = isAnyPanelOpen();
     if (chatbotWindowOpen) {
         closeEdgePanel();
-        clearInterval(autoPopOutInterval);
-    } else if (!edgePanel.classList.contains('visible')) {
-        autoPopOutEdgePanel();
     }
 }
 
@@ -776,11 +773,14 @@ function closeCyclePrecision() {
         const baseGap = window.innerWidth <= 900 ? Math.max(Math.round(window.innerWidth * 0.03), 10) : 16;
         EDGE_PANEL_VISIBLE_X = baseGap;
 
-        const handleExposure = Math.max(Math.round(handleRect.width * 0.6), 14);
-        const minCollapsed = baseGap - handleExposure;
-        EDGE_PANEL_COLLAPSED_X = Math.max(minCollapsed, baseGap - (panelRect.width - 28));
+        const handleExposure = Math.max(Math.round(handleRect.width * 0.75), 18);
+        const tuckDistance = panelRect.width - handleExposure;
+        EDGE_PANEL_COLLAPSED_X = baseGap - tuckDistance;
 
-        EDGE_PANEL_PEEK_X = Math.min(Math.round(baseGap - (handleRect.width + 12)), EDGE_PANEL_COLLAPSED_X - 12);
+        const midpoint = Math.round((EDGE_PANEL_COLLAPSED_X + EDGE_PANEL_VISIBLE_X) / 2);
+        const peekLimit = EDGE_PANEL_VISIBLE_X - Math.round(handleRect.width * 1.1);
+        const peekCandidate = Math.min(midpoint, peekLimit);
+        EDGE_PANEL_PEEK_X = Math.max(peekCandidate, EDGE_PANEL_COLLAPSED_X + Math.round(handleExposure * 0.6));
     };
 
     const applyEdgePanelPosition = (state) => {
@@ -897,24 +897,8 @@ function closeCyclePrecision() {
 
 
 
-    /* AUTO POP-OUT/RETRACT EDGE PANEL */
+    /* EDGE PANEL STATE HELPERS */
     let chatbotWindowOpen = false;
-    let autoPopOutInterval;
-
-    function autoPopOutEdgePanel() {
-        if (!edgePanel || chatbotWindowOpen || edgePanel.classList.contains('visible')) return;
-
-        setTimeout(() => {
-            computeEdgePanelOffsets();
-            applyEdgePanelPosition('peek');
-
-            setTimeout(() => {
-                if (!chatbotWindowOpen) {
-                    applyEdgePanelPosition('collapsed');
-                }
-            }, 5000);
-        }, 2000);
-    }
 
 function showNowPlayingToast(trackTitle) {
   const toast = document.getElementById('nowPlayingToast');


### PR DESCRIPTION
## Summary
- adjust edge panel sizing variables and scroll container so the launcher stays tucked away yet fully browsable
- remove the auto-pop behaviour and update the offset math to keep only the handle visible by default
- streamline the footer by dropping the crafted-in-Naija and last-updated copy

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_69049083323c8332b2a45a67c0fa7896