### PR TITLE
Add Pepper 4 Body track to Omoluabi catalogue

### DIFF
--- a/Omoluabi_Production_Catalogue.md
+++ b/Omoluabi_Production_Catalogue.md
@@ -2,6 +2,7 @@
 
 ![Omoluabi Productions Logo](Logo.jpg)
 
+- [Pepper 4 Body](https://suno.com/s/czQByjy0jSlFGgRL)
 - [Comfort Zone](https://suno.com/s/o6kpQDz1PBmt8fSy)
 - [Dad is Missing](https://suno.com/s/ZJcZTLwSKP3wOSuG)
 - [Watchman](https://cdn1.suno.ai/5c17dd10-1770-467a-947a-db773c72ec78.mp3)

--- a/scripts/data.js
+++ b/scripts/data.js
@@ -132,6 +132,7 @@ const albums = [
           name: 'Omoluabi Production Catalogue',
           cover: `${BASE_URL}Logo.jpg`,
           tracks: [
+            { src: 'https://cdn1.suno.ai/5262fb23-fc38-404e-932b-e95de36effa8.mp3', title: 'Pepper 4 Body' },
             { src: 'https://cdn1.suno.ai/7a8b0fa8-fb18-4af8-9007-c2b54e2daa0b.mp3', title: 'Dad is Missing' },
             { src: 'https://cdn1.suno.ai/5baa29da-81ce-4f7d-94cc-3b15e88055f5.mp3', title: 'Comfort Zone' },
             { src: 'https://cdn1.suno.ai/8e63cdab-2e25-4993-ad25-1d074224b0c2.mp3', title: 'Persecutory Paranoia' },
@@ -184,6 +185,12 @@ const LATEST_TRACK_WINDOW_HOURS = 168;
 const LATEST_TRACK_LIMIT = 2;
 
 const latestTrackAnnouncements = [
+  {
+    albumName: 'Omoluabi Production Catalogue',
+    title: 'Pepper 4 Body',
+    src: 'https://cdn1.suno.ai/5262fb23-fc38-404e-932b-e95de36effa8.mp3',
+    addedOn: '2025-11-09T09:00:00Z'
+  },
   {
     albumName: 'Omoluabi Production Catalogue',
     title: 'Dad is Missing',


### PR DESCRIPTION
## Summary
- add Pepper 4 Body to the Omoluabi Production Catalogue album data so it loads in the track modal
- surface the new single in the latest-track announcements for the catalogue
- list the Suno share link for Pepper 4 Body in the Omoluabi catalogue markdown

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910e4ac20b08332ab20743dff489776)