### PR TITLE
Refresh palette for creative professional theme

### DIFF
--- a/about.html
+++ b/about.html
@@ -8,7 +8,7 @@
   <meta name="apple-mobile-web-app-title" content="Àríyò AI" />
   <meta name="apple-touch-fullscreen" content="yes" />
   <link rel="apple-touch-icon" href="icons/Ariyo.png">
-  <meta name="theme-color" content="#12B76A" />
+  <meta name="theme-color" content="#8E5BFF" />
   <title>About - Àríyò AI</title>
   <meta name="description" content="Learn more about Àríyò AI, a smart Naija AI powered by Omoluabi. Discover our mission, our music, and our team." />
   <meta name="keywords" content="About Àríyò AI, Omoluabi, Paul A.K. Iyogun, Nigerian AI, AI music" />

--- a/apps/music-player/music-player.css
+++ b/apps/music-player/music-player.css
@@ -1,7 +1,7 @@
 :root {
   color-scheme: dark;
   --player-bg: transparent;
-  --player-accent: #12B76A;
+  --player-accent: #8E5BFF;
   --player-muted: rgba(255, 255, 255, 0.7);
   --player-border: rgba(255, 255, 255, 0.12);
   --player-radius: 24px;
@@ -14,7 +14,7 @@ body {
   margin: 0;
   padding: 0;
   font-family: 'Montserrat', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-  background: radial-gradient(circle at top, rgba(33, 150, 83, 0.35), rgba(5, 5, 5, 0.95));
+  background: radial-gradient(circle at top, rgba(142, 91, 255, 0.3), rgba(8, 10, 24, 0.96));
   color: #fff;
   min-height: 100vh;
   display: flex;
@@ -26,7 +26,7 @@ body {
   align-items: center;
   gap: 1rem;
   padding: calc(1rem + env(safe-area-inset-top)) 1.25rem 1rem;
-  background: linear-gradient(135deg, rgba(18, 183, 106, 0.8), rgba(0, 0, 0, 0.85));
+  background: linear-gradient(135deg, rgba(142, 91, 255, 0.82), rgba(12, 20, 46, 0.9));
   border-bottom: 1px solid var(--player-border);
 }
 
@@ -280,7 +280,7 @@ body {
 .progress-bar div {
   height: 100%;
   width: 0%;
-  background: linear-gradient(90deg, var(--player-accent), rgba(18, 183, 106, 0.25));
+  background: linear-gradient(90deg, var(--player-accent), rgba(255, 127, 197, 0.28));
   border-radius: inherit;
   transition: width 0.2s ease;
 }
@@ -430,7 +430,7 @@ body {
 }
 
 .album-group.is-open .album-toggle {
-  background: rgba(18, 183, 106, 0.18);
+  background: rgba(142, 91, 255, 0.14);
   border-color: var(--player-accent);
 }
 
@@ -516,7 +516,7 @@ body {
 }
 
 .album-track[aria-current='true'] {
-  background: rgba(18, 183, 106, 0.2);
+  background: rgba(142, 91, 255, 0.22);
   border-color: var(--player-accent);
   color: #fff;
   font-weight: 600;

--- a/color-scheme.css
+++ b/color-scheme.css
@@ -1,10 +1,10 @@
-/* Naija green energy with an Omoluabi golden glow */
+/* Aurora-inspired blend for creative, professional polish */
 :root {
-  /* Deep emerald evokes the Naija flag */
-  --theme-color: #0E9F6E;
-  --gradient-start: #055C36;
-  /* Warm gold represents the Omoluabi spirit */
-  --gradient-end: #F4B400;
+  /* Luminous violet accent for calls to action */
+  --theme-color: #8E5BFF;
+  --gradient-start: #0C1B3C;
+  /* Coral flare to keep the experience energetic */
+  --gradient-end: #FF7FC5;
 }
 
 body {

--- a/index.css
+++ b/index.css
@@ -5,11 +5,11 @@
 body {
     margin: 0;
     font-family: 'Montserrat', sans-serif;
-    background-color: #02140a;
+    background-color: #0a0f1f;
     background-image:
-        radial-gradient(120% 120% at 15% 20%, rgba(34, 197, 94, 0.35), rgba(2, 20, 10, 0.92) 65%),
-        radial-gradient(120% 120% at 85% 25%, rgba(245, 158, 11, 0.28), rgba(2, 20, 10, 0.95) 60%),
-        radial-gradient(150% 140% at 50% 85%, rgba(16, 185, 129, 0.24), rgba(2, 20, 10, 0.95) 70%);
+        radial-gradient(120% 120% at 15% 20%, rgba(90, 195, 255, 0.26), rgba(10, 15, 31, 0.92) 65%),
+        radial-gradient(120% 120% at 85% 25%, rgba(255, 127, 197, 0.28), rgba(10, 15, 31, 0.94) 60%),
+        radial-gradient(150% 140% at 50% 85%, rgba(142, 91, 255, 0.24), rgba(10, 15, 31, 0.93) 70%);
     color: #f3fdf7;
     text-shadow: 0 12px 35px rgba(0, 0, 0, 0.65);
     display: flex;
@@ -34,18 +34,18 @@ body {
 }
 
 .countdown.red-on-black {
-    color: var(--theme-color, #12B76A);
+    color: var(--theme-color, #8E5BFF);
     background-color: #02140a;
 }
 
 .countdown.black-on-red {
     color: #02140a;
-    background-color: var(--theme-color, #12B76A);
+    background-color: var(--theme-color, #8E5BFF);
 }
 
 
 .overlay {
-    background: linear-gradient(150deg, rgba(6, 24, 16, 0.9), rgba(6, 24, 16, 0.78));
+    background: linear-gradient(150deg, rgba(12, 20, 46, 0.9), rgba(12, 20, 46, 0.76));
     padding: clamp(1.5rem, 5vw, 2.75rem);
     border-radius: 24px;
     position: relative;
@@ -57,7 +57,7 @@ body {
     flex-direction: column;
     gap: clamp(1.5rem, 4vw, 2.5rem);
     box-shadow: 0 35px 70px rgba(0, 0, 0, 0.5);
-    border: 1px solid rgba(18, 164, 84, 0.25);
+    border: 1px solid rgba(142, 91, 255, 0.25);
 }
 
 h1, p, .feature-card, footer {
@@ -90,7 +90,7 @@ a {
     text-transform: uppercase;
     letter-spacing: 0.35rem;
     font-size: 0.75rem;
-    color: rgba(245, 158, 11, 0.85);
+    color: rgba(125, 210, 255, 0.9);
     font-weight: 700;
 }
 
@@ -122,8 +122,8 @@ a {
     justify-content: center;
     gap: 0.45rem;
     padding: 0.85rem 1.1rem;
-    background: linear-gradient(135deg, rgba(18, 164, 84, 0.4), rgba(245, 158, 11, 0.65));
-    border: 1px solid rgba(18, 164, 84, 0.45);
+    background: linear-gradient(135deg, rgba(142, 91, 255, 0.35), rgba(255, 127, 197, 0.65));
+    border: 1px solid rgba(142, 91, 255, 0.45);
     border-radius: 18px;
     cursor: pointer;
     transition: transform 0.3s ease, box-shadow 0.3s ease;
@@ -132,7 +132,7 @@ a {
 
 .enter-button:hover {
     transform: translateY(-4px) scale(1.02);
-    box-shadow: 0 18px 30px rgba(18, 164, 84, 0.4);
+    box-shadow: 0 18px 30px rgba(255, 127, 197, 0.35);
 }
 
 .enter-button.clicked {
@@ -175,8 +175,8 @@ a {
 }
 
 .feature-card {
-    background: rgba(6, 32, 20, 0.68);
-    border: 1px solid rgba(18, 164, 84, 0.2);
+    background: rgba(14, 20, 44, 0.7);
+    border: 1px solid rgba(142, 91, 255, 0.2);
     border-radius: 18px;
     padding: clamp(1rem, 3vw, 1.35rem);
     display: flex;
@@ -190,8 +190,8 @@ a {
 .feature-card:hover,
 .feature-card.feature-active {
     transform: translateY(-6px);
-    border-color: rgba(245, 158, 11, 0.45);
-    box-shadow: 0 25px 40px rgba(245, 158, 11, 0.35);
+    border-color: rgba(255, 127, 197, 0.55);
+    box-shadow: 0 25px 40px rgba(142, 91, 255, 0.35);
     opacity: 1;
 }
 
@@ -238,7 +238,7 @@ a {
 }
 .footer-note .footer-updated {
     margin-top: 0.35rem;
-    color: #12b76a;
+    color: #8E5BFF;
     font-weight: 600;
     letter-spacing: 0.08em;
     text-transform: uppercase;
@@ -307,14 +307,14 @@ a {
     display: flex;
     align-items: center;
     justify-content: center;
-    color: var(--theme-color, #12B76A);
+    color: var(--theme-color, #8E5BFF);
     transition: transform 0.3s ease, box-shadow 0.3s ease, border-color 0.3s ease;
 }
 
 #speaker-container:focus-visible {
     outline: none;
-    border-color: var(--theme-color, #12B76A);
-    box-shadow: 0 0 0 3px rgba(18, 183, 106, 0.45);
+    border-color: var(--theme-color, #8E5BFF);
+    box-shadow: 0 0 0 3px rgba(142, 91, 255, 0.45);
 }
 
 #speaker-container[aria-pressed="true"],
@@ -404,7 +404,7 @@ a {
     transform: translateX(-50%);
     width: min(420px, 90vw);
     height: 10px;
-    background: rgba(18, 164, 84, 0.2);
+    background: rgba(142, 91, 255, 0.24);
     z-index: 10000;
     border-radius: 999px;
     overflow: hidden;
@@ -415,7 +415,7 @@ a {
 #timer-progress {
     width: 100%;
     height: 100%;
-    background: linear-gradient(90deg, #047857 0%, #12B76A 45%, #FACC15 100%);
+    background: linear-gradient(90deg, #00c2ff 0%, #8E5BFF 50%, #FF7FC5 100%);
     position: relative;
     border-radius: inherit;
     box-shadow: inset 0 0 12px rgba(0, 0, 0, 0.25);

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
   <meta name="apple-mobile-web-app-title" content="Àríyò AI" />
   <meta name="apple-touch-fullscreen" content="yes" />
-  <meta name="theme-color" content="#12B76A" />
+  <meta name="theme-color" content="#8E5BFF" />
   <meta name="description" content="Àríyò AI by Paul A.K. Iyogun (Omoluabi) is a smart Nigerian music assistant featuring Ariyo AI." />
   <meta name="keywords" content="Paul Iyogun, Omoluabi, Àríyò AI, Ariyo, Nigerian music, Naija AI, AI chatbot, PWA" />
   <meta property="og:title" content="Àríyò AI - Smart Naija AI by Paul Iyogun" />

--- a/main.html
+++ b/main.html
@@ -10,7 +10,7 @@
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
   <meta name="apple-mobile-web-app-title" content="Àríyò AI">
   <meta name="apple-touch-fullscreen" content="yes">
-  <meta name="theme-color" content="#12B76A" />
+  <meta name="theme-color" content="#8E5BFF" />
   <link rel="manifest" href="manifest.json">
   <link rel="apple-touch-icon" href="icons/Ariyo.png">
   <meta name="description" content="Àríyò AI is a web-based music player that provides a unique and culturally-rich experience for users. It features a curated selection of Nigerian music and the Ariyo AI assistant." />
@@ -252,7 +252,7 @@
       gap: 0.45rem;
     }
     .edge-panel-hint {
-      background: rgba(18, 183, 106, 0.18);
+      background: rgba(142, 91, 255, 0.16);
       border-left: 3px solid var(--theme-color);
       padding: 0.65rem 1rem;
       border-radius: 12px;
@@ -361,7 +361,7 @@
         height: 6px;
       }
       .sidebar::-webkit-scrollbar-thumb {
-        background: rgba(18, 183, 106, 0.7);
+        background: rgba(255, 127, 197, 0.6);
         border-radius: 999px;
       }
       .sidebar .search-bar {
@@ -615,7 +615,7 @@
         bottom: auto;
         transform: translateY(-50%);
         width: var(--edge-panel-width);
-        background: linear-gradient(160deg, rgba(8, 31, 22, 0.9), rgba(3, 15, 10, 0.86));
+        background: linear-gradient(160deg, rgba(14, 19, 48, 0.9), rgba(9, 12, 30, 0.86));
         border-radius: 24px 0 0 24px;
         transition: right 0.3s ease-in-out, box-shadow 0.3s ease-in-out, background 0.3s ease-in-out, transform 0.3s ease-in-out;
         z-index: 10000;
@@ -640,11 +640,11 @@
     .edge-panel[data-position='collapsed'] {
         opacity: 0.95;
         box-shadow: 0 18px 38px rgba(0, 0, 0, 0.45);
-        background: linear-gradient(160deg, rgba(8, 31, 22, 0.92), rgba(3, 15, 10, 0.88));
+        background: linear-gradient(160deg, rgba(14, 19, 48, 0.92), rgba(9, 12, 30, 0.88));
     }
     .edge-panel[data-position='peek'] {
         box-shadow: 0 22px 48px rgba(0, 0, 0, 0.55);
-        background: linear-gradient(160deg, rgba(8, 31, 22, 0.94), rgba(3, 15, 10, 0.9));
+        background: linear-gradient(160deg, rgba(14, 19, 48, 0.94), rgba(9, 12, 30, 0.9));
     }
     .edge-panel-handle {
         position: absolute;
@@ -653,7 +653,7 @@
         transform: translate(-58%, -50%);
         width: var(--edge-panel-handle-width);
         height: clamp(96px, 26vh, 168px);
-        background: linear-gradient(200deg, rgba(255, 255, 255, 0.86), rgba(18, 183, 106, 0.88));
+        background: linear-gradient(200deg, rgba(255, 255, 255, 0.86), rgba(142, 91, 255, 0.88));
         border-radius: 999px 0 0 999px;
         cursor: pointer;
         display: flex;
@@ -661,7 +661,7 @@
         justify-content: center;
         align-items: center;
         gap: 0.14rem;
-        color: rgba(12, 34, 25, 0.92);
+        color: rgba(18, 21, 45, 0.92);
         text-transform: uppercase;
         font-weight: 600;
         letter-spacing: 0.16em;
@@ -695,7 +695,7 @@
         width: 6px;
         height: 48%;
         border-radius: 999px;
-        background: linear-gradient(180deg, rgba(12, 34, 25, 0.2), rgba(12, 34, 25, 0.6));
+        background: linear-gradient(180deg, rgba(18, 21, 45, 0.2), rgba(18, 21, 45, 0.58));
         box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.38);
     }
     .edge-panel-handle::after {
@@ -797,11 +797,11 @@
     }
     .edge-panel-item:focus-visible {
       outline: none;
-      box-shadow: 0 0 0 3px rgba(18, 183, 106, 0.5);
+      box-shadow: 0 0 0 3px rgba(142, 91, 255, 0.5);
     }
     .edge-panel-item:hover {
       transform: translateX(-2px);
-      background: rgba(18, 183, 106, 0.35);
+      background: rgba(142, 91, 255, 0.28);
       box-shadow: 0 8px 18px rgba(0,0,0,0.35);
     }
     .edge-panel-item img {
@@ -832,8 +832,8 @@
       margin: clamp(0.6rem, 2.5vw, 1rem) clamp(0.95rem, 2.4vw, 1.2rem) clamp(0.85rem, 3vw, 1.3rem);
       padding: clamp(0.55rem, 2.6vw, 0.85rem);
       border-radius: 14px;
-      background: rgba(5, 26, 18, 0.78);
-      border: 1px solid rgba(18, 183, 106, 0.28);
+      background: rgba(15, 18, 40, 0.78);
+      border: 1px solid rgba(142, 91, 255, 0.32);
       box-shadow: 0 16px 32px rgba(0,0,0,0.35);
       backdrop-filter: saturate(140%) blur(var(--glass-blur));
       flex-shrink: 0;
@@ -871,7 +871,7 @@
     }
     .app-footer .last-updated {
       font-weight: 600;
-      color: rgba(18, 183, 106, 0.9);
+      color: rgba(142, 91, 255, 0.9);
       text-transform: uppercase;
       letter-spacing: 0.08em;
       font-size: clamp(0.7rem, 1.8vw, 0.85rem);
@@ -928,7 +928,7 @@
       max-width: 560px;
       text-align: center;
       font-size: clamp(0.85rem, 2.2vw, 0.95rem);
-      color: rgba(18, 24, 33, 0.82);
+      color: rgba(18, 22, 44, 0.82);
       line-height: 1.5;
     }
     .quick-start-list {
@@ -939,12 +939,12 @@
       gap: 0.5rem;
     }
     .quick-start-list li {
-      background: rgba(18, 183, 106, 0.18);
+      background: rgba(142, 91, 255, 0.16);
       border-radius: 12px;
       padding: 0.6rem 0.8rem;
       font-size: clamp(0.8rem, 2vw, 0.95rem);
-      color: rgba(18, 24, 33, 0.85);
-      border: 1px solid rgba(18, 183, 106, 0.25);
+      color: rgba(18, 22, 44, 0.85);
+      border: 1px solid rgba(142, 91, 255, 0.24);
     }
     .youtube-modal-actions {
       display: flex;

--- a/manifest.json
+++ b/manifest.json
@@ -32,6 +32,6 @@
   "start_url": "/",
   "scope": "/",
   "display": "standalone",
-  "theme_color": "#12B76A",
+  "theme_color": "#8E5BFF",
   "background_color": "#000000"
 }

--- a/privacy.html
+++ b/privacy.html
@@ -20,7 +20,7 @@
     header {
       width: 100%;
       padding: clamp(1.5rem, 5vw, 3rem);
-      background: linear-gradient(135deg, #12B76A, #054d3b);
+      background: linear-gradient(135deg, #8E5BFF, #0c1b3c);
       color: #fff;
       text-align: center;
       box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35);


### PR DESCRIPTION
## Summary
- switch the site-wide theme color to a violet and coral aurora palette for a more creative, professional tone
- update landing and main app surfaces, timer, and edge panel accents to match the refreshed colors
- retheme the music player and metadata (manifest/about/privacy) to keep the experience consistent

## Testing
- no automated tests run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691fa87bf6bc8332956b126331395023)