### PR TITLE
Add accessibility improvements and dark/light theme toggle

### DIFF
--- a/color-scheme.css
+++ b/color-scheme.css
@@ -5,6 +5,20 @@
   --gradient-start: #0C1B3C;
   /* Coral flare to keep the experience energetic */
   --gradient-end: #FF7FC5;
+  --surface-bg: rgba(0, 0, 0, 0.42);
+  --surface-contrast: #f3fdf7;
+  --surface-border: rgba(142, 91, 255, 0.25);
+  --card-bg: linear-gradient(150deg, rgba(12, 20, 46, 0.9), rgba(12, 20, 46, 0.76));
+}
+
+:root[data-theme="light"] {
+  --theme-color: #6f45ff;
+  --gradient-start: #f1e9ff;
+  --gradient-end: #ffd9f0;
+  --surface-bg: rgba(255, 255, 255, 0.9);
+  --surface-contrast: #0f172a;
+  --surface-border: rgba(111, 69, 255, 0.28);
+  --card-bg: linear-gradient(140deg, #ffffff, #f5f2ff);
 }
 
 body {
@@ -19,3 +33,32 @@ body {
 .progress-bar div { background: var(--theme-color); }
 .install-btn { background: var(--theme-color); }
 .radio-region-header { color: var(--theme-color); }
+
+.theme-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.55rem 0.9rem;
+  border-radius: 999px;
+  border: 1px solid var(--surface-border);
+  background: linear-gradient(135deg, rgba(142, 91, 255, 0.18), rgba(255, 127, 197, 0.22));
+  color: var(--surface-contrast);
+  cursor: pointer;
+  font-weight: 600;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.theme-toggle:hover,
+.theme-toggle:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.18);
+  outline: none;
+}
+
+.theme-toggle:focus-visible {
+  box-shadow: 0 0 0 3px rgba(111, 69, 255, 0.4);
+}
+
+.theme-toggle-icon {
+  font-size: 1.1rem;
+}

--- a/index.css
+++ b/index.css
@@ -10,7 +10,7 @@ body {
         radial-gradient(120% 120% at 15% 20%, rgba(90, 195, 255, 0.26), rgba(10, 15, 31, 0.92) 65%),
         radial-gradient(120% 120% at 85% 25%, rgba(255, 127, 197, 0.28), rgba(10, 15, 31, 0.94) 60%),
         radial-gradient(150% 140% at 50% 85%, rgba(142, 91, 255, 0.24), rgba(10, 15, 31, 0.93) 70%);
-    color: #f3fdf7;
+    color: var(--surface-contrast);
     text-shadow: 0 12px 35px rgba(0, 0, 0, 0.65);
     display: flex;
     justify-content: center;
@@ -21,6 +21,16 @@ body {
     text-align: center;
     position: relative;
     transition: background 0.5s ease-in-out, background-color 0.5s ease-in-out;
+}
+
+body[data-theme="light"] {
+    background-color: #f6f7fb;
+    background-image:
+        radial-gradient(120% 120% at 15% 20%, rgba(111, 69, 255, 0.12), rgba(255, 255, 255, 0.9) 65%),
+        radial-gradient(120% 120% at 85% 25%, rgba(255, 127, 197, 0.14), rgba(255, 255, 255, 0.92) 60%),
+        radial-gradient(150% 140% at 50% 85%, rgba(111, 69, 255, 0.12), rgba(255, 255, 255, 0.9) 70%);
+    color: #0f172a;
+    text-shadow: none;
 }
 
 .countdown {
@@ -45,7 +55,7 @@ body {
 
 
 .overlay {
-    background: linear-gradient(150deg, rgba(12, 20, 46, 0.9), rgba(12, 20, 46, 0.76));
+    background: var(--card-bg);
     padding: clamp(1.5rem, 5vw, 2.75rem);
     border-radius: 24px;
     position: relative;
@@ -60,8 +70,21 @@ body {
     border: 1px solid rgba(142, 91, 255, 0.25);
 }
 
+body[data-theme="light"] .overlay {
+    color: #0f172a;
+    border-color: var(--surface-border);
+    box-shadow: 0 25px 60px rgba(17, 24, 39, 0.18);
+}
+
 h1, p, .feature-card, footer {
     color: inherit;
+}
+
+.page-actions {
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+    margin-bottom: 0.5rem;
 }
 
 h1 {
@@ -98,6 +121,13 @@ a {
     box-shadow: 0 20px 50px rgba(0, 0, 0, 0.45);
 }
 
+body[data-theme="light"] .hero-banner {
+    background: linear-gradient(120deg, #ffffff, #f3edff);
+    border-color: var(--surface-border);
+    color: #0f172a;
+    box-shadow: 0 18px 40px rgba(17, 24, 39, 0.18);
+}
+
 .logo-lockup {
     display: flex;
     flex-direction: column;
@@ -130,6 +160,12 @@ a {
     font-weight: 700;
     letter-spacing: 0.08em;
     text-transform: uppercase;
+}
+
+body[data-theme="light"] .banner-pill {
+    background: rgba(111, 69, 255, 0.18);
+    border-color: rgba(111, 69, 255, 0.35);
+    color: #2c0e63;
 }
 
 .hero-body {
@@ -242,12 +278,25 @@ a {
     opacity: 0.82;
 }
 
+body[data-theme="light"] .feature-card {
+    background: #ffffff;
+    border-color: var(--surface-border);
+    box-shadow: 0 15px 30px rgba(15, 23, 42, 0.18);
+    color: #0f172a;
+}
+
 .feature-card:hover,
 .feature-card.feature-active {
     transform: translateY(-6px);
     border-color: rgba(255, 127, 197, 0.55);
     box-shadow: 0 25px 40px rgba(142, 91, 255, 0.35);
     opacity: 1;
+}
+
+body[data-theme="light"] .feature-card.feature-active,
+body[data-theme="light"] .feature-card:hover {
+    border-color: rgba(111, 69, 255, 0.5);
+    box-shadow: 0 22px 38px rgba(111, 69, 255, 0.25);
 }
 
 .feature-icon {

--- a/index.html
+++ b/index.html
@@ -22,6 +22,7 @@
     <title>Welcome to Àríyò AI</title>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.2/gsap.min.js" defer integrity="sha384-d+vyQ0dYcymoP8ndq2hW7FGC50nqGdXUEgoOUGxbbkAJwZqL7h+jKN0GGgn9hFDS" crossorigin="anonymous"></script>
     <script src="viewport-height.js" defer></script>
+    <script src="scripts/theme-toggle.js" defer></script>
     <link href="https://fonts.googleapis.com/css2?family=Eczar:wght@600&family=Manrope:wght@500;700&family=Montserrat:wght@400;700&family=Roboto:wght@400;700&family=Roboto+Slab:wght@700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="color-scheme.css">
     <link rel="stylesheet" href="index.css">
@@ -36,6 +37,12 @@
         <div id="bg2" class="bg-image"></div>
     </div>
     <div class="overlay">
+        <div class="page-actions">
+            <button class="theme-toggle" type="button" data-theme-toggle aria-pressed="false">
+                <span class="theme-toggle-icon" aria-hidden="true">🌞</span>
+                <span class="theme-toggle-label">Light mode</span>
+            </button>
+        </div>
         <div class="hero-layout">
             <div class="hero-banner hero-animate">
                 <div class="logo-lockup">
@@ -229,6 +236,10 @@
 
               const updateSpeakerIcon = (playing) => {
                   speakerContainer.setAttribute('aria-pressed', playing ? 'true' : 'false');
+                  const statusLabel = playing ? 'Welcome audio playing' : 'Welcome audio muted';
+                  speakerIcon.setAttribute('aria-label', statusLabel);
+                  speakerIcon.setAttribute('role', 'img');
+                  speakerIcon.setAttribute('focusable', 'false');
                   if (playing) {
                       speakerIcon.innerHTML = `<path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M15 8a5 5 0 0 1 0 8"/><path d="M17.7 5a9 9 0 0 1 0 14" /><path d="M6 15h-2a1 1 0 0 1 -1 -1v-4a1 1 0 0 1 1 -1h2l3.5 -4.5a.8 .8 0 0 1 1.5 .5v14a.8 .8 0 0 1 -1.5 .5l-3.5 -4.5" />`;
                   } else {

--- a/main.html
+++ b/main.html
@@ -49,6 +49,7 @@
   <!-- Animations & Chat -->
   <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.2/gsap.min.js" integrity="sha384-d+vyQ0dYcymoP8ndq2hW7FGC50nqGdXUEgoOUGxbbkAJwZqL7h+jKN0GGgn9hFDS" crossorigin="anonymous"></script>
   <script src="viewport-height.js" defer></script>
+  <script src="scripts/theme-toggle.js" defer></script>
 
 
   <style>
@@ -72,7 +73,7 @@
     }
     body {
       font-family: 'Montserrat', sans-serif;
-      color: #fff;
+      color: var(--surface-contrast);
       display: flex;
       flex-direction: column;
       min-height: var(--app-height, 100vh);
@@ -81,6 +82,13 @@
       background-position: center;
       transition: background-color 0.5s ease-in-out, color 0.5s ease-in-out;
       box-sizing: border-box;
+    }
+
+    body[data-theme="light"] {
+      color: #0f172a;
+      background-color: #f6f7fb;
+      background-image: none;
+      text-shadow: none;
     }
     a { text-decoration: none; }
     .header {
@@ -1202,7 +1210,11 @@
     <span class="header-title">Àríyò AI Studio</span>
     <div class="header-actions">
       <button class="share-button" aria-label="Share this page" onclick="shareContent()">
-        <i class="fas fa-share-alt"></i>
+        <i class="fas fa-share-alt" aria-hidden="true"></i>
+      </button>
+      <button class="theme-toggle" type="button" data-theme-toggle aria-pressed="false">
+        <span class="theme-toggle-icon" aria-hidden="true">🌞</span>
+        <span class="theme-toggle-label">Light mode</span>
       </button>
     </div>
   </div>

--- a/scripts/theme-toggle.js
+++ b/scripts/theme-toggle.js
@@ -1,0 +1,66 @@
+(function () {
+  const THEME_STORAGE_KEY = 'ariyo-theme-preference';
+  const DEFAULT_THEME = 'dark';
+
+  const getPreferredTheme = () => {
+    const stored = localStorage.getItem(THEME_STORAGE_KEY);
+    if (stored === 'light' || stored === 'dark') {
+      return stored;
+    }
+    if (window.matchMedia && window.matchMedia('(prefers-color-scheme: light)').matches) {
+      return 'light';
+    }
+    return DEFAULT_THEME;
+  };
+
+  const applyTheme = (theme) => {
+    const safeTheme = theme === 'light' ? 'light' : 'dark';
+    document.documentElement.setAttribute('data-theme', safeTheme);
+    document.body && document.body.setAttribute('data-theme', safeTheme);
+
+    document.querySelectorAll('[data-theme-toggle]').forEach((toggle) => {
+      const labelTarget = toggle.querySelector('.theme-toggle-label');
+      const iconTarget = toggle.querySelector('.theme-toggle-icon');
+      toggle.setAttribute('aria-pressed', safeTheme === 'dark' ? 'false' : 'true');
+      toggle.setAttribute('aria-label', safeTheme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode');
+      if (labelTarget) {
+        labelTarget.textContent = safeTheme === 'dark' ? 'Light mode' : 'Dark mode';
+      }
+      if (iconTarget) {
+        iconTarget.textContent = safeTheme === 'dark' ? '🌞' : '🌙';
+      }
+    });
+  };
+
+  const toggleTheme = () => {
+    const current = document.documentElement.getAttribute('data-theme') || DEFAULT_THEME;
+    const next = current === 'dark' ? 'light' : 'dark';
+    localStorage.setItem(THEME_STORAGE_KEY, next);
+    applyTheme(next);
+  };
+
+  const attachToggleHandlers = () => {
+    document.querySelectorAll('[data-theme-toggle]').forEach((toggle) => {
+      toggle.addEventListener('click', toggleTheme);
+      toggle.addEventListener('keydown', (event) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault();
+          toggleTheme();
+        }
+      });
+    });
+  };
+
+  const ensureAltText = () => {
+    const FALLBACK_ALT = 'Decorative image';
+    document.querySelectorAll('img:not([alt]), img[alt=""]').forEach((img) => {
+      img.setAttribute('alt', FALLBACK_ALT);
+    });
+  };
+
+  document.addEventListener('DOMContentLoaded', () => {
+    applyTheme(getPreferredTheme());
+    attachToggleHandlers();
+    ensureAltText();
+  });
+})();

--- a/scripts/ui.js
+++ b/scripts/ui.js
@@ -875,6 +875,41 @@ function closeCyclePrecision() {
 
     const edgePanel = document.getElementById('edgePanel');
     const edgePanelHandle = edgePanel ? edgePanel.querySelector('.edge-panel-handle') : null;
+    const focusFirstEdgePanelItem = () => {
+        const firstItem = edgePanel?.querySelector('.edge-panel-item');
+        if (firstItem) {
+            firstItem.focus();
+        }
+    };
+    const setupEdgePanelListNavigation = () => {
+        const list = document.querySelector('.edge-panel-list');
+        if (!list) return;
+
+        list.addEventListener('keydown', (event) => {
+            const activeElement = document.activeElement;
+            if (!list.contains(activeElement)) return;
+
+            const items = Array.from(list.querySelectorAll('.edge-panel-item'));
+            const currentIndex = items.indexOf(activeElement);
+            if (currentIndex === -1) return;
+
+            let nextIndex = null;
+            if (event.key === 'ArrowDown' || event.key === 'ArrowRight') {
+                nextIndex = Math.min(currentIndex + 1, items.length - 1);
+            } else if (event.key === 'ArrowUp' || event.key === 'ArrowLeft') {
+                nextIndex = Math.max(currentIndex - 1, 0);
+            } else if (event.key === 'Home') {
+                nextIndex = 0;
+            } else if (event.key === 'End') {
+                nextIndex = items.length - 1;
+            }
+
+            if (nextIndex !== null && nextIndex !== currentIndex) {
+                event.preventDefault();
+                items[nextIndex].focus();
+            }
+        });
+    };
     let isDragging = false;
     let initialX;
     let initialRight;
@@ -991,11 +1026,14 @@ function closeCyclePrecision() {
                 showEdgePanelPeek();
             }
         }, 600);
-        const toggleEdgePanelVisibility = ({ userInitiated = false } = {}) => {
+        const toggleEdgePanelVisibility = ({ userInitiated = false, focusLaunchers = false } = {}) => {
             if (edgePanelState === 'visible') {
                 applyEdgePanelPosition('collapsed', { userInitiated });
             } else {
                 applyEdgePanelPosition('visible', { userInitiated });
+                if (focusLaunchers) {
+                    focusFirstEdgePanelItem();
+                }
             }
         };
 
@@ -1068,7 +1106,7 @@ function closeCyclePrecision() {
             if (isDragging) return;
             if (event.key === 'Enter' || event.key === ' ') {
                 event.preventDefault();
-                toggleEdgePanelVisibility({ userInitiated: true });
+                toggleEdgePanelVisibility({ userInitiated: true, focusLaunchers: true });
             }
         });
 
@@ -1094,6 +1132,8 @@ function closeCyclePrecision() {
             }
         });
     }
+
+    setupEdgePanelListNavigation();
 
     function closeEdgePanel() {
         applyEdgePanelPosition('collapsed');

--- a/style.css
+++ b/style.css
@@ -13,13 +13,19 @@ img {
 /* General Body Styles */
 body {
     font-family: 'Montserrat', sans-serif;
-    color: #fff;
+    color: var(--surface-contrast);
     background-color: #000;
     margin: 0;
     padding: 0;
     overflow-x: hidden;
     position: relative;
     text-shadow: 1px 1px 2px #000;
+}
+
+body[data-theme="light"] {
+    color: #0f172a;
+    background-color: #f6f7fb;
+    text-shadow: none;
 }
 
 :root {
@@ -1143,4 +1149,49 @@ body {
     transition: opacity 2s ease-in-out;
     z-index: 0;
     pointer-events: none;
+}
+
+/* Light mode overrides */
+body[data-theme="light"] .header {
+    color: #0f172a;
+    -webkit-text-stroke: 0;
+    text-shadow: none;
+}
+
+body[data-theme="light"] .sidebar,
+body[data-theme="light"] .content,
+body[data-theme="light"] .modal .modal-content,
+body[data-theme="light"] .chatbot-container,
+body[data-theme="light"] .music-player {
+    background: var(--surface-bg);
+    color: #0f172a;
+    box-shadow: 0 12px 30px rgba(17, 24, 39, 0.18);
+}
+
+body[data-theme="light"] .sidebar button,
+body[data-theme="light"] .retry-button,
+body[data-theme="light"] .install-btn {
+    color: #0f172a;
+}
+
+body[data-theme="light"] .edge-panel {
+    background: var(--surface-bg);
+    color: #0f172a;
+    border: 1px solid var(--surface-border);
+    box-shadow: 0 10px 25px rgba(17, 24, 39, 0.22);
+}
+
+body[data-theme="light"] .edge-panel-item {
+    background: rgba(255, 255, 255, 0.82);
+    color: #0f172a;
+    box-shadow: 0 6px 14px rgba(17, 24, 39, 0.12);
+}
+
+body[data-theme="light"] .edge-panel-handle {
+    background: linear-gradient(180deg, rgba(111, 69, 255, 0.8), rgba(255, 127, 197, 0.6));
+}
+
+body[data-theme="light"] .edge-panel-privacy,
+body[data-theme="light"] .edge-panel-privacy a {
+    color: #0f172a;
 }


### PR DESCRIPTION
## Summary
- add a reusable light/dark theme toggle on the landing and studio pages with stored user preference
- improve accessibility with ARIA updates for the speaker control, default alt text for images, and keyboard navigation for the game hub
- introduce light-mode surface styles for overlays, panels, and other UI elements

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ca16880148332b602084afff0d85c)