### PR TITLE
Improve Omoluabi player accordion and landing update indicator

### DIFF
--- a/apps/music-player/music-player.css
+++ b/apps/music-player/music-player.css
@@ -479,9 +479,17 @@ body {
   margin: 0.4rem 0 0;
   padding: 0 0 0 2.6rem;
   list-style: none;
-  display: flex;
+  display: none;
   flex-direction: column;
   gap: 0.4rem;
+}
+
+.album-group.is-open .album-track-list {
+  display: flex;
+}
+
+.album-track-list[hidden] {
+  display: none !important;
 }
 
 .album-track {

--- a/apps/music-player/music-player.js
+++ b/apps/music-player/music-player.js
@@ -147,6 +147,7 @@
     }
     if (list) {
       list.hidden = true;
+      list.setAttribute('aria-hidden', 'true');
     }
   }
 
@@ -166,6 +167,7 @@
     }
     if (list) {
       list.hidden = false;
+      list.setAttribute('aria-hidden', 'false');
     }
   }
 
@@ -351,6 +353,7 @@
       trackList.id = trackListId;
       trackList.hidden = true;
       trackList.setAttribute('role', 'list');
+      trackList.setAttribute('aria-hidden', 'true');
 
       tracks.forEach(track => {
         const orderIndex = orderLookup.get(track.globalIndex);
@@ -396,6 +399,17 @@
           collapseAlbumGroup(albumGroup);
         } else {
           expandAlbumGroup(albumGroup);
+        }
+      });
+
+      toggle.addEventListener('keydown', event => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault();
+          if (albumGroup.classList.contains('is-open')) {
+            collapseAlbumGroup(albumGroup);
+          } else {
+            expandAlbumGroup(albumGroup);
+          }
         }
       });
 

--- a/index.html
+++ b/index.html
@@ -75,7 +75,7 @@
         </button>
         <footer class="footer-note">
             <p>&copy; 2024 <a href="https://linkedin.com/in/paul-iyogun-7591a571" target="_blank">A Paul Iyogun (A.K.A. Omoluabi)</a> Project. All Rights Reserved. <a href="privacy.html">Privacy &amp; data use</a></p>
-            <p class="footer-updated" aria-live="polite">Last updated: February 2025</p>
+            <p class="footer-updated" aria-live="polite">Last updated: Loading…</p>
         </footer>
     </div>
 
@@ -144,6 +144,51 @@
               const audio = document.getElementById('welcomeAudio');
               const speakerContainer = document.getElementById('speaker-container');
               const speakerIcon = document.getElementById('speaker-icon');
+              const updatedLabel = document.querySelector('.footer-updated');
+
+              const parseDate = (value) => {
+                  if (!value) return null;
+                  const parsed = new Date(value);
+                  return Number.isNaN(parsed.getTime()) ? null : parsed;
+              };
+
+              const fallbackDate = () => parseDate(document.lastModified) || new Date();
+
+              const formatDate = (date) =>
+                  date.toLocaleDateString(undefined, { month: 'long', day: 'numeric', year: 'numeric' });
+
+              const setUpdatedLabel = (date, version) => {
+                  if (!updatedLabel || !date) return;
+                  const formatted = formatDate(date);
+                  updatedLabel.textContent = version
+                      ? `Last updated: ${formatted} • v${version}`
+                      : `Last updated: ${formatted}`;
+                  if (version) {
+                      updatedLabel.dataset.version = version;
+                  }
+              };
+
+              if (updatedLabel) {
+                  const initialDate = fallbackDate();
+                  setUpdatedLabel(initialDate);
+
+                  fetch('version.json', { cache: 'no-store' })
+                      .then(response => {
+                          if (!response.ok) {
+                              throw new Error(`Version request failed with status ${response.status}`);
+                          }
+                          const headerDate = response.headers.get('last-modified');
+                          return response.json().then(data => ({ data, headerDate }));
+                      })
+                      .then(({ data, headerDate }) => {
+                          const version = data && typeof data.version === 'string' ? data.version : null;
+                          const resolvedDate = parseDate(headerDate) || initialDate;
+                          setUpdatedLabel(resolvedDate, version);
+                      })
+                      .catch(() => {
+                          setUpdatedLabel(initialDate);
+                      });
+              }
 
               let isPlaying = false;
               let userPaused = false;


### PR DESCRIPTION
## Summary
- ensure the Omoluabi player album accordion toggles reliably with improved accessibility
- guard playlist styling so collapsed album tracks stay hidden until opened
- drive the landing page "Last updated" label from runtime data instead of a hard-coded date

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691274da60e88332af2162445511d67e)