### PR TITLE
Relocate music player into main content column

### DIFF
--- a/main.html
+++ b/main.html
@@ -1147,69 +1147,68 @@
         </div>
       </details>
       <div class="edge-panel-hint" role="note">Look for the floating “Quick hub” tab near the player—swipe it open or tap the buttons above to jump into chat, Bible study, video, or puzzle modes.</div>
-      <div id="newsContainer" class="news-container" style="display: none;"></div>
-    </div>
-    <!-- Music Player -->
-    <div class="music-player">
-      <h3>Music Player</h3>
-      <div class="player-body">
-        <div class="player-visual">
-          <div class="turntable-wrapper">
-            <div class="turntable">
-              <div class="turntable-disc">
-                <span class="turntable-grooves" aria-hidden="true"></span>
-                <img
-                  id="albumCover"
-                  class="album-cover"
-                  src="https://raw.githubusercontent.com/Omoluabi1003/Ariyo-AI/main/Kindness%20Cover%20Art.jpg"
-                  alt="Album Cover"
-                  onerror="this.onerror=null;this.src='Logo.jpg';"
-                />
-                <span class="album-groove-overlay" aria-hidden="true"></span>
-                <span class="turntable-label" aria-hidden="true"></span>
+      <!-- Music Player -->
+      <div class="music-player">
+        <h3>Music Player</h3>
+        <div class="player-body">
+          <div class="player-visual">
+            <div class="turntable-wrapper">
+              <div class="turntable">
+                <div class="turntable-disc">
+                  <span class="turntable-grooves" aria-hidden="true"></span>
+                  <img
+                    id="albumCover"
+                    class="album-cover"
+                    src="https://raw.githubusercontent.com/Omoluabi1003/Ariyo-AI/main/Kindness%20Cover%20Art.jpg"
+                    alt="Album Cover"
+                    onerror="this.onerror=null;this.src='Logo.jpg';"
+                  />
+                  <span class="album-groove-overlay" aria-hidden="true"></span>
+                  <span class="turntable-label" aria-hidden="true"></span>
+                </div>
+                <span class="turntable-sheen" aria-hidden="true"></span>
               </div>
-              <span class="turntable-sheen" aria-hidden="true"></span>
             </div>
+            <div id="loadingSpinner" class="loading-spinner"></div>
           </div>
-          <div id="loadingSpinner" class="loading-spinner"></div>
-        </div>
-        <div class="player-main">
-          <div id="progressBar" class="progress-bar">
-            <div id="progressBarFill"></div>
-          </div>
-          <p class="track-info" id="trackInfo" aria-live="polite">A Very Good Bad Guy v3</p>
-          <div class="player-meta-grid">
-            <p class="track-details" id="trackArtist">Artist:</p>
-            <p class="track-details" id="trackYear">Release Year: 2025</p>
-            <p class="track-details" id="trackAlbum"></p>
-            <p class="track-duration" id="trackDuration">0:00 / 0:00</p>
-            <p id="shuffleStatusInfo" class="track-details" style="font-style: italic;"></p>
-            <p id="nextTrackInfo" class="track-details" style="font-style: italic;"></p>
-          </div>
-          <input
-            type="range"
-            id="seekBar"
-            value="0"
-            min="0"
-            max="100"
-            step="1"
-            class="seek-bar"
-            aria-label="Seek bar for audio playback"
-            aria-controls="audioPlayer"
-          />
-          <div class="player-utility">
-            <button id="retryButton" class="retry-button" onclick="retryTrack()" aria-label="Retry loading track">Retry</button>
-            <button id="addToPlaylistButton" class="retry-button" onclick="addCurrentTrackToPlaylist()" aria-label="Add current track to playlist">Add to Playlist</button>
-            <button id="lyricsToggle" class="retry-button" onclick="toggleLyrics()" aria-label="Toggle lyrics">Lyrics</button>
-          </div>
-          <div id="lyrics"></div>
-          <div class="music-controls icons-only">
-            <button aria-label="Previous track" onclick="previousTrack()" title="Previous track" aria-controls="audioPlayer" class="ripple shockwave">⏮</button>
-            <button aria-label="Play" onclick="playMusic()" title="Play" aria-controls="audioPlayer" class="ripple shockwave play-button"></button>
-            <button aria-label="Pause" onclick="pauseMusic()" title="Pause" aria-controls="audioPlayer" class="ripple shockwave">⏸</button>
-            <button aria-label="Stop" onclick="stopMusic()" title="Stop" aria-controls="audioPlayer" class="ripple shockwave">⏹</button>
-            <button aria-label="Next track" onclick="nextTrack()" title="Next track" aria-controls="audioPlayer" class="ripple shockwave">⏭</button>
-            <button aria-label="Toggle shuffle" onclick="toggleShuffle()" title="Toggle shuffle" aria-pressed="false" class="ripple shockwave shuffle-button">🔀</button>
+          <div class="player-main">
+            <div id="progressBar" class="progress-bar">
+              <div id="progressBarFill"></div>
+            </div>
+            <p class="track-info" id="trackInfo" aria-live="polite">A Very Good Bad Guy v3</p>
+            <div class="player-meta-grid">
+              <p class="track-details" id="trackArtist">Artist:</p>
+              <p class="track-details" id="trackYear">Release Year: 2025</p>
+              <p class="track-details" id="trackAlbum"></p>
+              <p class="track-duration" id="trackDuration">0:00 / 0:00</p>
+              <p id="shuffleStatusInfo" class="track-details" style="font-style: italic;"></p>
+              <p id="nextTrackInfo" class="track-details" style="font-style: italic;"></p>
+            </div>
+            <input
+              type="range"
+              id="seekBar"
+              value="0"
+              min="0"
+              max="100"
+              step="1"
+              class="seek-bar"
+              aria-label="Seek bar for audio playback"
+              aria-controls="audioPlayer"
+            />
+            <div class="player-utility">
+              <button id="retryButton" class="retry-button" onclick="retryTrack()" aria-label="Retry loading track">Retry</button>
+              <button id="addToPlaylistButton" class="retry-button" onclick="addCurrentTrackToPlaylist()" aria-label="Add current track to playlist">Add to Playlist</button>
+              <button id="lyricsToggle" class="retry-button" onclick="toggleLyrics()" aria-label="Toggle lyrics">Lyrics</button>
+            </div>
+            <div id="lyrics"></div>
+            <div class="music-controls icons-only">
+              <button aria-label="Previous track" onclick="previousTrack()" title="Previous track" aria-controls="audioPlayer" class="ripple shockwave">⏮</button>
+              <button aria-label="Play" onclick="playMusic()" title="Play" aria-controls="audioPlayer" class="ripple shockwave play-button"></button>
+              <button aria-label="Pause" onclick="pauseMusic()" title="Pause" aria-controls="audioPlayer" class="ripple shockwave">⏸</button>
+              <button aria-label="Stop" onclick="stopMusic()" title="Stop" aria-controls="audioPlayer" class="ripple shockwave">⏹</button>
+              <button aria-label="Next track" onclick="nextTrack()" title="Next track" aria-controls="audioPlayer" class="ripple shockwave">⏭</button>
+              <button aria-label="Toggle shuffle" onclick="toggleShuffle()" title="Toggle shuffle" aria-pressed="false" class="ripple shockwave shuffle-button">🔀</button>
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- remove the unused news container above the player and embed the music player inside the main content area
- keep the player markup intact while ensuring indentation matches the surrounding structure

## Testing
- not run (HTML/CSS change only)

------
https://chatgpt.com/codex/tasks/task_e_6905eed2bd888332acb48b6a95842159