### PR TITLE
Refine edge panel sizing for quick glance

### DIFF
--- a/main.html
+++ b/main.html
@@ -53,12 +53,12 @@
   <style>
     :root {
       --glass-blur: 0px;
-      --edge-panel-top-offset: clamp(18px, 4vh, 48px);
-      --edge-panel-bottom-guard: clamp(8rem, 30vh, 12rem);
-      --edge-panel-max-height: 88vh;
-      --edge-panel-width: clamp(248px, 36vw, 320px);
-      --edge-panel-handle-width: clamp(18px, 4vw, 26px);
-      --edge-panel-visible-gap: clamp(10px, 2.75vw, 16px);
+      --edge-panel-top-offset: clamp(14px, 3vh, 32px);
+      --edge-panel-bottom-guard: clamp(4rem, 18vh, 6rem);
+      --edge-panel-max-height: 92vh;
+      --edge-panel-width: clamp(220px, 30vw, 280px);
+      --edge-panel-handle-width: clamp(14px, 3vw, 20px);
+      --edge-panel-visible-gap: clamp(6px, 1.8vw, 12px);
     }
     html, body {
       height: 100%;
@@ -629,24 +629,24 @@
         position: absolute;
         top: 50%;
         left: 0;
-        transform: translate(-60%, -50%);
+        transform: translate(-58%, -50%);
         width: var(--edge-panel-handle-width);
-        height: clamp(96px, 30vh, 168px);
-        background: linear-gradient(200deg, rgba(255, 255, 255, 0.88), rgba(18, 183, 106, 0.9));
+        height: clamp(72px, 22vh, 128px);
+        background: linear-gradient(200deg, rgba(255, 255, 255, 0.86), rgba(18, 183, 106, 0.88));
         border-radius: 999px 0 0 999px;
         cursor: pointer;
         display: flex;
         flex-direction: column;
         justify-content: center;
         align-items: center;
-        gap: 0.18rem;
+        gap: 0.14rem;
         color: rgba(12, 34, 25, 0.92);
         text-transform: uppercase;
         font-weight: 600;
-        letter-spacing: 0.12em;
-        font-size: 0.62rem;
-        box-shadow: 0 14px 30px rgba(0, 0, 0, 0.38);
-        border: 1px solid rgba(255, 255, 255, 0.35);
+        letter-spacing: 0.16em;
+        font-size: 0.55rem;
+        box-shadow: 0 10px 22px rgba(0, 0, 0, 0.36);
+        border: 1px solid rgba(255, 255, 255, 0.32);
         background-clip: padding-box;
         transition: transform 0.3s ease, box-shadow 0.3s ease, opacity 0.3s ease;
     }
