### PR TITLE
Refine Omoluabi player playlist layout

### DIFF
--- a/apps/music-player/music-player.css
+++ b/apps/music-player/music-player.css
@@ -392,49 +392,140 @@ body {
 
 .playlist-items {
   margin: 0;
-  padding-left: 1.25rem;
+  padding: 0;
+  list-style: none;
   display: flex;
   flex-direction: column;
-  gap: 0.65rem;
+  gap: 0.75rem;
   max-height: 100%;
   overflow-y: auto;
 }
 
-.playlist-items li {
-  list-style: decimal;
-  cursor: pointer;
+.album-group {
+  list-style: none;
+}
+
+.album-toggle {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
   background: rgba(255, 255, 255, 0.08);
-  border: 1px solid transparent;
-  border-radius: 14px;
-  padding: 0.75rem 1rem;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 16px;
+  padding: 0.55rem 0.85rem;
+  color: inherit;
+  font: inherit;
+  font-size: 0.85rem;
+  cursor: pointer;
   transition: background 0.2s ease, transform 0.2s ease, border-color 0.2s ease;
 }
 
-.playlist-items li:hover,
-.playlist-items li:focus-visible {
-  background: rgba(255, 255, 255, 0.16);
-  transform: translateY(-2px);
+.album-toggle:hover,
+.album-toggle:focus-visible {
+  background: rgba(255, 255, 255, 0.14);
   border-color: rgba(255, 255, 255, 0.28);
   outline: none;
+  transform: translateY(-1px);
 }
 
-.playlist-items li[aria-current='true'] {
+.album-group.is-open .album-toggle {
   background: rgba(18, 183, 106, 0.18);
+  border-color: var(--player-accent);
+}
+
+.album-thumb {
+  width: 36px;
+  height: 36px;
+  border-radius: 10px;
+  object-fit: cover;
+  flex-shrink: 0;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.35);
+}
+
+.album-toggle-text {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.15rem;
+}
+
+.album-name {
+  font-size: 0.82rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+
+.album-meta {
+  font-size: 0.68rem;
+  color: var(--player-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.album-toggle-icon {
+  margin-left: auto;
+  font-size: 0.8rem;
+  color: var(--player-muted);
+  transition: transform 0.2s ease;
+}
+
+.album-group.is-open .album-toggle-icon {
+  transform: rotate(180deg);
+  color: #fff;
+}
+
+.album-track-list {
+  margin: 0.4rem 0 0;
+  padding: 0 0 0 2.6rem;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.album-track {
+  list-style: none;
+  cursor: pointer;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid transparent;
+  border-radius: 12px;
+  padding: 0.55rem 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  transition: background 0.2s ease, transform 0.2s ease, border-color 0.2s ease;
+  font-size: 0.78rem;
+  color: rgba(255, 255, 255, 0.92);
+}
+
+.album-track:hover,
+.album-track:focus-visible {
+  background: rgba(255, 255, 255, 0.12);
+  border-color: rgba(255, 255, 255, 0.22);
+  outline: none;
+  transform: translateX(4px);
+}
+
+.album-track[aria-current='true'] {
+  background: rgba(18, 183, 106, 0.2);
   border-color: var(--player-accent);
   color: #fff;
   font-weight: 600;
 }
 
-.playlist-items .track-title {
+.album-track-title {
   margin: 0;
-  font-size: 0.9rem;
+  font-size: 0.78rem;
   font-weight: 600;
 }
 
-.playlist-items .track-meta {
-  margin: 0.15rem 0 0;
-  font-size: 0.75rem;
+.album-track-meta {
+  margin: 0;
+  font-size: 0.65rem;
   color: var(--player-muted);
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
 }
 
 @keyframes spinDisc {
@@ -493,7 +584,11 @@ body {
   }
 
   .playlist-items {
-    padding-left: 1rem;
+    padding-left: 0;
+  }
+
+  .album-track-list {
+    padding-left: 1.75rem;
   }
 }
 

--- a/apps/music-player/music-player.html
+++ b/apps/music-player/music-player.html
@@ -94,7 +94,7 @@
           <button type="button" id="refreshButton" class="control secondary">Reshuffle order</button>
         </div>
       </div>
-      <ol id="playlist" class="playlist-items"></ol>
+      <ol id="playlist" class="playlist-items album-accordion" role="list"></ol>
     </section>
   </main>
 


### PR DESCRIPTION
## Summary
- reorganize the Omoluabi player playlist into an album-based accordion with compact typography and thumbnails
- update the music player script to render grouped track lists while preserving playback controls and shuffle order
- refresh the playlist styles for smaller text and responsive spacing

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_690b69816a188332a234e955548e4445