### PR TITLE
Refine music player album navigation

### DIFF
--- a/apps/music-player/music-player.css
+++ b/apps/music-player/music-player.css
@@ -392,48 +392,177 @@ body {
 
 .playlist-items {
   margin: 0;
-  padding-left: 1.25rem;
+  padding: 0;
+  list-style: none;
   display: flex;
   flex-direction: column;
-  gap: 0.65rem;
+  gap: 0.75rem;
   max-height: 100%;
   overflow-y: auto;
 }
 
-.playlist-items li {
-  list-style: decimal;
-  cursor: pointer;
-  background: rgba(255, 255, 255, 0.08);
-  border: 1px solid transparent;
-  border-radius: 14px;
-  padding: 0.75rem 1rem;
-  transition: background 0.2s ease, transform 0.2s ease, border-color 0.2s ease;
+.album-group {
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 16px;
+  padding: 0.35rem 0.65rem;
 }
 
-.playlist-items li:hover,
-.playlist-items li:focus-visible {
-  background: rgba(255, 255, 255, 0.16);
-  transform: translateY(-2px);
-  border-color: rgba(255, 255, 255, 0.28);
+.album-details {
+  border-radius: inherit;
+}
+
+.album-summary {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  list-style: none;
+  cursor: pointer;
+  padding: 0.4rem 0.85rem 0.4rem 0.35rem;
+  border-radius: 12px;
+  transition: background 0.2s ease;
+  position: relative;
+}
+
+.album-summary:hover,
+.album-summary:focus-visible {
+  background: rgba(255, 255, 255, 0.08);
   outline: none;
 }
 
-.playlist-items li[aria-current='true'] {
-  background: rgba(18, 183, 106, 0.18);
-  border-color: var(--player-accent);
-  color: #fff;
-  font-weight: 600;
+.album-summary::after {
+  content: '▾';
+  margin-left: auto;
+  font-size: 0.65rem;
+  color: var(--player-muted);
+  transition: transform 0.2s ease;
+  pointer-events: none;
 }
 
-.playlist-items .track-title {
+.album-details[open] .album-summary::after {
+  transform: rotate(-180deg);
+}
+
+.album-summary::-webkit-details-marker {
+  display: none;
+}
+
+.album-summary::marker {
+  content: '';
+}
+
+.album-thumb {
+  width: 38px;
+  height: 38px;
+  border-radius: 10px;
+  object-fit: cover;
+  flex: 0 0 auto;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.25);
+}
+
+.album-info {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  flex: 1 1 auto;
+}
+
+.album-title {
   margin: 0;
-  font-size: 0.9rem;
+  font-size: 0.95rem;
   font-weight: 600;
 }
 
-.playlist-items .track-meta {
-  margin: 0.15rem 0 0;
-  font-size: 0.75rem;
+.album-meta {
+  margin: 0;
+  font-size: 0.7rem;
+  color: var(--player-muted);
+}
+
+.album-tracklist {
+  list-style: none;
+  margin: 0.35rem 0 0.35rem 0;
+  padding: 0 0 0.4rem 0.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.track-item {
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid transparent;
+  transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+}
+
+.track-button {
+  width: 100%;
+  padding: 0.55rem 0.75rem;
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  background: transparent;
+  border: none;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+  border-radius: inherit;
+  transition: transform 0.2s ease;
+}
+
+.track-button:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(18, 183, 106, 0.45);
+}
+
+.track-item:hover,
+.track-button:hover {
+  background: rgba(255, 255, 255, 0.1);
+  border-color: rgba(255, 255, 255, 0.18);
+}
+
+.track-button:hover {
+  transform: translateY(-1px);
+}
+
+.track-item[aria-current='true'] {
+  background: rgba(18, 183, 106, 0.16);
+  border-color: var(--player-accent);
+}
+
+.track-item[aria-current='true'] .track-button {
+  color: #fff;
+}
+
+.album-details[open] .album-summary {
+  background: rgba(18, 183, 106, 0.08);
+}
+
+.track-number {
+  font-size: 0.7rem;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.85);
+  width: 2ch;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.track-text {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+}
+
+.track-title {
+  margin: 0;
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.track-meta {
+  margin: 0;
+  font-size: 0.68rem;
   color: var(--player-muted);
 }
 
@@ -492,8 +621,8 @@ body {
     justify-content: center;
   }
 
-  .playlist-items {
-    padding-left: 1rem;
+  .album-summary {
+    padding: 0.4rem 0.25rem;
   }
 }
 


### PR DESCRIPTION
## Summary
- group the Omoluabi player playlist into collapsible album sections keyed by album art thumbnails
- tighten playlist typography and spacing to deliver a smaller, cleaner presentation
- keep the active track highlighted while expanding its album section for easier navigation

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_690b69816a188332a234e955548e4445