### PR TITLE
Restore media player after returning from About page

### DIFF
--- a/style.css
+++ b/style.css
@@ -656,6 +656,26 @@ body {
     color: #fff;
 }
 
+.content-loading {
+    background: rgba(18, 183, 106, 0.15);
+    color: #d9fbe7;
+    padding: 0.85rem 1.25rem;
+    border-radius: 16px;
+    text-align: center;
+    font-size: clamp(0.85rem, 2.4vw, 1rem);
+    margin-bottom: 1rem;
+}
+
+.content-error-banner {
+    background: rgba(220, 38, 38, 0.85);
+    color: #fff;
+    padding: 0.85rem 1.25rem;
+    border-radius: 16px;
+    margin-bottom: 1rem;
+    box-shadow: 0 12px 32px rgba(0, 0, 0, 0.45);
+    font-size: clamp(0.85rem, 2.4vw, 1rem);
+}
+
 .dropdown {
     width: 100%;
     background: rgba(34,34,34,0.8);


### PR DESCRIPTION
## Summary
- preserve the original main content when navigating to the About page so the music player can be restored intact
- add lightweight loading and error feedback when About content fails to load and refresh edge panel layout on return
- style the new loading/error banners used during About navigation

## Testing
- manual Playwright verification that the music player remains after visiting About and returning

------
https://chatgpt.com/codex/tasks/task_e_6905f2e0e7c483329d2c0dcf21a5a056