### PR TITLE
Fix DJ Mix toggle responsiveness

### DIFF
--- a/main.html
+++ b/main.html
@@ -1315,7 +1315,7 @@
               <button aria-label="Stop" onclick="stopMusic()" title="Stop" aria-controls="audioPlayer" class="ripple shockwave">⏹</button>
               <button aria-label="Next track" onclick="nextTrack()" title="Next track" aria-controls="audioPlayer" class="ripple shockwave">⏭</button>
               <button aria-label="Toggle shuffle" onclick="toggleShuffle()" title="Toggle shuffle" aria-pressed="false" class="ripple shockwave shuffle-button">🔀</button>
-              <button id="djModeToggle" aria-label="Toggle DJ Mix" onclick="toggleDjMode()" title="Toggle DJ Mix" class="ripple shockwave">🎚️</button>
+              <button id="djModeToggle" aria-label="Toggle DJ Mix" title="Toggle DJ Mix" class="ripple shockwave">🎚️</button>
             </div>
             <audio id="audioPlayer" preload="auto" hidden aria-hidden="true"></audio>
           </div>

--- a/scripts/player.js
+++ b/scripts/player.js
@@ -783,6 +783,9 @@ function toggleDjMode() {
         CrossfadePlayer.setConfig({ enabled: false });
         CrossfadePlayer.onTrackEnd(null);
     }
+    if (toggleButton) {
+        toggleButton.setAttribute('aria-pressed', String(djAutoMixEnabled));
+    }
     console.log(`DJ Mix mode is now ${djAutoMixEnabled ? 'enabled' : 'disabled'}`);
 }
 

--- a/scripts/ui.js
+++ b/scripts/ui.js
@@ -520,6 +520,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
     const djModeToggle = document.getElementById('djModeToggle');
     if (djModeToggle) {
+        djModeToggle.setAttribute('aria-pressed', 'false');
         djModeToggle.addEventListener('click', toggleDjMode);
     }
     prepareDeferredIframes();


### PR DESCRIPTION
## Summary
- remove the inline DJ Mix toggle handler so clicks only fire once
- update the DJ Mix button to reflect its on/off state via aria-pressed
- initialize the toggle’s accessibility state when the page loads

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c989118bc8332b068b42055d4e8e6)