### PR TITLE
Make chatbot panels dismissible via escape and backdrop

### DIFF
--- a/scripts/ui.js
+++ b/scripts/ui.js
@@ -542,6 +542,29 @@ document.addEventListener('DOMContentLoaded', () => {
 
         trigger.addEventListener('click', () => closePanel(targetId));
     });
+
+    // Allow users to dismiss any open panel by clicking its backdrop or pressing Escape
+    PANEL_IDS.forEach(id => {
+        const panel = getPanelElement(id);
+        if (!panel) return;
+
+        panel.addEventListener('click', (event) => {
+            if (event.target === panel && panel.style.display === 'block') {
+                closePanel(id);
+            }
+        });
+    });
+
+    document.addEventListener('keydown', (event) => {
+        if (event.key !== 'Escape') return;
+
+        PANEL_IDS.forEach(id => {
+            const panel = getPanelElement(id);
+            if (panel && panel.style.display === 'block') {
+                closePanel(id);
+            }
+        });
+    });
 });
 
 window.addEventListener('message', (event) => {


### PR DESCRIPTION
## Summary
- allow chatbot/modal panels to close when the user clicks the backdrop
- support closing any open panel with the Escape key

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923c39a67e08332ad759a3a9be5951d)