### PR TITLE
Fix mobile edge panel layout

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -757,13 +757,20 @@
         const isCompactLayout = window.matchMedia('(max-width: 900px)').matches;
 
         if (isCompactLayout) {
-            const compactGuard = Math.max(Math.ceil((musicPlayerElement?.getBoundingClientRect()?.height || 0)) + 48, EDGE_PANEL_MIN_HEIGHT);
-            rootElement.style.setProperty('--edge-panel-bottom-guard', `${compactGuard}px`);
-            rootElement.style.setProperty('--edge-panel-max-height', `${Math.max(viewportHeight - topOffset - compactGuard, EDGE_PANEL_MIN_HEIGHT)}px`);
+            const measuredPlayerHeight = Math.ceil(musicPlayerElement?.getBoundingClientRect()?.height || 0);
+            const guardTarget = Math.max(measuredPlayerHeight + 48, EDGE_PANEL_MIN_HEIGHT);
+            const compactTop = Math.max(topOffset, 16);
+            const maximumBottom = Math.max(viewportHeight - compactTop - EDGE_PANEL_MIN_HEIGHT, 0);
+            const compactBottom = Math.max(0, Math.min(guardTarget, maximumBottom));
+            const compactMaxHeight = Math.max(viewportHeight - compactTop - compactBottom, EDGE_PANEL_MIN_HEIGHT);
+
+            rootElement.style.setProperty('--edge-panel-bottom-guard', `${compactBottom}px`);
+            rootElement.style.setProperty('--edge-panel-max-height', `${compactMaxHeight}px`);
+
             mainEdgePanel.style.height = '';
             mainEdgePanel.style.transform = 'none';
-            mainEdgePanel.style.top = '';
-            mainEdgePanel.style.bottom = `${compactGuard}px`;
+            mainEdgePanel.style.top = `${compactTop}px`;
+            mainEdgePanel.style.bottom = `${compactBottom}px`;
             mainEdgePanelContent.style.maxHeight = '';
             mainEdgePanelContent.style.overflowY = 'auto';
             return;


### PR DESCRIPTION
## Summary
- cap the mobile edge panel guard by the viewport height so the panel no longer collapses off-screen
- align compact layout offsets with the desktop logic so the quick hub content stays visible on phones

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_6904fc7a2b748332af01229495f7c596