### PR TITLE
Center and extend the edge panel

### DIFF
--- a/main.html
+++ b/main.html
@@ -56,6 +56,7 @@
       --edge-panel-top-offset: clamp(14px, 3vh, 32px);
       --edge-panel-bottom-guard: clamp(4rem, 18vh, 6rem);
       --edge-panel-max-height: 92vh;
+      --edge-panel-min-height: clamp(320px, 68vh, 560px);
       --edge-panel-width: clamp(220px, 30vw, 280px);
       --edge-panel-handle-width: clamp(14px, 3vw, 20px);
       --edge-panel-visible-gap: clamp(6px, 1.8vw, 12px);
@@ -397,6 +398,7 @@
         top: 50%;
         bottom: auto;
         transform: translateY(-50%);
+        min-height: var(--edge-panel-min-height);
       }
       .edge-panel.visible {
         right: clamp(0.5rem, 5vw, 1.4rem);
@@ -409,7 +411,7 @@
       }
       .edge-panel-handle {
         width: var(--edge-panel-handle-width);
-        height: clamp(84px, 30vh, 160px);
+        height: clamp(110px, 32vh, 188px);
         gap: 0.16rem;
       }
       .edge-panel-content {
@@ -605,6 +607,7 @@
         display: flex;
         flex-direction: column;
         overflow: visible;
+        min-height: var(--edge-panel-min-height);
         max-height: min(
           var(--edge-panel-max-height),
           calc(
@@ -631,7 +634,7 @@
         left: 0;
         transform: translate(-58%, -50%);
         width: var(--edge-panel-handle-width);
-        height: clamp(72px, 22vh, 128px);
+        height: clamp(96px, 26vh, 168px);
         background: linear-gradient(200deg, rgba(255, 255, 255, 0.86), rgba(18, 183, 106, 0.88));
         border-radius: 999px 0 0 999px;
         cursor: pointer;

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -746,7 +746,7 @@
     const musicPlayerElement = document.querySelector('.music-player');
 
     const MIN_EDGE_PANEL_APPS_VISIBLE = 4;
-    const EDGE_PANEL_MIN_HEIGHT = 220;
+    const EDGE_PANEL_MIN_HEIGHT = 320;
 
     const updateEdgePanelHeight = () => {
         if (!mainEdgePanel || !mainEdgePanelContent) return;
@@ -767,10 +767,19 @@
             rootElement.style.setProperty('--edge-panel-bottom-guard', `${compactBottom}px`);
             rootElement.style.setProperty('--edge-panel-max-height', `${compactMaxHeight}px`);
 
+            const rawCompactSpace = viewportHeight - compactTop - compactBottom;
+            const compactHeightTarget = Math.max(rawCompactSpace, EDGE_PANEL_MIN_HEIGHT);
+            const compactHeight = Math.max(Math.min(compactMaxHeight, compactHeightTarget), EDGE_PANEL_MIN_HEIGHT);
+            const availableTopSpace = Math.max(viewportHeight - compactHeight, 0);
+            const centeredTop = availableTopSpace / 2;
+            const lowerBias = centeredTop + Math.max(0, compactHeight * 0.08);
+            const maxTop = Math.max(viewportHeight - compactHeight - compactBottom, compactTop);
+            const safeTop = Math.min(Math.max(compactTop, lowerBias), maxTop);
+
             mainEdgePanel.style.height = '';
             mainEdgePanel.style.transform = 'none';
-            mainEdgePanel.style.top = `${compactTop}px`;
-            mainEdgePanel.style.bottom = `${compactBottom}px`;
+            mainEdgePanel.style.bottom = '';
+            mainEdgePanel.style.top = `${safeTop}px`;
             mainEdgePanelContent.style.maxHeight = '';
             mainEdgePanelContent.style.overflowY = 'auto';
             return;


### PR DESCRIPTION
## Summary
- increase the edge panel's minimum height and handle length so the launcher feels taller
- bias the compact layout positioning logic to tuck the panel toward the middle of the screen instead of pinning it to the top

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_6905e8c0930c8332b9ae791ccaed2ed1