### PR TITLE
Add browser-based i18n with language detection and persistent language selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,3 +140,38 @@ This project is licensed under the MIT License.
 ---
 
 **SEO Keywords:** Paul Iyogun, Omoluabi, Àríyò AI, Ariyo, Nigerian music, Naija AI, AI chatbot, PWA
+
+## Localization (i18n)
+
+Ariyò AI includes a lightweight browser-based i18n utility in `scripts/i18n.js`.
+
+### How language is chosen
+- Default fallback language is English (`en`).
+- On first visit, language is detected from `navigator.languages` and `navigator.language`.
+- If a supported non-English language is detected, the UI switches automatically.
+- User choice from the language selector is saved in `localStorage` under `ariyo.language`.
+
+### Supported languages
+- English (`en`)
+- French (`fr`)
+- Spanish (`es`)
+- Portuguese (`pt`)
+- Yoruba (`yo`)
+- Hausa (`ha`)
+- Igbo (`ig`)
+
+### Adding a new translation
+1. Open `scripts/i18n.js`.
+2. Add the new language code to `SUPPORTED_LANGUAGES`.
+3. Add a matching top-level translation object under `translations`.
+4. Add an `<option>` for the language in the selector list in `injectLanguageSelector`.
+5. Tag UI text in HTML using:
+   - `data-i18n="path.to.key"` for normal text
+   - `data-i18n-placeholder="path.to.key"` for placeholder text
+   - `data-i18n-aria-label="path.to.key"` for accessibility labels
+6. Verify missing keys fall back to English (automatic behavior of `lookup`).
+
+### Notes
+- The implementation does **not** rely on IP geolocation.
+- Missing translations gracefully fall back to English.
+- Keep translation keys grouped semantically (for example: `ui.*`, `chatbot.*`, `errors.*`) to scale cleanly.

--- a/index.html
+++ b/index.html
@@ -88,6 +88,7 @@
     <script src="viewport-height.js" defer></script>
     <script src="scripts/theme-toggle.js" defer></script>
     <script src="scripts/deferred-init.js" defer></script>
+    <script src="scripts/i18n.js" defer></script>
     <link
       rel="prefetch"
       as="audio"
@@ -137,7 +138,7 @@
     </style>
   </head>
   <body data-page="landing">
-    <div id="bootSpinner" role="status" aria-live="polite" aria-label="Loading">
+    <div id="bootSpinner" role="status" aria-live="polite" aria-label="Loading" data-i18n-aria-label="ui.loading">
       <div class="boot-spinner-dot"></div>
     </div>
     <div id="timer-bar"><div id="timer-progress"></div></div>
@@ -146,10 +147,10 @@
       <div id="bg2" class="bg-image"></div>
     </div>
     <div class="overlay">
-      <div class="page-actions">
+      <div class="page-actions" data-language-switcher-host>
         <button class="theme-toggle" type="button" data-theme-toggle aria-pressed="false">
           <span class="theme-toggle-icon" aria-hidden="true">🌞</span>
-          <span class="theme-toggle-label">Light mode</span>
+          <span class="theme-toggle-label" data-i18n="ui.lightMode">Light mode</span>
         </button>
       </div>
       <div class="hero-layout">
@@ -186,7 +187,7 @@
             </div>
             <button class="enter-button shockwave" type="button" aria-label="Enter the Àríyò AI experience">
               <img src="Enter.png" alt="Enter Àríyò AI" class="enter-icon" />
-              <span class="enter-label">Launch experience</span>
+              <span class="enter-label" data-i18n="ui.launchExperience">Launch experience</span>
             </button>
           </div>
           <p class="email-gate-status" id="emailGateStatus" aria-live="polite"></p>
@@ -225,8 +226,8 @@
             </p>
           </div>
           <div class="cta-stack">
-            <button class="enter-button ghost" id="launchExperience" type="button">Launch experience</button>
-            <button class="badge-button" id="installPwa" type="button">Install PWA</button>
+            <button class="enter-button ghost" id="launchExperience" type="button" data-i18n="ui.launchExperience">Launch experience</button>
+            <button class="badge-button" id="installPwa" type="button" data-i18n="ui.installPwa">Install PWA</button>
             <p class="cta-hint" id="notificationStatus" aria-live="polite"></p>
           </div>
           <p class="cta-hint" id="experienceStatus" aria-live="polite"></p>

--- a/main.html
+++ b/main.html
@@ -111,6 +111,7 @@
     <script src="viewport-height.js" defer></script>
     <script src="scripts/theme-toggle.js" defer></script>
     <script src="scripts/deferred-init.js" defer></script>
