### PR TITLE
Add 'Famine Of Fathers' track to catalogue data

### DIFF
--- a/Omoluabi_Production_Catalogue.md
+++ b/Omoluabi_Production_Catalogue.md
@@ -3,6 +3,7 @@
 ![Omoluabi Productions Logo](Logo.jpg)
 
 - [Watchman](https://cdn1.suno.ai/5c17dd10-1770-467a-947a-db773c72ec78.mp3)
+- [Famine Of Fathers](https://suno.com/s/oU0v2zP2kD8NjR8q)
 - [Ọmọlúàbí](https://cdn1.suno.ai/fb1daddf-1de4-4164-bb9d-113f9639d732.mp3)
 - [Take The Risk](https://cdn1.suno.ai/d3ec2b0a-6062-417f-a62c-4d746f7f4f57.mp3)
 - [Woman who Hates Correction](https://suno.com/s/pzTkEn1EkSMS1i83)

--- a/scripts/data.js
+++ b/scripts/data.js
@@ -133,6 +133,7 @@ const albums = [
           cover: `${BASE_URL}Logo.jpg`,
           tracks: [
             { src: 'https://cdn1.suno.ai/8e63cdab-2e25-4993-ad25-1d074224b0c2.mp3', title: 'Persecutory Paranoia' },
+            { src: 'https://cdn1.suno.ai/22d01aa2-02bb-4c6a-917c-0cd1b1d28552.mp3', title: 'Famine Of Fathers' },
             { src: 'https://cdn1.suno.ai/5c17dd10-1770-467a-947a-db773c72ec78.mp3', title: 'Watchman' },
             { src: 'https://cdn1.suno.ai/fb1daddf-1de4-4164-bb9d-113f9639d732.mp3', title: 'Ọmọlúàbí' },
             { src: 'https://cdn1.suno.ai/d3ec2b0a-6062-417f-a62c-4d746f7f4f57.mp3', title: 'Take The Risk' },
@@ -180,6 +181,12 @@ const LATEST_TRACK_WINDOW_HOURS = 36;
 const LATEST_TRACK_LIMIT = 2;
 
 const latestTrackAnnouncements = [
+  {
+    albumName: 'Omoluabi Production Catalogue',
+    title: 'Famine Of Fathers',
+    src: 'https://cdn1.suno.ai/22d01aa2-02bb-4c6a-917c-0cd1b1d28552.mp3',
+    addedOn: '2025-10-31'
+  },
   {
     albumName: 'Omoluabi Production Catalogue',
     title: 'Persecutory Paranoia',


### PR DESCRIPTION
## Summary
- add the new "Famine Of Fathers" release to the Omoluabi Production Catalogue album data and latest track announcements so it appears in the music modal
- update the public catalogue markdown to list the new song with its Suno share link

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_6904d44871848332bf9cb4f3a59fdef9