### PR TITLE
Add “Conseils d’Amour” to Omoluabi Production Catalogue and announce release

### DIFF
--- a/Omoluabi_Production_Catalogue.md
+++ b/Omoluabi_Production_Catalogue.md
@@ -4,6 +4,7 @@
 
 ## Latest additions (now live in the catalogue player)
 
+- [Conseils d’Amour](https://suno.com/s/2NUmQdiR8vhNgshz)
 - [Atmosphere Status](https://suno.com/s/ywZSBxvG8uShMofM)
 - [Ling Zing](https://suno.com/s/FLqKSUuzOE2369fa)
 - [Alafia](https://suno.com/s/jgatsjo6lHfzV6wj)
@@ -20,6 +21,7 @@
 
 ## Full catalogue (includes the additions above)
 
+- [Conseils d’Amour](https://suno.com/s/2NUmQdiR8vhNgshz)
 - [Atmosphere Status](https://suno.com/s/ywZSBxvG8uShMofM)
 - [Ling Zing](https://suno.com/s/FLqKSUuzOE2369fa)
 - [Alafia](https://suno.com/s/jgatsjo6lHfzV6wj)

--- a/api/news.js
+++ b/api/news.js
@@ -49,6 +49,17 @@ const SOURCES = [
 
 const CURATED_STORIES = [
   {
+    id: 'conseils-damour-omoluabi-catalogue',
+    title: 'Conseils d’Amour joins the Omoluabi Production Catalogue',
+    summary:
+      'The new romantic Afro-fusion drop is now available from the track catalogue and inside the Omoluabi Production Catalogue album folder for instant playback.',
+    tag: 'Fresh Music Drop',
+    url: 'https://suno.com/s/2NUmQdiR8vhNgshz',
+    publishedAt: '2026-05-17T00:00:00Z',
+    image: 'https://cdn2.suno.ai/image_large_95d5798e-ac71-4740-a4d8-0070e0d33c7d.jpeg',
+    pinned: true,
+  },
+  {
     id: 'marquis-whos-who-2025',
     title: 'Marquis Who’s Who honors Àríyò AI founder Paul A.K. Iyogun as a 2025 Honored Listee',
     summary:

--- a/data/news.json
+++ b/data/news.json
@@ -1,1 +1,12 @@
-[]
+[
+  {
+    "id": "conseils-damour-omoluabi-catalogue",
+    "title": "Conseils d’Amour joins the Omoluabi Production Catalogue",
+    "summary": "The new romantic Afro-fusion drop is now available from the track catalogue and inside the Omoluabi Production Catalogue album folder for instant playback.",
+    "tag": "Fresh Music Drop",
+    "url": "https://suno.com/s/2NUmQdiR8vhNgshz",
+    "publishedAt": "2026-05-17T00:00:00Z",
+    "image": "https://cdn2.suno.ai/image_large_95d5798e-ac71-4740-a4d8-0070e0d33c7d.jpeg",
+    "pinned": true
+  }
+]

--- a/scripts/data.js
+++ b/scripts/data.js
@@ -306,6 +306,7 @@
       name: 'Omoluabi Production Catalogue',
       cover: `${BASE_URL}Logo.jpg`,
       tracks: [
+        { src: 'https://cdn1.suno.ai/95d5798e-ac71-4740-a4d8-0070e0d33c7d.mp3', title: 'Conseils d’Amour' },
         { src: 'https://cdn1.suno.ai/6c43cb2f-907e-488a-bc6d-cb8e582a189a.mp3', title: 'Is Love Conditional' },
         { src: 'https://cdn1.suno.ai/6447e1d2-2133-450a-aff8-536263dab07f.mp3', title: 'Ostrich Effect' },
         { src: 'https://cdn1.suno.ai/d9360744-21e6-4de3-a2ec-a2558d09abfe.mp3', title: 'Priapism' },
@@ -660,6 +661,13 @@
   const LATEST_TRACK_LIMIT = 2;
 
   const latestTrackAnnouncements = [
+    {
+      albumName: 'Omoluabi Production Catalogue',
+      title: 'Conseils d’Amour',
+      src: 'https://cdn1.suno.ai/95d5798e-ac71-4740-a4d8-0070e0d33c7d.mp3',
+      addedOn: '2026-05-16T19:58:18.667Z',
+      isFreshDrop: true,
+    },
     {
       albumName: 'OfficialPaulInspires Spoken Word Series',
       title: 'Me After You',

--- a/scripts/omoluabi-catalogue.js
+++ b/scripts/omoluabi-catalogue.js
@@ -3,6 +3,11 @@
 
   const OMOLUABI_TRACKS = [
     {
+      slug: 'conseils-damour',
+      title: 'Conseils d’Amour',
+      src: 'https://cdn1.suno.ai/95d5798e-ac71-4740-a4d8-0070e0d33c7d.mp3',
+    },
+    {
       slug: 'is-love-conditional',
       title: 'Is Love Conditional',
       src: 'https://cdn1.suno.ai/6c43cb2f-907e-488a-bc6d-cb8e582a189a.mp3',
@@ -330,6 +335,12 @@
   ];
 
   const LATEST_ANNOUNCEMENTS = [
+    {
+      albumName: 'Omoluabi Production Catalogue',
+      slug: 'conseils-damour',
+      addedOn: '2026-05-16T19:58:18.667Z',
+      isFreshDrop: true,
+    },
     {
       albumName: 'Omoluabi Production Catalogue',
       slug: 'is-love-conditional',


### PR DESCRIPTION
### Motivation
- Make the Suno link provided (https://suno.com/s/2NUmQdiR8vhNgshz) available inside the Omoluabi track catalogue and the Omoluabi Production Catalogue album so users can play it from both the track registry and the album folder. 

### Description
- Register the track in the catalogue provider by adding a new entry to `OMOLUABI_TRACKS` and to `LATEST_ANNOUNCEMENTS` so it resolves in track lookups and fresh-drop UI (`scripts/omoluabi-catalogue.js`).
- Add the track to the Omoluabi Production Catalogue album list and include it in the latest-track announcements pool (`scripts/data.js`).
- Publish the Suno link in the human-readable catalogue pages by updating `Omoluabi_Production_Catalogue.md` in both the "Latest additions" and "Full catalogue" sections.
- Add a curated news item and a fallback JSON news record so the release surfaces in the site news panel (`api/news.js`, `data/news.json`).

### Testing
- Ran unit tests `npm test -- --runTestsByPath tests/omoluabi-catalogue.test.js tests/news.test.js` which passed (all tests in those suites succeeded). 
- Ran `npm run validate:release-years` which completed but reported existing, pre-existing missing release-year metadata for other Omoluabi tracks (no failure introduced by this change). 
- Built the static site with `npm run build` which completed successfully and verified static output generation. 
- Performed a local smoke check with Playwright to capture a screenshot of the built site (Playwright browser/deps installed during the run) to confirm the new catalogue content is visible in the static build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a0fa815c483328f193bc88a08f4ef)