### PR TITLE
Improve launch and install CTA interactions

### DIFF
--- a/index.css
+++ b/index.css
@@ -599,6 +599,12 @@ body[data-theme="light"] .feature-card:hover {
     flex-wrap: wrap;
 }
 
+.cta-hint {
+    margin-top: 0.35rem;
+    color: rgba(255, 255, 255, 0.9);
+    font-size: 0.95rem;
+}
+
 .badge-button {
     background: rgba(255,255,255,0.12);
     color: #fff;

--- a/index.html
+++ b/index.html
@@ -96,6 +96,7 @@
                     <button class="enter-button ghost" id="launchExperience" type="button">Launch experience</button>
                     <button class="badge-button" id="installPwa" type="button">Install PWA</button>
                 </div>
+                <p class="cta-hint" id="experienceStatus" aria-live="polite"></p>
             </div>
             <div class="onboarding">
                 <video controls muted playsinline preload="metadata" poster="Naija AI4.png" class="intro-video">

--- a/scripts/experience.js
+++ b/scripts/experience.js
@@ -54,8 +54,21 @@
   function setupDashboardToggle() {
     const dashboard = document.querySelector('.pillar-dashboard');
     const launchButton = document.getElementById('launchExperience');
+    const statusText = document.getElementById('experienceStatus');
     if (launchButton) {
-      launchButton.addEventListener('click', () => dispatch({ type: 'TOGGLE_DASHBOARD' }));
+      launchButton.addEventListener('click', () => {
+        dispatch({ type: 'TOGGLE_DASHBOARD' });
+        if (dashboard) {
+          dashboard.scrollIntoView({ behavior: 'smooth', block: 'start' });
+          const firstTab = dashboard.querySelector('[role="tab"]');
+          if (firstTab) {
+            firstTab.focus();
+          }
+        }
+        if (statusText) {
+          statusText.textContent = 'Dashboard unlocked. Scroll down to explore the tabs.';
+        }
+      });
     }
     subscribe(({ dashboardVisible }) => {
       if (dashboard) {
@@ -92,17 +105,41 @@
   function setupPwaInstall() {
     let deferredPrompt;
     const installBtn = document.getElementById('installPwa');
+    const statusText = document.getElementById('experienceStatus');
     if (!installBtn) return;
+    installBtn.disabled = true;
+    installBtn.setAttribute('aria-disabled', 'true');
     window.addEventListener('beforeinstallprompt', (e) => {
       e.preventDefault();
       deferredPrompt = e;
       installBtn.disabled = false;
+      installBtn.removeAttribute('aria-disabled');
+      if (statusText) {
+        statusText.textContent = 'Àríyò AI is ready to be installed on your device.';
+      }
     });
     installBtn.addEventListener('click', async () => {
-      if (!deferredPrompt) return;
+      if (!deferredPrompt) {
+        if (statusText) {
+          statusText.textContent = 'Install prompt unavailable. Add to home screen from your browser menu.';
+        }
+        return;
+      }
       deferredPrompt.prompt();
       await deferredPrompt.userChoice;
       deferredPrompt = null;
+      installBtn.disabled = true;
+      installBtn.setAttribute('aria-disabled', 'true');
+      if (statusText) {
+        statusText.textContent = 'Thanks for installing! You can now launch Àríyò AI from your home screen.';
+      }
+    });
+    window.addEventListener('appinstalled', () => {
+      if (statusText) {
+        statusText.textContent = 'App installed — enjoy the full experience from your home screen!';
+      }
+      installBtn.disabled = true;
+      installBtn.setAttribute('aria-disabled', 'true');
     });
   }
 


### PR DESCRIPTION
## Summary
- add inline status hint for launch and install CTAs and scroll/focus the dashboard when launched
- harden PWA install flow with disabled state, install status updates, and appinstalled handling

## Testing
- Not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692cac0ae9d08332bff4b56448bf0cf2)