### PR TITLE
Add embedded Omoluabi music player app

### DIFF
--- a/apps/music-player/music-player.css
+++ b/apps/music-player/music-player.css
@@ -1,0 +1,315 @@
+:root {
+  color-scheme: dark;
+  --player-bg: rgba(8, 8, 12, 0.9);
+  --player-accent: #12B76A;
+  --player-muted: rgba(255, 255, 255, 0.7);
+  --player-border: rgba(255, 255, 255, 0.1);
+  --player-radius: 20px;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+  font-family: 'Montserrat', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background: radial-gradient(circle at top, rgba(33, 150, 83, 0.35), rgba(5, 5, 5, 0.95));
+  color: #fff;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.player-header {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: calc(1rem + env(safe-area-inset-top)) 1.25rem 1rem;
+  background: linear-gradient(135deg, rgba(18, 183, 106, 0.75), rgba(0, 0, 0, 0.85));
+  border-bottom: 1px solid var(--player-border);
+}
+
+.player-logo {
+  width: clamp(52px, 12vw, 68px);
+  height: clamp(52px, 12vw, 68px);
+  object-fit: contain;
+  border-radius: 16px;
+  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.35);
+}
+
+.player-title-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.player-title {
+  margin: 0;
+  font-size: clamp(1.6rem, 4vw, 2rem);
+  font-weight: 700;
+}
+
+.player-tagline {
+  margin: 0;
+  font-size: clamp(0.9rem, 2.6vw, 1rem);
+  color: var(--player-muted);
+}
+
+.player-shell {
+  flex: 1;
+  display: grid;
+  grid-template-columns: minmax(0, 360px) minmax(0, 1fr);
+  gap: clamp(1.25rem, 4vw, 2rem);
+  padding: clamp(1.25rem, 3vw, 2.5rem);
+  box-sizing: border-box;
+}
+
+.player-panel,
+.playlist {
+  background: var(--player-bg);
+  border-radius: var(--player-radius);
+  border: 1px solid var(--player-border);
+  padding: clamp(1.25rem, 3vw, 1.75rem);
+  box-shadow: 0 24px 46px rgba(0, 0, 0, 0.35);
+  backdrop-filter: blur(18px);
+}
+
+.player-panel {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 1rem;
+  align-content: start;
+}
+
+.artwork-frame {
+  width: min(100%, 240px);
+  aspect-ratio: 1 / 1;
+  margin: 0 auto;
+  border-radius: 16px;
+  overflow: hidden;
+  border: 2px solid rgba(255, 255, 255, 0.1);
+  box-shadow: 0 16px 32px rgba(0, 0, 0, 0.4);
+}
+
+.artwork-frame img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.now-playing {
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+}
+
+.track-title {
+  margin: 0;
+  font-size: clamp(1.35rem, 3vw, 1.75rem);
+  font-weight: 700;
+}
+
+.track-artist {
+  margin: 0;
+  color: var(--player-muted);
+  font-size: clamp(0.95rem, 2.3vw, 1.05rem);
+}
+
+.time-row {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 0.75rem;
+  align-items: center;
+  font-variant-numeric: tabular-nums;
+}
+
+.seek {
+  width: 100%;
+  accent-color: var(--player-accent);
+}
+
+.control-row,
+.support-row {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.control {
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid transparent;
+  color: #fff;
+  padding: 0.6rem 1rem;
+  border-radius: 999px;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.control:hover,
+.control:focus-visible {
+  background: rgba(255, 255, 255, 0.18);
+  transform: translateY(-1px);
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.25);
+  outline: none;
+}
+
+.control.primary {
+  background: var(--player-accent);
+  color: #06130b;
+  font-weight: 700;
+}
+
+.control.secondary {
+  font-size: 0.85rem;
+  padding-inline: 0.9rem;
+}
+
+.control[aria-pressed="true"] {
+  background: rgba(18, 183, 106, 0.25);
+  border-color: var(--player-accent);
+}
+
+.volume-label {
+  font-size: 0.85rem;
+  letter-spacing: 0.01em;
+  color: var(--player-muted);
+}
+
+.status {
+  min-height: 1.2rem;
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--player-muted);
+}
+
+.status[data-tone="error"] {
+  color: #ffb8b8;
+}
+
+.status[data-tone="warning"] {
+  color: #ffe4a3;
+}
+
+.status[data-tone="success"] {
+  color: #bbffce;
+}
+
+.playlist {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.playlist-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.playlist-items {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.playlist-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.75rem 1rem;
+  border-radius: 14px;
+  border: 1px solid transparent;
+  background: rgba(255, 255, 255, 0.05);
+  transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+  cursor: pointer;
+}
+
+.playlist-item:hover,
+.playlist-item:focus-visible {
+  background: rgba(255, 255, 255, 0.12);
+  border-color: rgba(18, 183, 106, 0.45);
+  transform: translateY(-1px);
+  outline: none;
+}
+
+.playlist-item.active {
+  background: rgba(18, 183, 106, 0.2);
+  border-color: rgba(18, 183, 106, 0.8);
+}
+
+.playlist-meta {
+  display: flex;
+  flex-direction: column;
+}
+
+.playlist-meta span:first-child {
+  font-weight: 600;
+}
+
+.playlist-artist {
+  color: var(--player-muted);
+  font-size: 0.85rem;
+}
+
+.playlist-duration {
+  font-variant-numeric: tabular-nums;
+  color: var(--player-muted);
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@media (max-width: 980px) {
+  .player-shell {
+    grid-template-columns: 1fr;
+  }
+
+  .player-panel {
+    grid-template-columns: minmax(0, 1fr);
+    justify-items: center;
+  }
+
+  .artwork-frame {
+    width: min(220px, 60vw);
+  }
+}
+
+@media (max-width: 600px) {
+  .player-header {
+    flex-direction: column;
+    text-align: center;
+  }
+
+  .player-shell {
+    padding: clamp(1rem, 6vw, 2rem);
+  }
+
+  .control-row,
+  .support-row {
+    justify-content: center;
+  }
+
+  .playlist-item {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.35rem;
+  }
+
+  .playlist-duration {
+    align-self: flex-end;
+  }
+}

--- a/apps/music-player/music-player.html
+++ b/apps/music-player/music-player.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover" />
+  <meta name="apple-mobile-web-app-capable" content="yes" />
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+  <meta name="apple-mobile-web-app-title" content="Àríyò AI" />
+  <meta name="apple-touch-fullscreen" content="yes" />
+  <link rel="apple-touch-icon" href="../../icons/Ariyo.png" />
+  <title>Omoluabi Music Player</title>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600;700&display=swap" />
+  <link rel="stylesheet" href="../../color-scheme.css" />
+  <link rel="stylesheet" href="./music-player.css" />
+  <script src="../../viewport-height.js" defer></script>
+</head>
+<body>
+  <header class="player-header" role="banner">
+    <img src="../../music-player.png" alt="Omoluabi music player logo" class="player-logo" />
+    <div class="player-title-group">
+      <h1 class="player-title">Omoluabi Player</h1>
+      <p class="player-tagline">Handpicked Àríyò favourites ready to spin wherever you are.</p>
+    </div>
+  </header>
+
+  <main class="player-shell" role="main">
+    <section class="player-panel" aria-labelledby="nowPlayingHeading">
+      <h2 id="nowPlayingHeading" class="visually-hidden">Now playing</h2>
+      <div class="artwork-frame" aria-hidden="true">
+        <img id="artwork" src="../../Kindness%20Cover%20Art.jpg" alt="Current track cover art" />
+      </div>
+      <div class="now-playing">
+        <p id="trackTitle" class="track-title">A Very Good Bad Guy v3</p>
+        <p id="trackArtist" class="track-artist">Omoluabi</p>
+        <div class="time-row">
+          <span id="elapsedTime">0:00</span>
+          <input type="range" id="seekBar" class="seek" min="0" max="100" value="0" step="1" aria-label="Track progress" />
+          <span id="totalTime">0:00</span>
+        </div>
+        <div class="control-row">
+          <button type="button" class="control" id="prevButton" aria-label="Previous track">⏮</button>
+          <button type="button" class="control primary" id="playPauseButton" aria-label="Play track">▶️</button>
+          <button type="button" class="control" id="nextButton" aria-label="Next track">⏭</button>
+        </div>
+        <div class="support-row">
+          <label class="volume-label" for="volumeControl">Volume</label>
+          <input type="range" id="volumeControl" min="0" max="1" step="0.01" value="1" aria-label="Playback volume" />
+          <button type="button" class="control secondary" id="shuffleButton" aria-pressed="false">Shuffle</button>
+        </div>
+        <p id="statusMessage" class="status" role="status" aria-live="polite"></p>
+      </div>
+    </section>
+
+    <section class="playlist" aria-labelledby="playlistHeading">
+      <div class="playlist-header">
+        <h2 id="playlistHeading">Track list</h2>
+        <button type="button" id="refreshButton" class="control secondary">Reshuffle order</button>
+      </div>
+      <ol id="playlist" class="playlist-items"></ol>
+    </section>
+  </main>
+
+  <audio id="audio" preload="metadata" crossorigin="anonymous" playsinline></audio>
+
+  <script src="./music-player.js"></script>
+  <script src="../../color-scheme.js"></script>
+  <script>
+    changeColorScheme();
+  </script>
+  <script src="../../prevent-zoom.js"></script>
+</body>
+</html>

--- a/apps/music-player/music-player.js
+++ b/apps/music-player/music-player.js
@@ -1,0 +1,379 @@
+(function () {
+  const audio = document.getElementById('audio');
+  const artwork = document.getElementById('artwork');
+  const trackTitle = document.getElementById('trackTitle');
+  const trackArtist = document.getElementById('trackArtist');
+  const elapsedTime = document.getElementById('elapsedTime');
+  const totalTime = document.getElementById('totalTime');
+  const seekBar = document.getElementById('seekBar');
+  const volumeControl = document.getElementById('volumeControl');
+  const playPauseButton = document.getElementById('playPauseButton');
+  const prevButton = document.getElementById('prevButton');
+  const nextButton = document.getElementById('nextButton');
+  const shuffleButton = document.getElementById('shuffleButton');
+  const refreshButton = document.getElementById('refreshButton');
+  const playlistElement = document.getElementById('playlist');
+  const statusMessage = document.getElementById('statusMessage');
+
+  const tracks = [
+    {
+      title: 'A Very Good Bad Guy v3',
+      artist: 'Omoluabi',
+      src: '../../A%20Very%20Good%20Bad%20Guy%20v3.mp3',
+      cover: '../../Kindness%20Cover%20Art.jpg',
+      duration: 0,
+    },
+    {
+      title: 'Algorithm Of Life',
+      artist: 'Omoluabi',
+      src: '../../Algorithm%20Of%20Life.mp3',
+      cover: '../../Street_Sense_Album_Cover.jpg',
+      duration: 0,
+    },
+    {
+      title: 'Holy Vibes Only',
+      artist: 'Omoluabi',
+      src: '../../Holy%20Vibes%20Only.mp3',
+      cover: '../../Naija%20AI4.png',
+      duration: 0,
+    },
+    {
+      title: 'Multi choice palava',
+      artist: 'Omoluabi',
+      src: '../../Multi%20choice%20palava.mp3',
+      cover: '../../Naija%20AI6.png',
+      duration: 0,
+    },
+    {
+      title: 'Street Sense',
+      artist: 'Omoluabi',
+      src: '../../Street%20Sense.mp3',
+      cover: '../../Street_Sense_Album_Cover.jpg',
+      duration: 0,
+    },
+    {
+      title: 'Working on myself',
+      artist: 'Omoluabi',
+      src: '../../Working%20on%20myself.mp3',
+      cover: '../../Naija%20AI2.png',
+      duration: 0,
+    },
+  ];
+
+  let currentIndex = 0;
+  let isShuffle = false;
+  let shuffleOrder = [...Array(tracks.length).keys()];
+  let userSeeking = false;
+
+  function postPanelStatus(status, detail) {
+    if (window.parent && window.parent !== window) {
+      window.parent.postMessage({
+        source: 'edge-panel-app',
+        panelId: 'musicPlayerContainer',
+        status,
+        detail: detail || null,
+      }, '*');
+    }
+  }
+
+  function formatTime(seconds) {
+    const safeSeconds = Number.isFinite(seconds) ? Math.max(seconds, 0) : 0;
+    const minutes = Math.floor(safeSeconds / 60);
+    const secs = Math.floor(safeSeconds % 60)
+      .toString()
+      .padStart(2, '0');
+    return `${minutes}:${secs}`;
+  }
+
+  function setStatus(message, tone = 'info') {
+    statusMessage.textContent = message || '';
+    statusMessage.dataset.tone = tone;
+  }
+
+  function updatePlayButton() {
+    if (audio.paused) {
+      playPauseButton.textContent = '▶️';
+      playPauseButton.setAttribute('aria-label', 'Play track');
+    } else {
+      playPauseButton.textContent = '⏸';
+      playPauseButton.setAttribute('aria-label', 'Pause track');
+    }
+  }
+
+  function getCurrentTrack() {
+    return tracks[shuffleOrder[currentIndex]];
+  }
+
+  function preloadDuration(track) {
+    return new Promise(resolve => {
+      if (track.duration && Number.isFinite(track.duration)) {
+        resolve(track.duration);
+        return;
+      }
+
+      const probe = new Audio();
+      probe.preload = 'metadata';
+      probe.src = track.src;
+      probe.addEventListener('loadedmetadata', () => {
+        track.duration = probe.duration;
+        resolve(track.duration);
+      }, { once: true });
+      probe.addEventListener('error', () => resolve(0), { once: true });
+    });
+  }
+
+  function updatePlaylistActive() {
+    const items = playlistElement.querySelectorAll('.playlist-item');
+    items.forEach((item, index) => {
+      const isActive = index === currentIndex;
+      item.classList.toggle('active', isActive);
+      if (isActive) {
+        item.setAttribute('aria-current', 'true');
+        item.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+      } else {
+        item.removeAttribute('aria-current');
+      }
+    });
+  }
+
+  function loadTrack(index, { autoplay = false } = {}) {
+    currentIndex = index;
+    const track = getCurrentTrack();
+    audio.src = track.src;
+    audio.load();
+    artwork.src = track.cover || '../../Logo.jpg';
+    artwork.alt = `${track.title} cover art`;
+    trackTitle.textContent = track.title;
+    trackArtist.textContent = track.artist || 'Àríyò Collective';
+    seekBar.value = 0;
+    elapsedTime.textContent = '0:00';
+    totalTime.textContent = track.duration ? formatTime(track.duration) : '0:00';
+    setStatus('Loading track…');
+    updatePlaylistActive();
+
+    if (autoplay) {
+      const playPromise = audio.play();
+      if (playPromise) {
+        playPromise.catch(() => {
+          updatePlayButton();
+          setStatus('Tap play to start listening.', 'warning');
+        });
+      }
+    } else {
+      updatePlayButton();
+    }
+  }
+
+  function playCurrent() {
+    const playPromise = audio.play();
+    if (playPromise) {
+      playPromise
+        .then(() => {
+          setStatus(`Now playing: ${trackTitle.textContent}`);
+          updatePlayButton();
+        })
+        .catch(() => {
+          setStatus('Playback was blocked by your browser. Tap play again.', 'warning');
+          updatePlayButton();
+        });
+    }
+  }
+
+  function pausePlayback() {
+    audio.pause();
+    updatePlayButton();
+    setStatus('Playback paused.');
+  }
+
+  function playNext() {
+    const nextIndex = (currentIndex + 1) % shuffleOrder.length;
+    loadTrack(nextIndex, { autoplay: true });
+  }
+
+  function playPrevious() {
+    const prevIndex = (currentIndex - 1 + shuffleOrder.length) % shuffleOrder.length;
+    loadTrack(prevIndex, { autoplay: true });
+  }
+
+  function shuffleOrderRandomly() {
+    const currentTrackIndex = shuffleOrder[currentIndex];
+    shuffleOrder = shuffleOrder
+      .map(value => ({ value, sortKey: Math.random() }))
+      .sort((a, b) => a.sortKey - b.sortKey)
+      .map(item => item.value);
+    currentIndex = shuffleOrder.indexOf(currentTrackIndex);
+    updatePlaylist();
+    updatePlaylistActive();
+  }
+
+  function toggleShuffle() {
+    isShuffle = !isShuffle;
+    shuffleButton.setAttribute('aria-pressed', String(isShuffle));
+    shuffleButton.textContent = isShuffle ? 'Shuffling' : 'Shuffle';
+
+    const currentTrackIndex = shuffleOrder[currentIndex];
+    if (isShuffle) {
+      shuffleOrderRandomly();
+      setStatus('Shuffle mode enabled.');
+    } else {
+      shuffleOrder = [...Array(tracks.length).keys()];
+      currentIndex = shuffleOrder.indexOf(currentTrackIndex);
+      updatePlaylist();
+      updatePlaylistActive();
+      setStatus('Shuffle disabled.');
+    }
+  }
+
+  function updatePlaylist() {
+    playlistElement.innerHTML = '';
+
+    shuffleOrder.forEach((trackIndex, orderIndex) => {
+      const track = tracks[trackIndex];
+      const item = document.createElement('li');
+      item.className = 'playlist-item';
+      item.tabIndex = 0;
+
+      const meta = document.createElement('div');
+      meta.className = 'playlist-meta';
+
+      const titleSpan = document.createElement('span');
+      titleSpan.textContent = track.title;
+      meta.appendChild(titleSpan);
+
+      const artistSpan = document.createElement('span');
+      artistSpan.textContent = track.artist;
+      artistSpan.className = 'playlist-artist';
+      meta.appendChild(artistSpan);
+
+      const durationSpan = document.createElement('span');
+      durationSpan.className = 'playlist-duration';
+      durationSpan.textContent = track.duration ? formatTime(track.duration) : '…';
+
+      item.appendChild(meta);
+      item.appendChild(durationSpan);
+
+      item.addEventListener('click', () => {
+        if (orderIndex === currentIndex) {
+          playCurrent();
+        } else {
+          loadTrack(orderIndex, { autoplay: true });
+        }
+      });
+
+      item.addEventListener('keydown', event => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault();
+          if (orderIndex === currentIndex) {
+            playCurrent();
+          } else {
+            loadTrack(orderIndex, { autoplay: true });
+          }
+        }
+      });
+
+      playlistElement.appendChild(item);
+
+      preloadDuration(track).then(duration => {
+        if (duration) {
+          durationSpan.textContent = formatTime(duration);
+        }
+      });
+    });
+  }
+
+  audio.addEventListener('loadedmetadata', () => {
+    if (!Number.isFinite(audio.duration)) {
+      totalTime.textContent = '0:00';
+    } else {
+      totalTime.textContent = formatTime(audio.duration);
+    }
+    setStatus(`Ready: ${trackTitle.textContent}`);
+  });
+
+  audio.addEventListener('timeupdate', () => {
+    if (userSeeking) return;
+    elapsedTime.textContent = formatTime(audio.currentTime);
+    if (Number.isFinite(audio.duration) && audio.duration > 0) {
+      const progress = (audio.currentTime / audio.duration) * 100;
+      seekBar.value = progress;
+    }
+  });
+
+  audio.addEventListener('ended', () => {
+    playNext();
+  });
+
+  audio.addEventListener('play', updatePlayButton);
+  audio.addEventListener('pause', updatePlayButton);
+
+  audio.addEventListener('error', () => {
+    setStatus('We could not load this file. Skipping to the next track.', 'error');
+    playNext();
+  });
+
+  seekBar.addEventListener('input', event => {
+    userSeeking = true;
+    const value = Number(event.target.value);
+    if (Number.isFinite(audio.duration)) {
+      const newTime = (value / 100) * audio.duration;
+      elapsedTime.textContent = formatTime(newTime);
+    }
+  });
+
+  seekBar.addEventListener('change', event => {
+    userSeeking = false;
+    const value = Number(event.target.value);
+    if (Number.isFinite(audio.duration)) {
+      audio.currentTime = (value / 100) * audio.duration;
+    }
+  });
+
+  volumeControl.addEventListener('input', event => {
+    audio.volume = Number(event.target.value);
+  });
+
+  playPauseButton.addEventListener('click', () => {
+    if (audio.paused) {
+      playCurrent();
+    } else {
+      pausePlayback();
+    }
+  });
+
+  prevButton.addEventListener('click', playPrevious);
+  nextButton.addEventListener('click', playNext);
+  shuffleButton.addEventListener('click', toggleShuffle);
+  refreshButton.addEventListener('click', () => {
+    if (!isShuffle) {
+      setStatus('Enable shuffle to randomise the queue.', 'info');
+      shuffleButton.focus();
+      return;
+    }
+    shuffleOrderRandomly();
+    setStatus('Playlist order refreshed.');
+  });
+
+  document.addEventListener('visibilitychange', () => {
+    if (document.visibilityState === 'hidden' && !audio.paused) {
+      audio.pause();
+      setStatus('Playback paused while hidden. Tap play to resume.');
+    }
+  });
+
+  window.addEventListener('pageshow', () => {
+    updatePlayButton();
+  });
+
+  window.addEventListener('error', event => {
+    postPanelStatus('error', event.message || 'Unknown error');
+  });
+
+  function initialise() {
+    updatePlaylist();
+    loadTrack(0);
+    audio.volume = 1;
+    postPanelStatus('ready');
+  }
+
+  document.addEventListener('DOMContentLoaded', initialise);
+})();

