### PR TITLE
Adjust crossfade to trigger near track end

### DIFF
--- a/apps/music-player/music-player.js
+++ b/apps/music-player/music-player.js
@@ -105,6 +105,17 @@
   let standbyPreloadedIndex = null;
   let audioContext = null;
 
+  function getCrossfadeDurationForTrack(trackDurationSeconds) {
+    if (!trackDurationSeconds || !Number.isFinite(trackDurationSeconds)) {
+      return crossfadeDurationSeconds;
+    }
+
+    const maxFadeShare = 0.25;
+    const minimumFadeSeconds = 2;
+    const cappedByTrackLength = Math.max(minimumFadeSeconds, trackDurationSeconds * maxFadeShare);
+    return Math.min(crossfadeDurationSeconds, cappedByTrackLength);
+  }
+
   function createDeck(audioElement) {
     return {
       audio: audioElement,
@@ -877,8 +888,10 @@
           cueTrackOnDeck(getStandbyDeckKey(), nextIndex, { updateUI: false, preloadOnly: true });
           standbyPreloadedIndex = nextIndex;
         }
-        if (remaining <= crossfadeDurationSeconds) {
-          startCrossfade(nextIndex, { duration: crossfadeDurationSeconds });
+
+        const fadeDuration = getCrossfadeDurationForTrack(event.target.duration);
+        if (remaining <= fadeDuration) {
+          startCrossfade(nextIndex, { duration: fadeDuration });
         }
       }
     }


### PR DESCRIPTION
## Summary
- cap crossfade duration relative to track length to keep mixing near the end of shorter songs
- start crossfade using the per-track fade window while preserving preload timing

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c9a56aa4c83328e3930906cc4a419)