### PR TITLE
Fix DJ auto-mix timer and auto-advance

### DIFF
--- a/scripts/player.js
+++ b/scripts/player.js
@@ -774,13 +774,16 @@ function toggleDjMode() {
             preloadAhead: djPreloadAheadSeconds,
             onCrossfadeStart: handleCrossfadeStart,
             onCrossfadeComplete: handleCrossfadeComplete,
-            onTrackEnd: handleAutoNextTrack
+            onTrackEnd: handleAutoNextTrack,
+            onTimeUpdate: updateTrackTime
         });
+        CrossfadePlayer.onTimeUpdate(updateTrackTime);
         primeDjDecks();
     } else {
         toggleButton.classList.remove('active');
         djMixStatusInfo.textContent = 'DJ Auto-Mix: Off';
         CrossfadePlayer.setConfig({ enabled: false });
+        CrossfadePlayer.onTimeUpdate(null);
         CrossfadePlayer.onTrackEnd(null);
     }
     if (toggleButton) {


### PR DESCRIPTION
## Summary
- add DJ auto-mix timeupdate callback so track timer and UI stay in sync
- wire auto-mix toggle to send time updates and detach callbacks when disabled

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c9df136308332bda8df90f5338e5e)