### PR TITLE
Fix chat edge panel handshake target origin resolution

### DIFF
--- a/apps/ariyo-ai-chat/ariyo-ai-chat.html
+++ b/apps/ariyo-ai-chat/ariyo-ai-chat.html
@@ -29,19 +29,46 @@
       const PANEL_ID = 'ariyoChatbotContainer';
       const SOURCE = 'edge-panel-app';
 
-      const targetOrigin = (() => {
+      function isValidOrigin(origin) {
+        if (!origin) return false;
+        if (origin === 'null' || origin === 'about:blank') return false;
+        return !origin.startsWith('file:');
+      }
+
+      function resolveTargetOrigin() {
         try {
           if (document.referrer) {
-            return new URL(document.referrer).origin;
-          }
-          if (window.location && window.location.origin) {
-            return window.location.origin;
+            const referrerOrigin = new URL(document.referrer, window.location.href).origin;
+            if (isValidOrigin(referrerOrigin)) {
+              return referrerOrigin;
+            }
           }
         } catch (error) {
-          /* ignore and fall back to wildcard */
+          /* ignore invalid referrer */
         }
+
+        if (window.location) {
+          try {
+            const currentOrigin = window.location.origin;
+            if (isValidOrigin(currentOrigin)) {
+              return currentOrigin;
+            }
+          } catch (error) {
+            /* ignore invalid current origin */
+          }
+
+          if (window.location.ancestorOrigins && window.location.ancestorOrigins.length) {
+            const ancestorOrigin = window.location.ancestorOrigins[0];
+            if (isValidOrigin(ancestorOrigin)) {
+              return ancestorOrigin;
+            }
+          }
+        }
+
         return '*';
-      })();
+      }
+
+      const targetOrigin = resolveTargetOrigin();
 
       function postStatus(status, reason) {
         if (!window.parent || window.parent === window) return;

--- a/apps/sabi-bible/sabi-bible.html
+++ b/apps/sabi-bible/sabi-bible.html
@@ -29,19 +29,46 @@
       const PANEL_ID = 'sabiBibleContainer';
       const SOURCE = 'edge-panel-app';
 
-      const targetOrigin = (() => {
+      function isValidOrigin(origin) {
+        if (!origin) return false;
+        if (origin === 'null' || origin === 'about:blank') return false;
+        return !origin.startsWith('file:');
+      }
+
+      function resolveTargetOrigin() {
         try {
           if (document.referrer) {
-            return new URL(document.referrer).origin;
-          }
-          if (window.location && window.location.origin) {
-            return window.location.origin;
+            const referrerOrigin = new URL(document.referrer, window.location.href).origin;
+            if (isValidOrigin(referrerOrigin)) {
+              return referrerOrigin;
+            }
           }
         } catch (error) {
-          /* ignore */
+          /* ignore invalid referrer */
         }
+
+        if (window.location) {
+          try {
+            const currentOrigin = window.location.origin;
+            if (isValidOrigin(currentOrigin)) {
+              return currentOrigin;
+            }
+          } catch (error) {
+            /* ignore invalid current origin */
+          }
+
+          if (window.location.ancestorOrigins && window.location.ancestorOrigins.length) {
+            const ancestorOrigin = window.location.ancestorOrigins[0];
+            if (isValidOrigin(ancestorOrigin)) {
+              return ancestorOrigin;
+            }
+          }
+        }
+
         return '*';
-      })();
+      }
+
+      const targetOrigin = resolveTargetOrigin();
 
       function postStatus(status, reason) {
         if (!window.parent || window.parent === window) return;


### PR DESCRIPTION
## Summary
- harden the Ariyo AI and Sabi Bible edge panel handshakes so they validate the referrer origin before posting status updates
- fall back to the current window origin or wildcard when the referrer is about:blank so the parent always receives ready events after lazy iframe loads

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_69079185b4f883329553b47ef04fc61b