### PR TITLE
Add "Built Like This" track to Omoluabi catalogue

### DIFF
--- a/scripts/data.js
+++ b/scripts/data.js
@@ -132,6 +132,7 @@ const albums = [
         name: 'Omoluabi Production Catalogue',
         cover: `${BASE_URL}Logo.jpg`,
         tracks: [
+            { src: 'https://cdn1.suno.ai/383f1d83-84da-492d-9716-a09608fdeba4.mp3', title: 'Built Like This' },
             { src: 'https://cdn1.suno.ai/97301c6c-bcad-411b-adce-02b9cfd071d8.mp3', title: 'One Position' },
             { src: 'https://cdn1.suno.ai/4423f194-f2b3-4aea-ae4d-ed9150de2477.mp3', title: 'When Help Rode In From Nowhere' },
             { src: 'https://cdn1.suno.ai/312ec841-e3db-4cf4-9cf0-5a581e02322d.mp3', title: 'Freedom' },
@@ -194,6 +195,12 @@ const LATEST_TRACK_WINDOW_HOURS = 168;
 const LATEST_TRACK_LIMIT = 2;
 
 const latestTrackAnnouncements = [
+  {
+    albumName: 'Omoluabi Production Catalogue',
+    title: 'Built Like This',
+    src: 'https://cdn1.suno.ai/383f1d83-84da-492d-9716-a09608fdeba4.mp3',
+    addedOn: '2025-11-22T09:00:00Z'
+  },
   {
     albumName: 'Omoluabi Production Catalogue',
     title: 'One Position',


### PR DESCRIPTION
## Summary
- add the new Suno track "Built Like This" to the Omoluabi Production Catalogue album data
- include the track in the latest track announcements so it appears in the track modal for all users

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692107f273dc8332949708f96bb86e11)