@@ -658,53 +658,54 @@
         box-shadow: 0 18px 36px rgba(0, 0, 0, 0.42);
     }
     .edge-panel.visible .edge-panel-handle {
-        transform: translate(-30%, -50%);
-        box-shadow: 0 18px 36px rgba(0, 0, 0, 0.45);
+        transform: translate(-32%, -50%);
+        box-shadow: 0 16px 30px rgba(0, 0, 0, 0.42);
     }
     .edge-panel[data-position='peek'] .edge-panel-handle {
-        transform: translate(-48%, -50%);
+        transform: translate(-45%, -50%);
     }
     .edge-panel[data-position='collapsed'] .edge-panel-handle {
-        transform: translate(-66%, -50%);
-        opacity: 0.88;
+        transform: translate(-64%, -50%);
+        opacity: 0.86;
     }
     .edge-panel-handle::before {
         content: '';
         display: block;
-        width: 8px;
-        height: 44%;
+        width: 6px;
+        height: 48%;
         border-radius: 999px;
-        background: linear-gradient(180deg, rgba(12, 34, 25, 0.25), rgba(12, 34, 25, 0.65));
-        box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.45);
+        background: linear-gradient(180deg, rgba(12, 34, 25, 0.2), rgba(12, 34, 25, 0.6));
+        box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.38);
     }
     .edge-panel-handle::after {
         content: 'Apps';
         writing-mode: vertical-rl;
         transform: rotate(180deg);
-        font-size: 0.58rem;
-        letter-spacing: 0.2em;
+        font-size: 0.5rem;
+        letter-spacing: 0.18em;
     }
     .edge-panel-content {
         display: flex;
         flex-direction: column;
         justify-content: flex-start;
         align-items: stretch;
-        gap: clamp(0.45rem, 1.9vw, 0.75rem);
-        padding: clamp(0.9rem, 2.6vw, 1.1rem);
+        gap: clamp(0.35rem, 1.5vw, 0.55rem);
+        padding: clamp(0.7rem, 2vw, 0.9rem);
         flex: 1;
         overflow-y: auto;
         max-height: min(
-          calc(var(--edge-panel-max-height) - 28px),
+          calc(var(--edge-panel-max-height) - clamp(2.6rem, 10vh, 3.8rem)),
           calc(
             var(--app-height, 100vh)
             - env(safe-area-inset-top)
             - env(safe-area-inset-bottom)
             - var(--edge-panel-top-offset)
-            - clamp(5rem, 18vh, 7rem)
+            - clamp(3.8rem, 14vh, 5.2rem)
           )
         );
         overscroll-behavior: contain;
         scrollbar-gutter: stable;
+        scrollbar-width: thin;
     }
     .tap-area {
         position: fixed;
@@ -729,19 +730,19 @@
       cursor: pointer;
     }
     .edge-panel-intro {
-      font-size: clamp(0.76rem, 2.1vw, 0.88rem);
-      color: rgba(255,255,255,0.82);
+      font-size: clamp(0.7rem, 1.8vw, 0.82rem);
+      color: rgba(255,255,255,0.8);
       text-align: center;
-      line-height: 1.4;
-      padding: 0 0.3rem;
+      line-height: 1.35;
+      padding: 0 0.2rem;
     }
     .edge-panel-item {
       display: flex;
-      align-items: flex-start;
-      gap: 0.5rem;
-      padding: 0.5rem 0.65rem;
+      align-items: center;
+      gap: 0.45rem;
+      padding: 0.4rem 0.55rem;
       border-radius: 12px;
-      background: rgba(13, 45, 32, 0.55);
+      background: rgba(13, 45, 32, 0.5);
       border: 1px solid rgba(255,255,255,0.12);
       color: #fff;
       transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
@@ -753,7 +754,7 @@
       font: inherit;
       appearance: none;
       background-clip: padding-box;
-      min-height: 3.35rem;
+      min-height: 2.8rem;
     }
     .edge-panel-item:focus-visible {
       outline: none;
@@ -765,16 +766,15 @@
       box-shadow: 0 8px 18px rgba(0,0,0,0.35);
     }
     .edge-panel-item img {
-      width: 32px;
-      height: 32px;
+      width: 28px;
+      height: 28px;
       flex-shrink: 0;
       border-radius: 50%;
       box-shadow: 0px 4px 10px rgba(0,0,0,0.3);
-      margin-top: 0.1rem;
     }
     .edge-panel-label {
-      font-size: clamp(0.72rem, 1.9vw, 0.88rem);
-      line-height: 1.3;
+      font-size: clamp(0.68rem, 1.6vw, 0.82rem);
+      line-height: 1.28;
       display: block;
       max-width: 100%;
       white-space: normal;
@@ -782,13 +782,13 @@
     }
     .edge-panel-label strong {
       display: block;
-      font-size: clamp(0.78rem, 2vw, 0.94rem);
-      line-height: 1.2;
+      font-size: clamp(0.74rem, 1.8vw, 0.9rem);
+      line-height: 1.18;
     }
     .edge-panel-privacy {
-      font-size: clamp(0.7rem, 1.8vw, 0.85rem);
+      font-size: clamp(0.66rem, 1.5vw, 0.8rem);
       text-align: center;
-      line-height: 1.4;
+      line-height: 1.35;
       color: rgba(255,255,255,0.75);
     }
     .edge-panel-privacy a {


### PR DESCRIPTION
## Summary
- shrink the edge panel handle and spacing so the quick hub control feels slimmer
- tighten the app list typography and spacing to fit every launcher without scrolling
- expand the panel height allowance for better at-a-glance visibility

## Testing
- Not run (styling change only)


------
https://chatgpt.com/codex/tasks/task_e_6904f8db9a1c8332b5cfe28524b0dde1