### PR TITLE
Restore sidebar buttons hidden by container overflow

### DIFF
--- a/main.html
+++ b/main.html
@@ -141,7 +141,6 @@
       flex-direction: column;
       align-items: stretch;
       gap: 1.25rem;
-      overflow: hidden;
       padding: 0 clamp(1rem, 4vw, 2rem);
       box-sizing: border-box;
       width: 100%;

--- a/style.css
+++ b/style.css
@@ -168,7 +168,6 @@ body {
     flex-direction: column;
     align-items: stretch;
     gap: 1.25rem;
-    overflow: hidden;
     padding: 0 clamp(1rem, 4vw, 2rem);
     box-sizing: border-box;
     width: 100%;


### PR DESCRIPTION
## Summary
- remove the overflow clipping on the main page container so the navigation sidebar and search bar remain visible
- mirror the same change in the shared stylesheet to keep desktop and mobile layouts consistent

## Testing
- Manual verification on main.html

------
https://chatgpt.com/codex/tasks/task_e_6904e330c7308332ac706c247739590c