+    <script src="scripts/i18n.js" defer></script>
     <script src="scripts/email-gate.js" defer></script>
 
     <style>
@@ -1706,13 +1707,13 @@
           <span class="header-title">Àríyò AI Studio</span>
         </div>
       </div>
-      <div class="header-actions">
+      <div class="header-actions" data-language-switcher-host>
         <button class="share-button" aria-label="Share this page" onclick="openShareMenu()">
           <i class="fas fa-share-alt" aria-hidden="true"></i>
         </button>
         <button class="theme-toggle" type="button" data-theme-toggle aria-pressed="false">
           <span class="theme-toggle-icon" aria-hidden="true">🌞</span>
-          <span class="theme-toggle-label">Light mode</span>
+          <span class="theme-toggle-label" data-i18n="ui.lightMode">Light mode</span>
         </button>
       </div>
     </div>

--- a/scripts/i18n.js
+++ b/scripts/i18n.js
@@ -1,0 +1,178 @@
+(function () {
+  const STORAGE_KEY = 'ariyo.language';
+  const DEFAULT_LANG = 'en';
+  const SUPPORTED_LANGUAGES = ['en', 'fr', 'es', 'pt', 'yo', 'ha', 'ig'];
+
+  const translations = {
+    en: {
+      ui: {
+        language: 'Language',
+        launchExperience: 'Launch experience',
+        installPwa: 'Install PWA',
+        lightMode: 'Light mode',
+        darkMode: 'Dark mode',
+        loading: 'Loading',
+      },
+    },
+    fr: {
+      ui: {
+        language: 'Langue',
+        launchExperience: "Lancer l'expérience",
+        installPwa: 'Installer la PWA',
+        lightMode: 'Mode clair',
+        darkMode: 'Mode sombre',
+        loading: 'Chargement',
+      },
+    },
+    es: {
+      ui: {
+        language: 'Idioma',
+        launchExperience: 'Iniciar experiencia',
+        installPwa: 'Instalar PWA',
+        lightMode: 'Modo claro',
+        darkMode: 'Modo oscuro',
+        loading: 'Cargando',
+      },
+    },
+    pt: {
+      ui: {
+        language: 'Idioma',
+        launchExperience: 'Iniciar experiência',
+        installPwa: 'Instalar PWA',
+        lightMode: 'Modo claro',
+        darkMode: 'Modo escuro',
+        loading: 'Carregando',
+      },
+    },
+    yo: {
+      ui: {
+        language: 'Èdè',
+        launchExperience: 'Bẹ̀rẹ̀ ìrírí',
+        installPwa: 'Fi PWA sori ẹrọ',
+        lightMode: 'Móòdù ìmọ́lẹ̀',
+        darkMode: 'Móòdù òkùnkùn',
+        loading: 'Ń gbé wọlé',
+      },
+    },
+    ha: {
+      ui: {
+        language: 'Harshe',
+        launchExperience: 'Fara kwarewa',
+        installPwa: 'Saka PWA',
+        lightMode: 'Yanayin haske',
+        darkMode: 'Yanayin duhu',
+        loading: 'Ana lodawa',
+      },
+    },
+    ig: {
+      ui: {
+        language: 'Asụsụ',
+        launchExperience: 'Bido ahụmịhe',
+        installPwa: 'Wụnye PWA',
+        lightMode: 'Ọnọdụ ọkụ',
+        darkMode: 'Ọnọdụ ọchịchịrị',
+        loading: 'Na-ebudata',
+      },
+    },
+  };
+
+  function normalizeLanguage(language) {
+    if (!language) return DEFAULT_LANG;
+    const base = language.toLowerCase().split('-')[0];
+    return SUPPORTED_LANGUAGES.includes(base) ? base : DEFAULT_LANG;
+  }
+
+  function detectBrowserLanguage() {
+    const candidates = [...(Array.isArray(navigator.languages) ? navigator.languages : []), navigator.language].filter(
+      Boolean,
+    );
+
+    for (const candidate of candidates) {
+      const normalized = normalizeLanguage(candidate);
+      if (SUPPORTED_LANGUAGES.includes(normalized)) {
+        return normalized;
+      }
+    }
+    return DEFAULT_LANG;
+  }
+
+  function lookup(lang, key) {
+    const parts = key.split('.');
+    const resolve = (source) => parts.reduce((obj, part) => (obj && obj[part] != null ? obj[part] : undefined), source);
+    return resolve(translations[lang]) ?? resolve(translations[DEFAULT_LANG]) ?? key;
+  }
+
+  function applyTranslations(lang) {
+    document.documentElement.lang = lang;
+    document.querySelectorAll('[data-i18n]').forEach((el) => {
+      el.textContent = lookup(lang, el.dataset.i18n);
+    });
+    document.querySelectorAll('[data-i18n-placeholder]').forEach((el) => {
+      el.setAttribute('placeholder', lookup(lang, el.dataset.i18nPlaceholder));
+    });
+    document.querySelectorAll('[data-i18n-aria-label]').forEach((el) => {
+      el.setAttribute('aria-label', lookup(lang, el.dataset.i18nAriaLabel));
+    });
+  }
+
+  function setLanguage(lang) {
+    const nextLanguage = normalizeLanguage(lang);
+    localStorage.setItem(STORAGE_KEY, nextLanguage);
+    applyTranslations(nextLanguage);
+    window.dispatchEvent(new CustomEvent('ariyo:languageChanged', { detail: { language: nextLanguage } }));
+  }
+
+  function getInitialLanguage() {
+    const saved = localStorage.getItem(STORAGE_KEY);
+    if (saved) return normalizeLanguage(saved);
+    return detectBrowserLanguage();
+  }
+
+  function injectLanguageSelector(currentLanguage) {
+    const host = document.querySelector('[data-language-switcher-host]') || document.body;
+    const wrapper = document.createElement('div');
+    wrapper.className = 'language-switcher';
+    wrapper.innerHTML = `
+      <label for="languageSelector" data-i18n="ui.language">${lookup(currentLanguage, 'ui.language')}</label>
+      <select id="languageSelector" aria-label="Language selector">
+        <option value="en">English</option>
+        <option value="fr">Français</option>
+        <option value="es">Español</option>
+        <option value="pt">Português</option>
+        <option value="yo">Yorùbá</option>
+        <option value="ha">Hausa</option>
+        <option value="ig">Igbo</option>
+      </select>
+    `;
+    const select = wrapper.querySelector('#languageSelector');
+    select.value = currentLanguage;
+    select.addEventListener('change', (event) => setLanguage(event.target.value));
+    host.appendChild(wrapper);
+  }
+
+  function ensureStyles() {
+    if (document.getElementById('ariyo-i18n-style')) return;
+    const style = document.createElement('style');
+    style.id = 'ariyo-i18n-style';
+    style.textContent = `.language-switcher{display:inline-flex;align-items:center;gap:.4rem;font-size:.85rem;flex-wrap:wrap}.language-switcher select{border-radius:8px;padding:.2rem .4rem;max-width:160px}`;
+    document.head.appendChild(style);
+  }
+
+  function init() {
+    ensureStyles();
+    const lang = getInitialLanguage();
+    injectLanguageSelector(lang);
+    applyTranslations(lang);
+  }
+
+  window.AriyoI18n = {
+    setLanguage,
+    t: (key, lang = getInitialLanguage()) => lookup(lang, key),
+    supportedLanguages: SUPPORTED_LANGUAGES,
+  };
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init, { once: true });
+  } else {
+    init();
+  }
+})();