--- a/main.html
+++ b/main.html
@@ -1296,6 +1296,10 @@
                 <img src="https://raw.githubusercontent.com/Omoluabi1003/Ariyo-AI/main/Sabi%20Bible%20icon.png" alt="Sabi Bible icon" />
                 <span class="edge-panel-label" id="edgeLabelBible"><strong>Sabi Bible</strong>Yorùbá-English scripture explorer</span>
             </button>
+            <button class="edge-panel-item edge-panel-launcher" type="button" aria-controls="musicPlayerContainer" data-open-target="musicPlayerContainer" data-open-src="apps/music-player/music-player.html" aria-describedby="edgeLabelMusic" role="listitem">
+                <img src="music-player.png" alt="Omoluabi music player icon" />
+                <span class="edge-panel-label" id="edgeLabelMusic"><strong>Omoluabi Player</strong>Spin curated Àríyò catalog cuts</span>
+            </button>
             <button class="edge-panel-item edge-panel-launcher" type="button" aria-controls="youtubeModalContainer" data-open-target="youtubeModalContainer" data-open-src="https://www.youtube.com/embed/videoseries?list=UUzkQQysk1Afxsc-bRh1mYpg&amp;enablejsapi=1" aria-describedby="edgeLabelYouTube" role="listitem">
                 <img src="icons/youtube.svg" alt="Omoluabi Paul YouTube icon" />
                 <span class="edge-panel-label" id="edgeLabelYouTube"><strong>Watch Omoluabi Paul</strong>Latest videos &amp; performances</span>
