### PR TITLE
Add The Guilt Trip Trap to Omoluabi catalogue

### DIFF
--- a/Omoluabi_Production_Catalogue.md
+++ b/Omoluabi_Production_Catalogue.md
@@ -4,6 +4,7 @@
 
 - [Watchman](https://cdn1.suno.ai/5c17dd10-1770-467a-947a-db773c72ec78.mp3)
 - [Famine Of Fathers](https://suno.com/s/oU0v2zP2kD8NjR8q)
+- [The Guilt Trip Trap](https://suno.com/s/0a0yeYLjv6xJXrS5)
 - [Ọmọlúàbí](https://cdn1.suno.ai/fb1daddf-1de4-4164-bb9d-113f9639d732.mp3)
 - [Take The Risk](https://cdn1.suno.ai/d3ec2b0a-6062-417f-a62c-4d746f7f4f57.mp3)
 - [Woman who Hates Correction](https://suno.com/s/pzTkEn1EkSMS1i83)

--- a/scripts/data.js
+++ b/scripts/data.js
@@ -134,6 +134,7 @@ const albums = [
           tracks: [
             { src: 'https://cdn1.suno.ai/8e63cdab-2e25-4993-ad25-1d074224b0c2.mp3', title: 'Persecutory Paranoia' },
             { src: 'https://cdn1.suno.ai/22d01aa2-02bb-4c6a-917c-0cd1b1d28552.mp3', title: 'Famine Of Fathers' },
+            { src: 'https://cdn1.suno.ai/f0666a04-fab8-4c4f-bb75-56147c49feaa.mp3', title: 'The Guilt Trip Trap' },
             { src: 'https://cdn1.suno.ai/5c17dd10-1770-467a-947a-db773c72ec78.mp3', title: 'Watchman' },
             { src: 'https://cdn1.suno.ai/fb1daddf-1de4-4164-bb9d-113f9639d732.mp3', title: 'Ọmọlúàbí' },
             { src: 'https://cdn1.suno.ai/d3ec2b0a-6062-417f-a62c-4d746f7f4f57.mp3', title: 'Take The Risk' },


### PR DESCRIPTION
## Summary
- add the new Suno release "The Guilt Trip Trap" to the Omoluabi Production Catalogue album so it appears in the track list modal
- document the track in the Omoluabi Production Catalogue reference markdown

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_6905e7554de48332b3489b71f16e0ad6