### PR TITLE
Fix disappearing media player when switching albums or stations

### DIFF
--- a/scripts/player.js
+++ b/scripts/player.js
@@ -661,7 +661,6 @@ function loadMoreStations(region) {
       currentRadioIndex = -1;
       updateTrackListModal();
       openTrackList();
-      document.getElementById('main-content').innerHTML = '';
     }
 
 function selectTrack(src, title, index, rebuildQueue = true) {
@@ -760,7 +759,6 @@ function selectRadio(src, title, index, logo) {
       handleAudioLoad(src, title, true);
       updateMediaSession();
       showNowPlayingToast(title);
-      document.getElementById('main-content').innerHTML = '';
     }
 
     function retryTrack() {


### PR DESCRIPTION
## Summary
- stop the album and radio selection handlers from clearing the main content container, which removed the player UI

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_69060a16e7748332a96363bab14c0b9a