### PR TITLE
Improve music playback startup by switching audio preload to auto

### DIFF
--- a/components/AriyoAudioPlayer.tsx
+++ b/components/AriyoAudioPlayer.tsx
@@ -474,7 +474,7 @@ const AriyoAudioPlayer: React.FC<AriyoAudioPlayerProps> = ({
           </div>
         </div>
       </div>
-      <audio ref={audioRef} src={src} preload="metadata" />
+      <audio ref={audioRef} src={src} preload="auto" />
     </div>
   );
 };

--- a/main.html
+++ b/main.html
@@ -2085,7 +2085,7 @@
               </div>
               <audio
                 id="audioPlayer"
-                preload="metadata"
+                preload="auto"
                 playsinline
                 webkit-playsinline
                 hidden


### PR DESCRIPTION
### Motivation
- Reduce time-to-first-audio by allowing the browser to fetch playable audio data earlier instead of waiting until play is requested (`preload="auto"` vs `preload="metadata"`).

### Description
- Change `preload` on the main PWA player `<audio id="audioPlayer">` in `main.html` from `metadata` to `auto`.
- Change `preload` on the reusable React audio element in `components/AriyoAudioPlayer.tsx` from `metadata` to `auto`.

### Testing
- Ran `npm run lint -- components/AriyoAudioPlayer.tsx`; linting completed but surfaced pre-existing Prettier errors in `scripts/i18n.js` unrelated to these changes (no new code errors introduced by this PR).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14f93f34d88332b447031de7d11f9f)