### PR TITLE
Use existing news-fallback.svg for TrustLayer card image

### DIFF
--- a/main.html
+++ b/main.html
@@ -1794,7 +1794,7 @@
       <div class="content" id="main-content">
         <section class="badge-spotlight trust-layer" aria-label="Global leadership nomination">
           <img
-            src="img/tallberg-snf-eliasson-nomination-2026.jpg"
+            src="img/news-fallback.svg"
             alt="2026 Tällberg-SNF-Eliasson Global Leadership Prize nomination notice"
             class="badge-spotlight__image"
             loading="lazy"


### PR DESCRIPTION
### Motivation
- Replace a broken/missing TrustLayer image reference with an existing repository asset to eliminate the missing-image issue while keeping all TrustLayer text and compliance logic unchanged.

### Description
- Updated `main.html` to replace the `img/tallberg-snf-eliasson-nomination-2026.jpg` reference with `img/news-fallback.svg` and removed the now-unneeded `img/tallberg-snf-eliasson-nomination-2026.png` asset from the repository.

### Testing
- Verified the fallback asset exists with `test -f img/news-fallback.svg` and the check succeeded.
- Confirmed `main.html` contains the updated `src="img/news-fallback.svg"` reference using `rg`/`nl` output inspection and the search showed the new path.
- Re-ran PR metadata generation and the simplified PR title/body were produced successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9d93e15f883328c8f7712ae1b290d)