### PR TITLE
Restore audio player element

### DIFF
--- a/main.html
+++ b/main.html
@@ -1209,6 +1209,7 @@
               <button aria-label="Next track" onclick="nextTrack()" title="Next track" aria-controls="audioPlayer" class="ripple shockwave">⏭</button>
               <button aria-label="Toggle shuffle" onclick="toggleShuffle()" title="Toggle shuffle" aria-pressed="false" class="ripple shockwave shuffle-button">🔀</button>
             </div>
+            <audio id="audioPlayer" preload="auto" hidden aria-hidden="true"></audio>
           </div>
         </div>
       </div>

--- a/scripts/player.js
+++ b/scripts/player.js
@@ -1,5 +1,6 @@
 /* MUSIC PLAYER LOGIC */
-    const audioPlayer = new Audio();
+    const existingAudioElement = document.getElementById('audioPlayer');
+    const audioPlayer = existingAudioElement || document.createElement('audio');
     function setCrossOrigin(element, url) {
         try {
             const host = new URL(url, window.location.origin).hostname;
@@ -29,14 +30,18 @@
         window.addEventListener(evt, resumeAudioContext, { once: true, passive: true });
     });
 
-    audioPlayer.id = 'audioPlayer';
+    if (!existingAudioElement) {
+        audioPlayer.id = 'audioPlayer';
+    }
     audioPlayer.preload = 'auto';
     audioPlayer.volume = 1;
     audioPlayer.muted = false;
     audioPlayer.setAttribute('playsinline', '');
     audioPlayer.setAttribute('controlsList', 'nodownload');
     audioPlayer.addEventListener('contextmenu', e => e.preventDefault());
-    document.body.appendChild(audioPlayer);
+    if (!existingAudioElement) {
+        document.body.appendChild(audioPlayer);
+    }
     const albumCover = document.getElementById('albumCover');
     const turntableDisc = document.querySelector('.turntable-disc');
     const trackInfo = document.getElementById('trackInfo');


### PR DESCRIPTION
## Summary
- reintroduce a hidden audio element to the music player markup so the player is present in the DOM
- update the player script to reuse the embedded audio element when available while keeping the previous fallback

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6905f09f9ae48332ab4219202e8f60ed