### PR TITLE
Center and expand quick launch edge panel

### DIFF
--- a/main.html
+++ b/main.html
@@ -53,13 +53,14 @@
   <style>
     :root {
       --glass-blur: 0px;
-      --edge-panel-top-offset: clamp(140px, 18vh, 240px);
-      --edge-panel-bottom-guard: clamp(4rem, 18vh, 6rem);
-      --edge-panel-max-height: 92vh;
-      --edge-panel-min-height: clamp(320px, 68vh, 560px);
-      --edge-panel-width: clamp(220px, 30vw, 280px);
-      --edge-panel-handle-width: clamp(14px, 3vw, 20px);
-      --edge-panel-visible-gap: clamp(6px, 1.8vw, 12px);
+      --edge-panel-vertical-margin: clamp(48px, 12vh, 96px);
+      --edge-panel-top-offset: var(--edge-panel-vertical-margin);
+      --edge-panel-bottom-guard: var(--edge-panel-vertical-margin);
+      --edge-panel-max-height: calc(var(--app-height, 100vh) - (2 * var(--edge-panel-vertical-margin)));
+      --edge-panel-min-height: clamp(480px, 74vh, 640px);
+      --edge-panel-width: clamp(240px, 32vw, 320px);
+      --edge-panel-handle-width: clamp(18px, 4vw, 26px);
+      --edge-panel-visible-gap: clamp(8px, 2vw, 16px);
     }
     html, body {
       height: 100%;
@@ -593,13 +594,14 @@
     }
     .edge-panel {
         position: fixed;
-        top: calc(var(--edge-panel-top-offset) + env(safe-area-inset-top));
+        top: 50%;
         right: calc(var(--edge-panel-visible-gap) - var(--edge-panel-width));
         bottom: auto;
+        transform: translateY(-50%);
         width: var(--edge-panel-width);
         background: linear-gradient(160deg, rgba(8, 31, 22, 0.9), rgba(3, 15, 10, 0.86));
         border-radius: 24px 0 0 24px;
-        transition: right 0.3s ease-in-out, box-shadow 0.3s ease-in-out, background 0.3s ease-in-out;
+        transition: right 0.3s ease-in-out, box-shadow 0.3s ease-in-out, background 0.3s ease-in-out, transform 0.3s ease-in-out;
         z-index: 10000;
         box-shadow: 0 22px 46px rgba(0, 0, 0, 0.55);
         display: flex;
@@ -609,7 +611,7 @@
         max-height: min(
           var(--edge-panel-max-height),
           calc(
-            var(--app-height, 100vh) - env(safe-area-inset-top) - env(safe-area-inset-bottom) - var(--edge-panel-bottom-guard) - var(--edge-panel-top-offset)
+            var(--app-height, 100vh) - env(safe-area-inset-top) - env(safe-area-inset-bottom) - (2 * var(--edge-panel-vertical-margin))
           )
         );
         border: 1px solid rgba(255, 255, 255, 0.12);
@@ -691,15 +693,18 @@
         justify-content: flex-start;
         align-items: stretch;
         gap: clamp(0.45rem, 1.8vw, 0.65rem);
-        padding: clamp(0.85rem, 2.2vw, 1rem);
+        padding: clamp(0.95rem, 2.4vw, 1.2rem);
         flex: 1;
-        overflow: hidden;
+        overflow-y: auto;
+        overflow-x: hidden;
+        max-height: 100%;
+        scrollbar-width: thin;
     }
     .edge-panel-list {
         display: grid;
-        grid-auto-rows: minmax(clamp(2.6rem, 6.2vh, 3.4rem), 1fr);
+        grid-auto-rows: minmax(clamp(3.1rem, 6.5vh, 3.9rem), auto);
         align-content: stretch;
-        gap: clamp(0.35rem, 1.4vw, 0.55rem);
+        gap: clamp(0.4rem, 1.6vw, 0.65rem);
         flex: 1;
         min-height: 0;
     }
@@ -752,7 +757,7 @@
       font: inherit;
       appearance: none;
       background-clip: padding-box;
-      min-height: 2.8rem;
+      min-height: clamp(3.1rem, 6.5vh, 3.9rem);
     }
     .edge-panel-item:focus-visible {
       outline: none;
@@ -784,11 +789,12 @@
       line-height: 1.18;
     }
     .edge-panel-privacy {
-      font-size: clamp(0.66rem, 1.5vw, 0.8rem);
+      font-size: clamp(0.66rem, 1.5vw, 0.82rem);
       text-align: center;
-      line-height: 1.35;
+      line-height: 1.4;
       color: rgba(255,255,255,0.75);
-      margin-top: clamp(0.4rem, 1.6vw, 0.85rem);
+      margin-top: auto;
+      padding-top: clamp(0.5rem, 1.4vw, 0.85rem);
     }
     .edge-panel-privacy a {
       color: var(--theme-color);

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -829,8 +829,8 @@
     const mainEdgePanelContent = document.querySelector('.edge-panel-content');
     const musicPlayerElement = document.querySelector('.music-player');
 
-    const MIN_EDGE_PANEL_APPS_VISIBLE = 4;
-    const EDGE_PANEL_MIN_HEIGHT = 320;
+    const BASE_EDGE_PANEL_APPS_VISIBLE = 4;
+    const EDGE_PANEL_MIN_HEIGHT = 480;
 
     const updateEdgePanelHeight = () => {
         if (!mainEdgePanel || !mainEdgePanelContent) return;
@@ -890,7 +890,8 @@
         }
 
         const launcherItems = Array.from(mainEdgePanelContent.querySelectorAll('.edge-panel-item'));
-        const visibleCount = Math.min(MIN_EDGE_PANEL_APPS_VISIBLE, launcherItems.length);
+        const totalLauncherCount = launcherItems.length;
+        const visibleCount = Math.max(totalLauncherCount, BASE_EDGE_PANEL_APPS_VISIBLE);
         let launcherHeight = 0;
         if (launcherItems.length) {
             const itemRect = launcherItems[0].getBoundingClientRect();


### PR DESCRIPTION
## Summary
- center the quick launch edge panel vertically and widen its layout variables so it remains balanced across devices
- increase edge panel row spacing and typography while giving the privacy note its own padding so all app icons remain visible
- raise the dynamic sizing logic to account for the full launcher list and taller panel minimums

## Testing
- Not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_6905f84078a883328af9425463b2e601