### PR TITLE
Reposition edge panel privacy notice

### DIFF
--- a/main.html
+++ b/main.html
@@ -829,7 +829,7 @@
       text-align: center;
       line-height: 1.4;
       color: rgba(255,255,255,0.8);
-      margin-top: clamp(0.6rem, 2.5vw, 1rem);
+      margin: clamp(0.6rem, 2.5vw, 1rem) clamp(0.95rem, 2.4vw, 1.2rem) clamp(0.85rem, 3vw, 1.3rem);
       padding: clamp(0.55rem, 2.6vw, 0.85rem);
       border-radius: 14px;
       background: rgba(5, 26, 18, 0.78);
@@ -837,9 +837,6 @@
       box-shadow: 0 16px 32px rgba(0,0,0,0.35);
       backdrop-filter: saturate(140%) blur(var(--glass-blur));
       flex-shrink: 0;
-      position: sticky;
-      bottom: clamp(0.45rem, 2.2vw, 0.85rem);
-      z-index: 2;
       opacity: 0;
       transition: opacity 0.25s ease-in-out;
     }
@@ -1399,8 +1396,8 @@
                 <span class="edge-panel-label" id="edgeLabelCycle"><strong>Cycle Precision</strong>Track &amp; learn with calm visuals</span>
             </button>
         </div>
-        <p class="edge-panel-privacy">Zapier-hosted chatbots may store prompts. <a href="privacy.html" target="_blank" rel="noopener noreferrer">Read how Àríyò AI handles data</a>.</p>
     </div>
+    <p class="edge-panel-privacy">Zapier-hosted chatbots may store prompts. <a href="privacy.html" target="_blank" rel="noopener noreferrer">Read how Àríyò AI handles data</a>.</p>
 </div>
 
 <!-- Omoluabi Music Player Container -->


### PR DESCRIPTION
## Summary
- move the edge panel privacy notice outside the scrollable list so it no longer covers launcher buttons
- update the notice styling to sit at the bottom of the panel without using a sticky overlay

## Testing
- Manual verification in browser

------
https://chatgpt.com/codex/tasks/task_e_69078ea2932c833295c74846c1eeee6a