### PR TITLE
Center edge panel vertically on small screens

### DIFF
--- a/main.html
+++ b/main.html
@@ -394,9 +394,9 @@
         width: min(86vw, var(--edge-panel-width));
         right: calc(var(--edge-panel-visible-gap) - min(86vw, var(--edge-panel-width)));
         border-radius: 24px 0 0 24px;
-        top: calc(env(safe-area-inset-top) + 20px);
+        top: 50%;
         bottom: auto;
-        transform: none;
+        transform: translateY(-50%);
       }
       .edge-panel.visible {
         right: clamp(0.5rem, 5vw, 1.4rem);


### PR DESCRIPTION
## Summary
- update the small-screen edge panel layout so it anchors to the middle of the viewport
- restore the vertical translate offset to keep the handle centered while collapsed or expanded

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6905c8c2ae00833288c5d24c9158a43c