### PR TITLE
Fix shared links opening About modal

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -6,8 +6,12 @@
 
     /* SHARE BUTTON (Web Share API) */
     async function shareContent() {
-      const baseUrl = `${window.location.origin}${window.location.pathname}`;
-      let shareUrl = ensureHttps(window.location.href);
+      const sanitizedPath = window.location.pathname.endsWith('/about.html')
+        ? window.location.pathname.replace(/about\.html$/, '')
+        : window.location.pathname;
+      const baseUrl = `${window.location.origin}${sanitizedPath || '/'}`;
+
+      let shareUrl = ensureHttps(baseUrl);
       let shareTitle = "Àríyò AI - Smart Naija AI";
       let shareText = "Check out this awesome page!";
       let qrLabel = shareTitle;


### PR DESCRIPTION
## Summary
- sanitize the shared URL base to strip the About page path before building share links
- ensure shared links point at the player so shared tracks open and play automatically

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692350178e288332a0d0fc7fa255d4cd)