### PR TITLE
Improve About page transitions

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -200,7 +200,7 @@
       }
 
       const banner = document.createElement('div');
-      banner.className = 'content-error-banner';
+      banner.className = 'content-transition-banner content-error-banner';
       banner.setAttribute('role', 'status');
       banner.setAttribute('aria-live', 'polite');
       banner.textContent = message;
@@ -281,7 +281,7 @@
       const captured = captureMainContent(mainContent);
 
       if (captured) {
-        mainContent.innerHTML = '<p class="content-loading">Loading About page…</p>';
+        mainContent.innerHTML = '<p class="content-transition-banner content-loading">Loading About page…</p>';
       }
 
       savePlayerState();
@@ -294,7 +294,7 @@
           if (restored) {
             showContentError(mainContent, 'Error loading About page content. Please try again later.');
           } else {
-            mainContent.innerHTML = '<p class="content-error-banner">Error loading About page content. Please try again later.</p>';
+            mainContent.innerHTML = '<p class="content-transition-banner content-error-banner">Error loading About page content. Please try again later.</p>';
           }
           return;
         }
@@ -388,7 +388,7 @@
         if (restored) {
           showContentError(mainContent, 'Error loading About page content. Please try again later.');
         } else if (mainContent) {
-          mainContent.innerHTML = '<p class="content-error-banner">Error loading About page content. Please try again later.</p>';
+          mainContent.innerHTML = '<p class="content-transition-banner content-error-banner">Error loading About page content. Please try again later.</p>';
         }
       }
     }

--- a/style.css
+++ b/style.css
@@ -656,24 +656,23 @@ body {
     color: #fff;
 }
 
-.content-loading {
-    background: rgba(18, 183, 106, 0.15);
-    color: #d9fbe7;
+.content-transition-banner {
     padding: 0.85rem 1.25rem;
     border-radius: 16px;
     text-align: center;
     font-size: clamp(0.85rem, 2.4vw, 1rem);
     margin-bottom: 1rem;
+    box-shadow: 0 12px 32px rgba(0, 0, 0, 0.35);
+}
+
+.content-loading {
+    background: rgba(18, 183, 106, 0.18);
+    color: #d9fbe7;
 }
 
 .content-error-banner {
     background: rgba(220, 38, 38, 0.85);
     color: #fff;
-    padding: 0.85rem 1.25rem;
-    border-radius: 16px;
-    margin-bottom: 1rem;
-    box-shadow: 0 12px 32px rgba(0, 0, 0, 0.45);
-    font-size: clamp(0.85rem, 2.4vw, 1rem);
 }
 
 .dropdown {


### PR DESCRIPTION
## Summary
- apply shared content transition banner styling for the About page loading and error messages
- ensure About page failures reuse contextual banners while preserving the captured player DOM

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6905f9ede5c8833289bc52226e983455