### PR TITLE
Fix stale footer metadata and improve landing page update fallback

### DIFF
--- a/index.html
+++ b/index.html
@@ -306,8 +306,8 @@
             <svg id="speaker-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon icon-tabler icons-tabler-outline icon-tabler-volume-off"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M15 8a5 5 0 0 1 0 8" /><path d="M17.7 5a9 9 0 0 1 0 14" /><path d="M6 15h-2a1 1 0 0 1 -1 -1v-4a1 1 0 0 1 1 -1h2l3.5 -4.5a.8 .8 0 0 1 1.5 .5v14a.8 .8 0 0 1 -1.5 .5l-3.5 -4.5" /><path d="M12 12l0 .01" /></svg>
         </button>
         <footer class="footer-note">
-            <p>&copy; 2024 <a href="https://linkedin.com/in/paul-iyogun-7591a571" target="_blank">A Paul Iyogun (A.K.A. Omoluabi)</a> Project. All Rights Reserved. <a href="privacy.html">Privacy &amp; data use</a></p>
-            <p class="footer-updated" aria-live="polite">Last updated: Loading…</p>
+            <p>&copy; <span id="footerYear"></span> <a href="https://linkedin.com/in/paul-iyogun-7591a571" target="_blank">A Paul Iyogun (A.K.A. Omoluabi)</a> Project. All Rights Reserved. <a href="privacy.html">Privacy &amp; data use</a></p>
+            <p class="footer-updated" aria-live="polite">Last updated: —</p>
         </footer>
     </div>
 
@@ -371,6 +371,10 @@
           document.addEventListener('DOMContentLoaded', () => {
               const enterIcon = document.querySelector('.enter-icon');
               const enterButton = document.querySelector('.enter-button');
+              const footerYear = document.getElementById('footerYear');
+              if (footerYear) {
+                  footerYear.textContent = String(new Date().getFullYear());
+              }
               if (enterButton) {
                   enterButton.addEventListener('click', enterApp);
                   enterButton.addEventListener('keydown', (event) => {
@@ -422,7 +426,13 @@
                   const initialDate = fallbackDate();
                   setUpdatedLabel(initialDate);
 
-                  fetch('version.json', { cache: 'no-store' })
+                  const controller = typeof AbortController === 'function' ? new AbortController() : null;
+                  const timeoutId = controller ? setTimeout(() => controller.abort(), 4000) : null;
+
+                  fetch('version.json', {
+                      cache: 'no-store',
+                      signal: controller ? controller.signal : undefined
+                  })
                       .then(response => {
                           if (!response.ok) {
                               throw new Error(`Version request failed with status ${response.status}`);
@@ -437,6 +447,11 @@
                       })
                       .catch(() => {
                           setUpdatedLabel(initialDate);
+                      })
+                      .finally(() => {
+                          if (timeoutId) {
+                              clearTimeout(timeoutId);
+                          }
                       });
               }
 

--- a/privacy.html
+++ b/privacy.html
@@ -116,8 +116,11 @@
     </section>
   </main>
   <footer>
-    <p>&copy; 2024 Omoluabi Productions — <a href="index.html">Return to Àríyò AI</a></p>
+    <p>&copy; <span id="privacyYear"></span> Omoluabi Productions — <a href="index.html">Return to Àríyò AI</a></p>
   </footer>
+  <script>
+    document.getElementById('privacyYear').textContent = String(new Date().getFullYear());
+  </script>
   <script src="scripts/sw-controller.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- The site displayed a hardcoded `© 2024` and a fragile “Last updated: Loading…” state which undermines trust and can remain unresolved if network requests hang. 
- Hardening the `version.json` fetch with a timeout prevents an indefinite pending state and ensures the footer always shows a deterministic value.

### Description
- Replaced hardcoded footer years with runtime-rendered year elements and populate them on `DOMContentLoaded` in `index.html` and `privacy.html` (added `#footerYear` and `#privacyYear`).
- Replaced the landing footer `Loading…` placeholder with a neutral fallback `—` and added an `AbortController` timeout (4s) for the `fetch('version.json')` call with cleanup in `.finally()` to avoid leaked timers.
- Preserved existing version-label behavior when `version.json` is available while ensuring a deterministic fallback when it is not.
- Files changed: `index.html`, `privacy.html`.

### Testing
- Ran `npm run build` and the static build completed successfully.
- Ran `npm test -- --runInBand` (Jest), and all test suites passed (16 suites, 42 tests passed).
- Ran `npm run lint` and it failed due to repository-wide Prettier/formatting debt (~7,751 errors), which is a separate cleanup task.
- Attempted a Playwright browser check but the environment lacked Playwright browser binaries (requires `npx playwright install`), so e2e/browser validation did not run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9855520cc8332aa78ee691f9d507e)