### PR DESCRIPTION
### Motivation
- Provide automatic, privacy-friendly UI language localization based on the browser's `navigator.languages` / `navigator.language` with English as a safe fallback. 
- Let visitors manually switch language and persist that preference so returning users see the UI in their chosen language. 
- Make static UI copy translation-ready and scalable so additional languages can be added without large refactors.

### Description
- Added a lightweight vanilla JS i18n utility at `scripts/i18n.js` that detects browser language, resolves translations, applies runtime updates, and exposes `window.AriyoI18n` with `setLanguage` and `t` helpers. 
- Implemented supported language packs for `en`, `fr`, `es`, `pt`, `yo`, `ha`, and `ig`, with graceful fallback to English when keys are missing. 
- Persisted user language choice in `localStorage` under `ariyo.language` and added an inline language selector injected into pages via a `data-language-switcher-host` container. 
- Marked key UI strings for runtime translation using `data-i18n`, `data-i18n-placeholder`, and `data-i18n-aria-label`, and integrated the i18n script into `index.html` and `main.html` without changing app flows. 
- Added minimal selector styling dynamically and documented how to add new translations and languages in `README.md`.

### Testing
- Ran `npx prettier --write scripts/i18n.js` and the file was formatted successfully. 
- Ran `npx eslint scripts/i18n.js` and linting completed with no errors. 
- Verified the language selector is injected into `index.html` and `main.html`, persisted value is stored in `localStorage` (`ariyo.language`), and runtime string replacement occurs for elements annotated with `data-i18n` (manual verification during integration).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f69de4e64883329fa24227dbe8676d)