@@ -1323,6 +1327,14 @@
         </div>
         <p class="edge-panel-privacy">Zapier-hosted chatbots may store prompts. <a href="privacy.html" target="_blank" rel="noopener noreferrer">Read how Àríyò AI handles data</a>.</p>
     </div>
+</div>
+
+<!-- Omoluabi Music Player Container -->
+<div id="musicPlayerContainer" class="chatbot-container" role="dialog" aria-modal="true" aria-labelledby="musicPlayerTitle" aria-describedby="musicPlayerTagline">
+    <button class="popup-close ripple shockwave" data-close-target="musicPlayerContainer" aria-label="Close Omoluabi Player">×</button>
+    <h3 id="musicPlayerTitle" class="modal-title">Omoluabi Music Player</h3>
+    <p id="musicPlayerTagline" class="modal-tagline">Dive into Àríyò AI’s curated catalogue without leaving the hub.</p>
+    <iframe src="apps/music-player/music-player.html" data-default-src="apps/music-player/music-player.html" title="Omoluabi music player" style="width: 100%; height: 100%; border: none;"></iframe>
 </div>
 
 <!-- Omoluabi Paul YouTube Container -->

--- a/scripts/ui.js
+++ b/scripts/ui.js
@@ -211,6 +211,7 @@ const PANEL_IDS = [
     'ariyoChatbotContainer',
     'sabiBibleContainer',
     'pictureGameContainer',
+    'musicPlayerContainer',
     'tetrisGameContainer',
     'wordSearchContainer',
     'connectFourContainer',
@@ -247,6 +248,10 @@ const PANEL_LOAD_CONFIG = {
         errorMessage: 'YouTube refused to play inside Àríyò AI. Please retry or open the full channel.',
         supportLink: 'https://youtube.com/@omoluabipaul?si=9zduvJQvN8_ZXMuV',
         supportLinkLabel: 'Open channel on YouTube'
+    },
+    musicPlayerContainer: {
+        loadingMessage: 'Loading Omoluabi Player…',
+        errorMessage: 'The music player is unavailable right now. Please retry in a moment.'
     }
 };
 


### PR DESCRIPTION
## Summary
- add a dedicated Omoluabi Player micro-app with a responsive layout, controls, and curated tracks
- surface the music player inside the quick launch hub and register it with the edge-panel loader messaging

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_69060184f1848332b50f5c461059625b