### PR TITLE
Keep music player visible when opening About

### DIFF
--- a/main.html
+++ b/main.html
@@ -1137,7 +1137,7 @@
       <button onclick="openTrackList()" aria-label="Choose a track" class="ripple shockwave"><i class="fas fa-music" aria-hidden="true"></i> Choose A Track</button>
       <button onclick="openPlaylist()" aria-label="My playlist" class="ripple shockwave"><i class="fas fa-list" aria-hidden="true"></i> My Playlist</button>
       <button onclick="openRadioList()" aria-label="Radio stations" class="ripple shockwave"><i class="fas fa-broadcast-tower" aria-hidden="true"></i> Radio Stations</button>
-      <button onclick="openAboutModal()" aria-label="About us" class="ripple shockwave"><i class="fas fa-info-circle" aria-hidden="true"></i> About Us</button>
+      <button onclick="navigateToAbout()" aria-label="About us" class="ripple shockwave"><i class="fas fa-info-circle" aria-hidden="true"></i> About Us</button>
     </div>
     <div class="content" id="main-content">
       <details class="in-app-guide">


### PR DESCRIPTION
## Summary
- route the sidebar "About Us" button through a new navigation helper that opens the modal without removing the music player
- remove the fragment swapping logic so the player markup stays in the DOM and restore the button text/handler when returning home
- update history handling so back/forward navigation simply opens or closes the modal while the player remains visible

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_69060a16e7748332a96363bab14c0b9a