### PR TITLE
Add DJ-style dual-deck crossfade playback

### DIFF
--- a/scripts/dj-player.js
+++ b/scripts/dj-player.js
@@ -13,7 +13,12 @@ window.CrossfadePlayer = (() => {
     let crossfadeDurationSeconds = 6;
     let preloadAheadSeconds = 8;
 
+    let activeTrackMeta = null;
+    let nextTrackMeta = null;
+
     let onTrackEndCallback = () => {};
+    let onCrossfadeStart = null;
+    let onCrossfadeComplete = null;
 
     function init() {
         audioContext = new (window.AudioContext || window.webkitAudioContext)();
@@ -43,15 +48,27 @@ window.CrossfadePlayer = (() => {
     function _createAudioPlayer(id) {
         const audio = document.createElement('audio');
         audio.id = id;
-        audio.crossOrigin = 'anonymous';
         audio.preload = 'auto';
         audio.style.display = 'none';
         document.body.appendChild(audio);
         return audio;
     }
 
+    function _applyCrossOrigin(element, url) {
+        try {
+            const host = new URL(url, window.location.origin).hostname;
+            const corsAllowedHosts = ['raw.githubusercontent.com', 'drive.google.com'];
+            if (corsAllowedHosts.some(h => host.endsWith(h))) {
+                element.crossOrigin = 'anonymous';
+            } else {
+                element.removeAttribute('crossorigin');
+            }
+        } catch (e) {
+            element.removeAttribute('crossorigin');
+        }
+    }
+
     function _bindEvents() {
-        // Remove old listeners before adding new ones
         player1.removeEventListener('timeupdate', _monitorTrackProgress);
         player2.removeEventListener('timeupdate', _monitorTrackProgress);
         activePlayer.addEventListener('timeupdate', _monitorTrackProgress);
@@ -62,82 +79,145 @@ window.CrossfadePlayer = (() => {
     }
 
     function _monitorTrackProgress() {
-        if (!djAutoMixEnabled || isCrossfading || activePlayer.duration < crossfadeDurationSeconds) {
+        if (!djAutoMixEnabled || isCrossfading || !activePlayer.duration || activePlayer.duration < crossfadeDurationSeconds) {
             return;
         }
 
         const remainingTime = activePlayer.duration - activePlayer.currentTime;
-        if (remainingTime <= crossfadeDurationSeconds) {
-             if (typeof onTrackEndCallback === 'function') {
-                onTrackEndCallback();
-            }
+        if (remainingTime <= preloadAheadSeconds && inactivePlayer.src && inactivePlayer.readyState === HTMLMediaElement.HAVE_NOTHING) {
+            inactivePlayer.load();
+        }
+
+        if (remainingTime <= crossfadeDurationSeconds && nextTrackMeta && nextTrackMeta.src) {
+            _startCrossfade('auto');
         }
     }
 
     function _handleTrackEnd() {
-        if (!djAutoMixEnabled) {
-            if (typeof onTrackEndCallback === 'function') {
-                onTrackEndCallback(true); // Signal that it was a natural end
-            }
+        if (djAutoMixEnabled && nextTrackMeta && nextTrackMeta.src && !isCrossfading) {
+            _startCrossfade('auto');
+            return;
+        }
+
+        if (typeof onTrackEndCallback === 'function') {
+            onTrackEndCallback(true);
         }
     }
 
-    function setConfig({ enabled, duration }) {
+    function _safeGainRamp(node, element, from, to, durationSeconds) {
+        if (node && node.gain && typeof node.gain.setValueAtTime === 'function') {
+            const now = audioContext.currentTime;
+            node.gain.setValueAtTime(from, now);
+            node.gain.linearRampToValueAtTime(to, now + durationSeconds);
+        } else {
+            _volumeFallbackRamp(element, from, to, durationSeconds);
+        }
+    }
+
+    function _volumeFallbackRamp(element, from, to, durationSeconds) {
+        const start = performance.now();
+        const diff = to - from;
+        const step = () => {
+            const elapsed = (performance.now() - start) / 1000;
+            const progress = Math.min(elapsed / durationSeconds, 1);
+            element.volume = from + diff * progress;
+            if (progress < 1) {
+                requestAnimationFrame(step);
+            }
+        };
+        element.volume = from;
+        requestAnimationFrame(step);
+    }
+
+    function _swapPlayers() {
+        [activePlayer, inactivePlayer] = [inactivePlayer, activePlayer];
+        [activeGainNode, inactiveGainNode] = [inactiveGainNode, activeGainNode];
+        activeTrackMeta = nextTrackMeta || activeTrackMeta;
+        nextTrackMeta = null;
+        _bindEvents();
+    }
+
+    function _startCrossfade(reason = 'manual', overrideDuration) {
+        if (isCrossfading || !inactivePlayer.src) return;
+        isCrossfading = true;
+
+        const duration = overrideDuration || crossfadeDurationSeconds;
+        if (typeof onCrossfadeStart === 'function') {
+            onCrossfadeStart({ reason, incoming: nextTrackMeta, outgoing: activeTrackMeta });
+        }
+
+        if (audioContext.state === 'suspended') {
+            audioContext.resume();
+        }
+
+        inactiveGainNode.gain.setValueAtTime(0, audioContext.currentTime);
+        inactivePlayer.play().catch(e => console.error('Play failed during crossfade', e));
+        _safeGainRamp(activeGainNode, activePlayer, activeGainNode.gain.value, 0, duration);
+        _safeGainRamp(inactiveGainNode, inactivePlayer, 0, 1, duration);
+
+        setTimeout(() => {
+            _swapPlayers();
+            inactivePlayer.pause();
+            inactivePlayer.src = '';
+            isCrossfading = false;
+            if (typeof onCrossfadeComplete === 'function') {
+                onCrossfadeComplete(activeTrackMeta);
+            }
+        }, duration * 1000);
+    }
+
+    function setConfig({ enabled, duration, preloadAhead, onCrossfadeStart: startCb, onCrossfadeComplete: completeCb, onTrackEnd }) {
         if (enabled !== undefined) {
             djAutoMixEnabled = enabled;
         }
         if (duration !== undefined) {
             crossfadeDurationSeconds = duration;
         }
+        if (preloadAhead !== undefined) {
+            preloadAheadSeconds = preloadAhead;
+        }
+        if (typeof startCb === 'function') {
+            onCrossfadeStart = startCb;
+        }
+        if (typeof completeCb === 'function') {
+            onCrossfadeComplete = completeCb;
+        }
+        if (typeof onTrackEnd === 'function') {
+            onTrackEndCallback = onTrackEnd;
+        }
     }
 
-    function loadTrack(src, isNext = false) {
+    function loadTrack(trackOrSrc, isNext = false) {
+        const { src, meta } = typeof trackOrSrc === 'string' ? { src: trackOrSrc, meta: null } : trackOrSrc;
         const player = isNext ? inactivePlayer : activePlayer;
+        _applyCrossOrigin(player, src);
         player.src = src;
         player.load();
+
+        if (isNext) {
+            nextTrackMeta = { ...(meta || {}), src };
+        } else {
+            activeTrackMeta = { ...(meta || {}), src };
+        }
     }
 
     function play() {
         if (audioContext.state === 'suspended') {
             audioContext.resume();
         }
-        activePlayer.play().catch(e => console.error("Play failed", e));
         activeGainNode.gain.setValueAtTime(1, audioContext.currentTime);
         inactiveGainNode.gain.setValueAtTime(0, audioContext.currentTime);
+        activePlayer.play().catch(e => console.error('Play failed', e));
     }
 
     function pause() {
         activePlayer.pause();
     }
 
-    function crossfade() {
-        if (isCrossfading) return;
-        isCrossfading = true;
-
-        const now = audioContext.currentTime;
-
-        // Fade out the active player
-        activeGainNode.gain.linearRampToValueAtTime(0, now + crossfadeDurationSeconds);
-
-        // Swap players
-        [activePlayer, inactivePlayer] = [inactivePlayer, activePlayer];
-        [activeGainNode, inactiveGainNode] = [inactiveGainNode, activeGainNode];
-
-        _bindEvents();
-
-        // Play and fade in the new active player
-        if (audioContext.state === 'suspended') {
-            audioContext.resume();
-        }
-        activePlayer.play().catch(e => console.error("Play failed during crossfade", e));
-        activeGainNode.gain.setValueAtTime(0, now);
-        activeGainNode.gain.linearRampToValueAtTime(1, now + crossfadeDurationSeconds);
-
-        setTimeout(() => {
-            isCrossfading = false;
-            inactivePlayer.pause();
-            inactivePlayer.src = ''; // Clear the source of the inactive player
-        }, crossfadeDurationSeconds * 1000);
+    function crossfade(options = {}) {
+        const { durationSeconds, immediate } = options;
+        const fadeDuration = immediate ? Math.min(2.5, durationSeconds || crossfadeDurationSeconds) : (durationSeconds || crossfadeDurationSeconds);
+        _startCrossfade('manual', fadeDuration);
     }
 
     function onTrackEnd(callback) {
@@ -166,7 +246,6 @@ window.CrossfadePlayer = (() => {
     };
 })();
 
-// Initialize the player when the script is loaded
 document.addEventListener('DOMContentLoaded', () => {
     CrossfadePlayer.init();
 });


### PR DESCRIPTION
## Summary
- implement a dual-source crossfade engine with gain ramps, preloading, and callbacks for DJ mode
- integrate the DJ mix toggle with deck priming, UI updates, and queue-aware track metadata
- support automatic and manual next/previous fades while keeping upcoming tracks preloaded

## Testing
- npm test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c926287e48332af2a97d2e7448d7e)