### PR TITLE
Fix Detry Season announcement and improve playback responsiveness

### DIFF
--- a/scripts/data.js
+++ b/scripts/data.js
@@ -188,7 +188,7 @@ const LATEST_TRACK_LIMIT = 1;
 const latestTrackAnnouncements = [
   {
     albumName: 'Omoluabi Production Catalogue',
-    title: 'Detty Season',
+    title: 'Detry Season',
     src: 'https://cdn1.suno.ai/b618aae7-c7b0-4260-af4a-2f7d2e5e3b70.mp3',
     addedOn: '2025-02-18T09:00:00Z'
   },

--- a/scripts/player.js
+++ b/scripts/player.js
@@ -884,6 +884,22 @@ function selectRadio(src, title, index, logo) {
       audioPlayer.addEventListener('canplay', onCanPlay, { once: true });
       audioPlayer.addEventListener('error', onError, { once: true });
 
+      let quickStartAttempts = 0;
+      const quickStartCheck = () => {
+        if (readyHandled) return;
+        const readyState = audioPlayer.readyState;
+        const readyThreshold = typeof HTMLMediaElement !== 'undefined'
+          ? HTMLMediaElement.HAVE_CURRENT_DATA
+          : 2;
+        if (readyState >= readyThreshold) {
+          onCanPlay();
+        } else if (quickStartAttempts < 120) {
+          quickStartAttempts += 1;
+          requestAnimationFrame(quickStartCheck);
+        }
+      };
+      requestAnimationFrame(quickStartCheck);
+
       audioPlayer.load(); // Force load
     }
 


### PR DESCRIPTION
## Summary
- correct the latest drop announcement to reference "Detry Season"
- add a ready-state polling fallback so tracks begin playing as soon as media data is available

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69113ff698c0833299f0653ab6879bfe)