### PR TITLE
Align Omoluabi vinyl art and sync playback

### DIFF
--- a/apps/music-player/music-player.css
+++ b/apps/music-player/music-player.css
@@ -183,6 +183,7 @@ body {
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
+  transform-origin: center;
   box-shadow: 0 6px 18px rgba(0, 0, 0, 0.45);
   border: none;
   z-index: 2;
@@ -230,6 +231,15 @@ body {
   border-top-color: var(--player-accent);
   animation: spin 0.8s linear infinite;
   display: none;
+}
+
+@keyframes spin {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
 }
 
 .player-main {
@@ -417,22 +427,31 @@ body {
 
 .playlist-items .track-title {
   margin: 0;
-  font-size: 1rem;
+  font-size: 0.9rem;
   font-weight: 600;
 }
 
 .playlist-items .track-meta {
   margin: 0.15rem 0 0;
-  font-size: 0.85rem;
+  font-size: 0.75rem;
   color: var(--player-muted);
 }
 
-@keyframes spin {
+@keyframes spinDisc {
   0% {
     transform: rotate(0deg);
   }
   100% {
     transform: rotate(360deg);
+  }
+}
+
+@keyframes spinAlbum {
+  0% {
+    transform: translate(-50%, -50%) rotate(0deg);
+  }
+  100% {
+    transform: translate(-50%, -50%) rotate(360deg);
   }
 }
 
@@ -445,9 +464,12 @@ body {
   }
 }
 
-.turntable-disc.spin,
+.turntable-disc.spin {
+  animation: spinDisc 3.5s linear infinite;
+}
+
 .album-cover.spin {
-  animation: spin 3.5s linear infinite;
+  animation: spinAlbum 3.5s linear infinite;
 }
 
 @media (max-width: 1024px) {

--- a/apps/music-player/music-player.js
+++ b/apps/music-player/music-player.js
@@ -33,7 +33,7 @@
 
   const allTracks = albums.flatMap((album, albumIndex) => {
     const artist = album.artist || 'Omoluabi';
-    const releaseYear = album.releaseYear || '—';
+    const releaseYear = typeof album.releaseYear !== 'undefined' ? album.releaseYear : '2025';
     const cover = album.cover || '../../Logo.jpg';
     return album.tracks.map((track, trackIndex) => ({
       title: track.title,

--- a/scripts/ui.js
+++ b/scripts/ui.js
@@ -640,6 +640,18 @@ function openPanel(targetId, trigger = null) {
     const panel = getPanelElement(targetId);
     if (!panel) return;
 
+    if (targetId === 'musicPlayerContainer') {
+        const mainAudio = document.getElementById('audioPlayer');
+        if (mainAudio && !mainAudio.paused) {
+            try {
+                mainAudio.pause();
+                mainAudio.currentTime = 0;
+            } catch (error) {
+                console.warn('Unable to stop main player when launching Omoluabi Player:', error);
+            }
+        }
+    }
+
     if (targetId === 'aboutModalContainer') {
         const iframe = panel.querySelector('iframe');
         if (iframe) {


### PR DESCRIPTION
## Summary
- center the Omoluabi cover art on the vinyl while it spins and tighten the playlist typography
- default the player release year to 2025 when album metadata is missing
- pause the main site audio player whenever the Omoluabi player is opened to avoid overlapping playback

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_6906b50036f0833299a4a7471e27a059