### PR TITLE
Reposition edge panel and music player

### DIFF
--- a/main.html
+++ b/main.html
@@ -53,7 +53,7 @@
   <style>
     :root {
       --glass-blur: 0px;
-      --edge-panel-top-offset: clamp(14px, 3vh, 32px);
+      --edge-panel-top-offset: clamp(140px, 18vh, 240px);
       --edge-panel-bottom-guard: clamp(4rem, 18vh, 6rem);
       --edge-panel-max-height: 92vh;
       --edge-panel-min-height: clamp(320px, 68vh, 560px);
@@ -199,7 +199,7 @@
       overflow-y: auto;
       opacity: 1;
       transition: opacity 0.5s ease-in-out;
-      padding-bottom: 20rem; /* Add padding to avoid overlap */
+      padding-bottom: clamp(3rem, 12vh, 6rem); /* Balanced spacing before the player */
       background: rgba(0, 0, 0, 0.35);
       border-radius: 20px;
       box-shadow: 0 18px 40px rgba(0, 0, 0, 0.35);
@@ -395,9 +395,8 @@
         width: min(86vw, var(--edge-panel-width));
         right: calc(var(--edge-panel-visible-gap) - min(86vw, var(--edge-panel-width)));
         border-radius: 24px 0 0 24px;
-        top: 50%;
+        top: calc(var(--edge-panel-top-offset) + env(safe-area-inset-top));
         bottom: auto;
-        transform: translateY(-50%);
         min-height: var(--edge-panel-min-height);
       }
       .edge-panel.visible {
@@ -594,9 +593,8 @@
     }
     .edge-panel {
         position: fixed;
-        top: 50%;
+        top: calc(var(--edge-panel-top-offset) + env(safe-area-inset-top));
         right: calc(var(--edge-panel-visible-gap) - var(--edge-panel-width));
-        transform: translateY(-50%);
         bottom: auto;
         width: var(--edge-panel-width);
         background: linear-gradient(160deg, rgba(8, 31, 22, 0.9), rgba(3, 15, 10, 0.86));
@@ -1151,73 +1149,68 @@
       <div class="edge-panel-hint" role="note">Look for the floating “Quick hub” tab near the player—swipe it open or tap the buttons above to jump into chat, Bible study, video, or puzzle modes.</div>
       <div id="newsContainer" class="news-container" style="display: none;"></div>
     </div>
-  </div>
-
-  <footer class="app-footer">
-    <p>&copy; 2024 Omoluabi Productions. <a href="privacy.html">Privacy &amp; data use</a></p>
-  </footer>
-
-  <!-- Music Player -->
-  <div class="music-player">
-    <h3>Music Player</h3>
-    <div class="player-body">
-      <div class="player-visual">
-        <div class="turntable-wrapper">
-          <div class="turntable">
-            <div class="turntable-disc">
-              <span class="turntable-grooves" aria-hidden="true"></span>
-              <img
-                id="albumCover"
-                class="album-cover"
-                src="https://raw.githubusercontent.com/Omoluabi1003/Ariyo-AI/main/Kindness%20Cover%20Art.jpg"
-                alt="Album Cover"
-                onerror="this.onerror=null;this.src='Logo.jpg';"
-              />
-              <span class="album-groove-overlay" aria-hidden="true"></span>
-              <span class="turntable-label" aria-hidden="true"></span>
+    <!-- Music Player -->
+    <div class="music-player">
+      <h3>Music Player</h3>
+      <div class="player-body">
+        <div class="player-visual">
+          <div class="turntable-wrapper">
+            <div class="turntable">
+              <div class="turntable-disc">
+                <span class="turntable-grooves" aria-hidden="true"></span>
+                <img
+                  id="albumCover"
+                  class="album-cover"
+                  src="https://raw.githubusercontent.com/Omoluabi1003/Ariyo-AI/main/Kindness%20Cover%20Art.jpg"
+                  alt="Album Cover"
+                  onerror="this.onerror=null;this.src='Logo.jpg';"
+                />
+                <span class="album-groove-overlay" aria-hidden="true"></span>
+                <span class="turntable-label" aria-hidden="true"></span>
+              </div>
+              <span class="turntable-sheen" aria-hidden="true"></span>
             </div>
-            <span class="turntable-sheen" aria-hidden="true"></span>
           </div>
+          <div id="loadingSpinner" class="loading-spinner"></div>
         </div>
-        <div id="loadingSpinner" class="loading-spinner"></div>
-      </div>
-      <div class="player-main">
-        <div id="progressBar" class="progress-bar">
-          <div id="progressBarFill"></div>
-        </div>
-        <p class="track-info" id="trackInfo" aria-live="polite">A Very Good Bad Guy v3</p>
-        <div class="player-meta-grid">
-          <p class="track-details" id="trackArtist">Artist:</p>
-          <p class="track-details" id="trackYear">Release Year: 2025</p>
-          <p class="track-details" id="trackAlbum"></p>
-          <p class="track-duration" id="trackDuration">0:00 / 0:00</p>
-          <p id="shuffleStatusInfo" class="track-details" style="font-style: italic;"></p>
-          <p id="nextTrackInfo" class="track-details" style="font-style: italic;"></p>
-        </div>
-        <input
-          type="range"
-          id="seekBar"
-          value="0"
-          min="0"
-          max="100"
-          step="1"
-          class="seek-bar"
-          aria-label="Seek bar for audio playback"
-          aria-controls="audioPlayer"
-        />
-        <div class="player-utility">
-          <button id="retryButton" class="retry-button" onclick="retryTrack()" aria-label="Retry loading track">Retry</button>
-          <button id="addToPlaylistButton" class="retry-button" onclick="addCurrentTrackToPlaylist()" aria-label="Add current track to playlist">Add to Playlist</button>
-          <button id="lyricsToggle" class="retry-button" onclick="toggleLyrics()" aria-label="Toggle lyrics">Lyrics</button>
-        </div>
-        <div id="lyrics"></div>
-        <div class="music-controls icons-only">
-          <button aria-label="Previous track" onclick="previousTrack()" title="Previous track" aria-controls="audioPlayer" class="ripple shockwave">⏮</button>
-          <button aria-label="Play" onclick="playMusic()" title="Play" aria-controls="audioPlayer" class="ripple shockwave play-button"></button>
-          <button aria-label="Pause" onclick="pauseMusic()" title="Pause" aria-controls="audioPlayer" class="ripple shockwave">⏸</button>
-          <button aria-label="Stop" onclick="stopMusic()" title="Stop" aria-controls="audioPlayer" class="ripple shockwave">⏹</button>
-          <button aria-label="Next track" onclick="nextTrack()" title="Next track" aria-controls="audioPlayer" class="ripple shockwave">⏭</button>
-          <button aria-label="Toggle shuffle" onclick="toggleShuffle()" title="Toggle shuffle" aria-pressed="false" class="ripple shockwave shuffle-button">🔀</button>
+        <div class="player-main">
+          <div id="progressBar" class="progress-bar">
+            <div id="progressBarFill"></div>
+          </div>
+          <p class="track-info" id="trackInfo" aria-live="polite">A Very Good Bad Guy v3</p>
+          <div class="player-meta-grid">
+            <p class="track-details" id="trackArtist">Artist:</p>
+            <p class="track-details" id="trackYear">Release Year: 2025</p>
+            <p class="track-details" id="trackAlbum"></p>
+            <p class="track-duration" id="trackDuration">0:00 / 0:00</p>
+            <p id="shuffleStatusInfo" class="track-details" style="font-style: italic;"></p>
+            <p id="nextTrackInfo" class="track-details" style="font-style: italic;"></p>
+          </div>
+          <input
+            type="range"
+            id="seekBar"
+            value="0"
+            min="0"
+            max="100"
+            step="1"
+            class="seek-bar"
+            aria-label="Seek bar for audio playback"
+            aria-controls="audioPlayer"
+          />
+          <div class="player-utility">
+            <button id="retryButton" class="retry-button" onclick="retryTrack()" aria-label="Retry loading track">Retry</button>
+            <button id="addToPlaylistButton" class="retry-button" onclick="addCurrentTrackToPlaylist()" aria-label="Add current track to playlist">Add to Playlist</button>
+            <button id="lyricsToggle" class="retry-button" onclick="toggleLyrics()" aria-label="Toggle lyrics">Lyrics</button>
+          </div>
+          <div id="lyrics"></div>
+          <div class="music-controls icons-only">
+            <button aria-label="Previous track" onclick="previousTrack()" title="Previous track" aria-controls="audioPlayer" class="ripple shockwave">⏮</button>
+            <button aria-label="Play" onclick="playMusic()" title="Play" aria-controls="audioPlayer" class="ripple shockwave play-button"></button>
+            <button aria-label="Pause" onclick="pauseMusic()" title="Pause" aria-controls="audioPlayer" class="ripple shockwave">⏸</button>
+            <button aria-label="Stop" onclick="stopMusic()" title="Stop" aria-controls="audioPlayer" class="ripple shockwave">⏹</button>
+            <button aria-label="Next track" onclick="nextTrack()" title="Next track" aria-controls="audioPlayer" class="ripple shockwave">⏭</button>
+            <button aria-label="Toggle shuffle" onclick="toggleShuffle()" title="Toggle shuffle" aria-pressed="false" class="ripple shockwave shuffle-button">🔀</button>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- lower the quick-launch edge panel so it no longer overlaps the header share button
- move the music player into the main layout in place of the removed footer and adjust surrounding spacing

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_6905ed3be8588332b0081a5bd2a73857