### PR TITLE
Upgrade Ariyọ into Africa's AI Media Intelligence Engine

### DIFF
--- a/companion.css
+++ b/companion.css
@@ -1,16 +1,17 @@
 :root {
-  --companion-ink: #f7f4e8;
-  --companion-muted: #b8b6aa;
-  --companion-panel: #111712;
-  --companion-panel-soft: #172019;
-  --companion-line: rgba(255, 255, 255, 0.11);
-  --companion-lime: #c8f04b;
-  --companion-gold: #f3bd4e;
-  --companion-coral: #ef745e;
-  --companion-green: #2e805e;
+  --intelligence-bg: #07111f;
+  --intelligence-surface: #0e1a2b;
+  --intelligence-surface-2: #14243a;
+  --intelligence-text: #f8fafc;
+  --intelligence-muted: #94a3b8;
+  --intelligence-gold: #d4af37;
+  --intelligence-emerald: #10b981;
+  --intelligence-border: rgba(255, 255, 255, 0.1);
+  --intelligence-border-strong: rgba(255, 255, 255, 0.18);
 }
+
 .sr-only {
-  position: absolute !important;
+  position: absolute;
   width: 1px;
   height: 1px;
   padding: 0;
@@ -21,1000 +22,1305 @@
   border: 0;
 }
 .companion-shell {
-  display: grid;
-  gap: clamp(2.75rem, 7vw, 6rem);
-  margin-bottom: clamp(3rem, 8vw, 7rem);
-  color: var(--companion-ink);
-  text-shadow: none;
+  width: min(100%, 1500px);
+  margin: 0 auto;
+  padding: 24px 28px 72px;
+  color: var(--intelligence-text);
+  background: var(--intelligence-bg);
+  font-family: inherit;
+}
+.companion-shell *,
+.companion-shell *::before,
+.companion-shell *::after {
+  box-sizing: border-box;
 }
 .companion-shell button,
-.mobile-companion-nav button {
+.companion-shell input,
+.companion-shell select {
   font: inherit;
 }
-.companion-hero {
+.companion-shell button {
+  cursor: pointer;
+}
+.companion-shell .eyebrow {
+  margin: 0 0 12px;
+  color: var(--intelligence-gold);
+  font-size: 0.69rem;
+  font-weight: 800;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.intelligence-hero {
   position: relative;
   isolation: isolate;
   overflow: hidden;
-  min-height: 560px;
-  padding: clamp(1.25rem, 4vw, 3.5rem);
-  border: 1px solid var(--companion-line);
-  border-radius: 32px;
-  background:
-    radial-gradient(circle at 82% 16%, rgba(200, 240, 75, 0.17), transparent 27%),
-    radial-gradient(circle at 8% 90%, rgba(46, 128, 94, 0.28), transparent 35%),
-    linear-gradient(145deg, #172018 0%, #080c09 75%);
-  box-shadow: 0 30px 80px rgba(0, 0, 0, 0.35);
+  min-height: 680px;
+  padding: 24px 34px 38px;
+  border: 1px solid var(--intelligence-border);
+  background: #091525;
+  box-shadow: 0 26px 80px rgba(0, 0, 0, 0.32);
 }
-.companion-hero:after {
-  content: 'ÀRÍYÒ';
-  position: absolute;
-  right: -0.04em;
-  bottom: -0.23em;
-  z-index: -1;
-  color: rgba(255, 255, 255, 0.025);
-  font:
-    900 clamp(7rem, 18vw, 16rem)/1 Montserrat,
-    sans-serif;
-  letter-spacing: -0.09em;
-}
-.companion-hero__glow {
-  position: absolute;
-  width: 280px;
-  height: 280px;
-  right: 8%;
-  top: 19%;
-  border: 1px solid rgba(200, 240, 75, 0.18);
-  border-radius: 50%;
-  box-shadow:
-    0 0 80px rgba(200, 240, 75, 0.08),
-    inset 0 0 80px rgba(200, 240, 75, 0.05);
-  z-index: -1;
-}
-.companion-hero__glow:before,
-.companion-hero__glow:after {
+.intelligence-hero::before {
   content: '';
   position: absolute;
-  inset: 16%;
-  border: 1px solid rgba(255, 255, 255, 0.09);
-  border-radius: 48% 52% 61% 39%;
-  transform: rotate(28deg);
+  inset: 0;
+  z-index: -2;
+  background:
+    radial-gradient(circle at 72% 20%, rgba(16, 185, 129, 0.09), transparent 32%),
+    radial-gradient(circle at 5% 95%, rgba(212, 175, 55, 0.07), transparent 26%);
 }
-.companion-hero__glow:after {
-  inset: 34%;
-  border-color: var(--companion-lime);
-  opacity: 0.45;
-  transform: rotate(-20deg);
+.hero-grid {
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  opacity: 0.17;
+  background-image:
+    linear-gradient(rgba(148, 163, 184, 0.16) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(148, 163, 184, 0.16) 1px, transparent 1px);
+  background-size: 42px 42px;
+  mask-image: linear-gradient(to bottom, #000, transparent 92%);
 }
-.companion-hero__topline {
+.hero-status-row {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 1rem;
-  color: var(--companion-muted);
-  font-size: 0.76rem;
-  text-transform: uppercase;
-  letter-spacing: 0.14em;
+  gap: 20px;
+  padding-bottom: 22px;
+  border-bottom: 1px solid var(--intelligence-border);
 }
-.live-pill {
-  display: inline-flex;
+.system-status {
+  display: flex;
   align-items: center;
-  gap: 0.5rem;
-  padding: 0.45rem 0.75rem;
-  border: 1px solid var(--companion-line);
-  border-radius: 100px;
-  background: rgba(0, 0, 0, 0.2);
+  gap: 9px;
+  color: #cbd5e1;
+  font-size: 0.74rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
 }
-.live-pill span {
+.system-status i,
+.station-card__live i {
   width: 7px;
   height: 7px;
   border-radius: 50%;
-  background: var(--companion-lime);
-  box-shadow: 0 0 12px var(--companion-lime);
+  background: var(--intelligence-emerald);
+  box-shadow: 0 0 14px rgba(16, 185, 129, 0.8);
 }
-.companion-hero__copy {
-  max-width: 780px;
-  margin: clamp(4.5rem, 10vw, 8rem) 0 2rem;
-}
-.companion-shell .eyebrow {
-  margin: 0 0 0.75rem;
-  color: var(--companion-lime);
+.language-control {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  color: var(--intelligence-muted);
   font-size: 0.72rem;
-  font-weight: 700;
-  letter-spacing: 0.18em;
   text-transform: uppercase;
+  letter-spacing: 0.1em;
 }
-.companion-hero h1 {
-  max-width: 730px;
+.language-control select,
+.filter-group select {
+  min-height: 36px;
+  padding: 0 30px 0 11px;
+  border: 1px solid var(--intelligence-border);
+  color: var(--intelligence-text);
+  background: var(--intelligence-surface);
+}
+.hero-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1.45fr) minmax(330px, 0.65fr);
+  gap: 54px;
+  align-items: center;
+  padding-top: 56px;
+}
+.hero-primary {
+  max-width: 860px;
+}
+.hero-primary h1 {
+  max-width: 780px;
   margin: 0;
-  font:
-    600 clamp(2.75rem, 7vw, 6.5rem)/0.96 Montserrat,
-    sans-serif;
-  letter-spacing: -0.065em;
+  color: var(--intelligence-text);
+  font-size: clamp(3rem, 5.8vw, 6rem);
+  font-weight: 650;
+  line-height: 0.98;
+  letter-spacing: -0.055em;
 }
-.companion-hero h1 em {
-  color: var(--companion-lime);
-  font-family: Georgia, serif;
-  font-weight: 400;
+.hero-primary h1 span {
+  display: block;
+  color: #cbd5e1;
 }
-.companion-hero__copy > p:last-child {
+.hero-deck {
   max-width: 680px;
-  margin: 1.5rem 0 0;
-  color: var(--companion-muted);
-  font-size: clamp(0.98rem, 2vw, 1.18rem);
+  margin: 24px 0 28px;
+  color: var(--intelligence-muted);
+  font-size: clamp(1rem, 1.6vw, 1.2rem);
   line-height: 1.7;
 }
 .ai-command {
   display: grid;
   grid-template-columns: auto 1fr auto;
   align-items: center;
-  gap: 0.75rem;
-  max-width: 830px;
-  padding: 0.65rem 0.65rem 0.65rem 1.2rem;
-  border: 1px solid rgba(200, 240, 75, 0.3);
-  border-radius: 18px;
-  background: rgba(4, 8, 5, 0.76);
-  box-shadow: 0 16px 42px rgba(0, 0, 0, 0.26);
+  min-height: 68px;
+  border: 1px solid rgba(212, 175, 55, 0.45);
+  background: rgba(7, 17, 31, 0.92);
+  box-shadow: 0 16px 40px rgba(0, 0, 0, 0.22);
 }
-.ai-command__mark {
-  color: var(--companion-lime);
-  font-size: 1.35rem;
+.command-prefix {
+  display: grid;
+  place-items: center;
+  width: 54px;
+  height: 38px;
+  margin-left: 14px;
+  border-right: 1px solid var(--intelligence-border);
+  color: var(--intelligence-gold);
+  font-size: 0.7rem;
+  font-weight: 900;
+  letter-spacing: 0.12em;
 }
 .ai-command input {
-  width: 100%;
   min-width: 0;
-  padding: 0.8rem 0;
+  height: 66px;
+  padding: 0 18px;
   border: 0;
   outline: 0;
+  color: var(--intelligence-text);
   background: transparent;
-  color: white;
-  font:
-    500 1rem Montserrat,
-    sans-serif;
 }
 .ai-command input::placeholder {
-  color: #8f938c;
+  color: #64748b;
 }
 .ai-command button,
-.briefing-pick button,
-.story-feature button {
-  display: flex;
-  align-items: center;
-  gap: 0.9rem;
-  padding: 0.9rem 1.1rem;
+.primary-action {
+  align-self: stretch;
   border: 0;
-  border-radius: 12px;
-  background: var(--companion-lime);
-  color: #12180b;
-  font-weight: 800;
-  cursor: pointer;
+  padding: 0 24px;
+  color: #07111f;
+  background: var(--intelligence-gold);
+  font-size: 0.78rem;
+  font-weight: 900;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+.command-categories {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 7px;
+  margin-top: 13px;
+  color: #64748b;
+  font-size: 0.66rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.command-categories button,
+.prompt-rail button,
+.filter-row button,
+.briefing-actions button,
+.language-actions button {
+  border: 1px solid var(--intelligence-border);
+  color: var(--intelligence-muted);
+  background: rgba(14, 26, 43, 0.72);
+}
+.command-categories button {
+  padding: 5px 8px;
+  font-size: 0.62rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
 }
 .prompt-rail {
   display: flex;
-  gap: 0.55rem;
-  max-width: 920px;
-  margin-top: 1rem;
+  gap: 8px;
   overflow-x: auto;
-  padding-bottom: 0.35rem;
-  scrollbar-width: none;
+  margin: 18px 0 0;
+  padding-bottom: 4px;
+  scrollbar-width: thin;
 }
-.prompt-rail::-webkit-scrollbar {
-  display: none;
-}
-.prompt-rail button,
-.filter-row button,
-.smart-radio-suggestions button {
-  flex: none;
-  padding: 0.58rem 0.85rem;
-  border: 1px solid var(--companion-line);
-  border-radius: 100px;
-  background: rgba(255, 255, 255, 0.045);
-  color: #d9d9d2;
-  cursor: pointer;
+.prompt-rail button {
+  flex: 0 0 auto;
+  padding: 9px 12px;
+  font-size: 0.7rem;
 }
 .prompt-rail button:hover,
+.command-categories button:hover,
 .filter-row button:hover,
 .filter-row button.active {
-  border-color: var(--companion-lime);
-  color: var(--companion-lime);
+  border-color: rgba(212, 175, 55, 0.65);
+  color: var(--intelligence-text);
+  background: rgba(212, 175, 55, 0.08);
+}
+.hero-actions {
+  display: flex;
+  gap: 10px;
+  margin-top: 24px;
+}
+.hero-actions button {
+  min-height: 44px;
+  padding: 0 18px;
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+.secondary-action {
+  border: 1px solid var(--intelligence-border-strong);
+  color: var(--intelligence-text);
+  background: transparent;
 }
 .ai-response,
 .returning-message {
-  max-width: 830px;
-  margin-top: 1rem;
-  padding: 0.85rem 1rem;
-  border-left: 2px solid var(--companion-lime);
-  background: rgba(200, 240, 75, 0.08);
-  color: #e3e8d4;
+  margin-top: 16px;
+  padding: 13px 15px;
+  border-left: 2px solid var(--intelligence-emerald);
+  color: var(--intelligence-muted);
+  background: rgba(16, 185, 129, 0.06);
+  font-size: 0.82rem;
 }
-.quick-actions {
+.ai-response span {
+  color: var(--intelligence-emerald);
+  font-size: 0.64rem;
+  font-weight: 900;
+  letter-spacing: 0.12em;
+}
+.ai-response p {
+  margin: 5px 0 0;
+}
+.metrics-panel {
+  padding: 24px;
+  border: 1px solid var(--intelligence-border);
+  background: rgba(14, 26, 43, 0.9);
+  box-shadow: 18px 18px 0 rgba(20, 36, 58, 0.45);
+}
+.panel-heading,
+.section-heading,
+.shelf-heading,
+.answer-header,
+.graph-head,
+.signal-heading {
+  display: flex;
+  justify-content: space-between;
+  gap: 18px;
+  align-items: flex-start;
+}
+.panel-heading h2 {
+  margin: 0;
+  font-size: 1.2rem;
+}
+.demo-label,
+.status-chip {
+  padding: 6px 8px;
+  border: 1px solid var(--intelligence-border);
+  color: var(--intelligence-muted);
+  font-size: 0.58rem;
+  font-weight: 800;
+  letter-spacing: 0.1em;
+  white-space: nowrap;
+}
+.metric-grid {
   display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  gap: 1px;
-  overflow: hidden;
-  border: 1px solid var(--companion-line);
-  border-radius: 20px;
-  background: var(--companion-line);
+  grid-template-columns: 1fr 1fr;
+  margin-top: 24px;
+  border-top: 1px solid var(--intelligence-border);
+  border-left: 1px solid var(--intelligence-border);
 }
-.quick-actions button {
-  display: grid;
-  grid-template-columns: auto 1fr;
-  grid-template-rows: auto auto;
-  column-gap: 0.9rem;
-  padding: 1.35rem;
-  text-align: left;
-  border: 0;
-  background: #111612;
-  color: white;
-  cursor: pointer;
+.metric-grid article {
+  min-height: 112px;
+  padding: 16px;
+  border-right: 1px solid var(--intelligence-border);
+  border-bottom: 1px solid var(--intelligence-border);
 }
-.quick-actions button:hover {
-  background: #182019;
+.metric-grid span,
+.metric-grid small {
+  display: block;
+  color: var(--intelligence-muted);
+  font-size: 0.64rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
 }
-.quick-actions span {
-  grid-row: 1/3;
-  align-self: center;
-  color: var(--companion-lime);
-  font-size: 1.35rem;
+.metric-grid strong {
+  display: block;
+  margin: 10px 0 5px;
+  color: var(--intelligence-text);
+  font-size: 2rem;
+  font-weight: 500;
+  font-variant-numeric: tabular-nums;
 }
-.quick-actions b {
-  font-size: 0.95rem;
+.signal-monitor,
+.routing-log {
+  margin-top: 20px;
+  padding-top: 18px;
+  border-top: 1px solid var(--intelligence-border);
 }
-.quick-actions small {
-  color: var(--companion-muted);
-  font-size: 0.72rem;
+.signal-heading span,
+.routing-log span {
+  color: var(--intelligence-muted);
+  font-size: 0.64rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
 }
-.companion-section {
-  scroll-margin-top: 110px;
+.signal-heading b {
+  color: var(--intelligence-emerald);
+  font-size: 0.6rem;
+  letter-spacing: 0.1em;
 }
-.section-heading {
+.signal-bars {
   display: flex;
   align-items: end;
+  gap: 4px;
+  height: 64px;
+  margin: 10px 0;
+}
+.signal-bars i {
+  flex: 1;
+  height: calc(22% + (var(--bar, 1) * 5%));
+  max-height: 100%;
+  background: #315069;
+  animation: signalShift 2.8s ease-in-out infinite alternate;
+}
+.signal-bars i:nth-child(2n) {
+  height: 62%;
+  background: #3d6577;
+  animation-delay: -0.8s;
+}
+.signal-bars i:nth-child(3n) {
+  height: 88%;
+  background: var(--intelligence-emerald);
+  animation-delay: -1.4s;
+}
+.signal-bars i:nth-child(5n) {
+  height: 42%;
+  background: var(--intelligence-gold);
+}
+.signal-legend {
+  display: flex;
   justify-content: space-between;
-  gap: 1.5rem;
-  margin-bottom: 1.5rem;
-}
-.section-heading h2,
-.culture-grid h2,
-.creator-studio h2 {
-  margin: 0;
-  font:
-    600 clamp(1.7rem, 4vw, 3.2rem)/1.05 Montserrat,
-    sans-serif;
-  letter-spacing: -0.045em;
-}
-.text-button {
-  padding: 0.6rem 0;
-  border: 0;
-  background: none;
-  color: var(--companion-muted);
-  cursor: pointer;
-}
-.text-button span {
-  color: var(--companion-lime);
-}
-.briefing-grid {
-  display: grid;
-  grid-template-columns: 1.55fr 0.72fr 0.72fr;
-  gap: 1rem;
-}
-.briefing-grid article,
-.personalized-shelf,
-.recently-played {
-  border: 1px solid var(--companion-line);
-  border-radius: 22px;
-  background: var(--companion-panel);
-  overflow: hidden;
-}
-.briefing-lead {
-  display: grid;
-  grid-template-columns: minmax(125px, 0.7fr) 1.3fr;
-  gap: 1.4rem;
-  padding: 1rem;
-}
-.briefing-lead__art {
-  display: grid;
-  place-items: end start;
-  min-height: 275px;
-  padding: 1.2rem;
-  border-radius: 15px;
-  background:
-    linear-gradient(145deg, rgba(200, 240, 75, 0.8), rgba(46, 128, 94, 0.82)),
-    repeating-linear-gradient(40deg, transparent 0 11px, rgba(0, 0, 0, 0.15) 12px 14px);
-  color: #0c1a0d;
-}
-.briefing-lead__art span {
-  font:
-    900 2.2rem/0.85 Montserrat,
-    sans-serif;
-  letter-spacing: -0.08em;
-}
-.briefing-lead h3,
-.briefing-pick h3 {
-  margin: 0.75rem 0;
-  font-size: clamp(1.2rem, 2.4vw, 1.75rem);
-  line-height: 1.12;
-}
-.briefing-lead p,
-.briefing-pick p {
-  color: var(--companion-muted);
-  line-height: 1.55;
-}
-.content-label {
-  display: inline-block;
-  color: var(--companion-lime);
-  font-size: 0.65rem;
-  font-weight: 800;
-  letter-spacing: 0.13em;
+  color: #64748b;
+  font-size: 0.57rem;
   text-transform: uppercase;
 }
-.briefing-actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.45rem;
-  margin-top: 1rem;
+.routing-log p {
+  margin: 8px 0 0;
+  color: #cbd5e1;
+  font-size: 0.78rem;
+  line-height: 1.5;
 }
-.briefing-actions button {
-  padding: 0.5rem 0.65rem;
-  border: 1px solid var(--companion-line);
-  border-radius: 8px;
+
+.companion-section {
+  margin-top: 74px;
+  scroll-margin-top: 24px;
+}
+.section-heading {
+  align-items: end;
+  margin-bottom: 28px;
+  padding-bottom: 22px;
+  border-bottom: 1px solid var(--intelligence-border);
+}
+.section-heading h2 {
+  margin: 0;
+  color: var(--intelligence-text);
+  font-size: clamp(1.8rem, 3.2vw, 3rem);
+  font-weight: 560;
+  letter-spacing: -0.035em;
+}
+.section-heading > div > p:last-child {
+  max-width: 680px;
+  margin: 10px 0 0;
+  color: var(--intelligence-muted);
+  line-height: 1.6;
+}
+.text-button {
+  border: 0;
+  padding: 0 0 4px;
+  color: var(--intelligence-text);
   background: transparent;
-  color: #e7e7df;
-  font-size: 0.68rem;
-  cursor: pointer;
+  font-size: 0.72rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
 }
-.briefing-pick {
+.text-button span {
+  color: var(--intelligence-gold);
+}
+.filter-console {
   display: flex;
-  flex-direction: column;
-  padding: 1.3rem;
-  background: linear-gradient(155deg, #1b231c, #101511) !important;
+  align-items: end;
+  gap: 20px;
+  margin-bottom: 18px;
+  padding: 14px;
+  border: 1px solid var(--intelligence-border);
+  background: var(--intelligence-surface);
 }
-.briefing-pick--radio {
-  background: linear-gradient(155deg, #2b1b15, #15100e) !important;
+.filter-group {
+  min-width: 150px;
 }
-.briefing-pick button {
-  justify-content: space-between;
-  margin-top: auto;
+.filter-group:first-child {
+  flex: 1;
 }
-.pick-icon {
-  display: grid;
-  place-items: center;
-  width: 72px;
-  height: 72px;
-  margin: 2.2rem 0 1rem;
-  border-radius: 50%;
-  background: var(--companion-coral);
-  font-size: 1.65rem;
-  box-shadow: 0 12px 30px rgba(239, 116, 94, 0.2);
-}
-.station-wave {
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  height: 72px;
-  margin: 2.2rem 0 1rem;
-}
-.station-wave i {
-  width: 5px;
-  height: 35%;
-  border-radius: 10px;
-  background: var(--companion-gold);
-  animation: companionWave 1.2s ease-in-out infinite alternate;
-}
-.station-wave i:nth-child(2) {
-  height: 75%;
-  animation-delay: -0.4s;
-}
-.station-wave i:nth-child(3) {
-  height: 100%;
-  animation-delay: -0.7s;
-}
-.station-wave i:nth-child(4) {
-  height: 60%;
-  animation-delay: -0.2s;
-}
-.station-wave i:nth-child(5) {
-  height: 30%;
-  animation-delay: -0.6s;
-}
-@keyframes companionWave {
-  to {
-    transform: scaleY(0.55);
-  }
+.filter-group > span,
+.filter-group > label {
+  display: block;
+  margin-bottom: 8px;
+  color: #64748b;
+  font-size: 0.6rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
 }
 .filter-row {
   display: flex;
-  gap: 0.5rem;
+  gap: 7px;
   overflow-x: auto;
-  margin-bottom: 1rem;
-  padding-bottom: 0.3rem;
+  scrollbar-width: thin;
+}
+.filter-row button {
+  flex: 0 0 auto;
+  min-height: 34px;
+  padding: 0 11px;
+  font-size: 0.66rem;
+  font-weight: 700;
+}
+.filter-group select {
+  width: 100%;
 }
 .radio-discovery-grid {
   display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  gap: 1rem;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px;
 }
 .station-card {
   position: relative;
-  min-height: 250px;
-  padding: 1.25rem;
-  border: 1px solid var(--companion-line);
-  border-radius: 20px;
-  background: linear-gradient(160deg, var(--station-color, #263328), #0d120e 72%);
-  color: white;
-  cursor: pointer;
-  text-align: left;
-  overflow: hidden;
+  min-height: 300px;
+  padding: 18px;
+  border: 1px solid var(--intelligence-border);
+  background: var(--intelligence-surface);
+  transition:
+    transform 180ms ease,
+    border-color 180ms ease;
 }
-.station-card:after {
-  content: '';
-  position: absolute;
-  width: 150px;
-  height: 150px;
-  right: -55px;
-  bottom: -55px;
-  border: 1px solid rgba(255, 255, 255, 0.13);
-  border-radius: 50%;
-  box-shadow:
-    0 0 0 22px rgba(255, 255, 255, 0.025),
-    0 0 0 44px rgba(255, 255, 255, 0.018);
+.station-card:hover {
+  transform: translateY(-3px);
+  border-color: rgba(212, 175, 55, 0.35);
 }
 .station-card__top {
   display: flex;
-  justify-content: space-between;
+  align-items: center;
+  gap: 9px;
+}
+.station-index {
+  margin-right: auto;
+  color: #52657b;
+  font-size: 0.68rem;
+  font-variant-numeric: tabular-nums;
 }
 .station-card__live {
-  color: var(--companion-lime);
-  font-size: 0.68rem;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--intelligence-emerald);
+  font-size: 0.58rem;
   font-weight: 800;
   text-transform: uppercase;
 }
 .station-card__favorite {
-  position: relative;
-  z-index: 2;
-  padding: 0;
   border: 0;
-  background: none;
-  color: white;
-  font-size: 1.2rem;
+  padding: 4px;
+  color: #64748b;
+  background: transparent;
+  font-size: 0.56rem;
+  font-weight: 800;
 }
-.station-card__mark {
-  display: grid;
-  place-items: center;
-  width: 65px;
-  height: 65px;
-  margin: 2.3rem 0 1rem;
-  border-radius: 50%;
-  background: rgba(255, 255, 255, 0.11);
-  font-size: 1.4rem;
+.station-card__favorite[aria-pressed='true'] {
+  color: var(--intelligence-gold);
 }
 .station-card h3 {
-  margin: 0 0 0.35rem;
-  font-size: 1.15rem;
+  margin: 34px 0 8px;
+  color: var(--intelligence-text);
+  font-size: 1.25rem;
+  font-weight: 600;
 }
-.station-card p {
+.station-card > p {
+  margin: 0 0 26px;
+  color: var(--intelligence-muted);
+  font-size: 0.75rem;
+}
+.station-card dl {
   margin: 0;
-  color: #bfc5bd;
-  font-size: 0.76rem;
 }
-.mood-grid {
-  display: grid;
-  grid-template-columns: repeat(7, 1fr);
-  gap: 0.75rem;
+.station-card dl div {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 8px 0;
+  border-top: 1px solid var(--intelligence-border);
 }
-.mood-card {
-  min-height: 150px;
-  padding: 1rem;
+.station-card dt {
+  color: #64748b;
+  font-size: 0.64rem;
+}
+.station-card dd {
+  margin: 0;
+  color: #cbd5e1;
+  font-size: 0.65rem;
+  text-align: right;
+}
+.station-play {
+  position: absolute;
+  right: 18px;
+  bottom: 16px;
+  left: 18px;
+  display: flex;
+  justify-content: space-between;
   border: 0;
-  border-radius: 18px;
-  background: var(--mood-bg, #293529);
-  color: white;
-  text-align: left;
-  cursor: pointer;
+  border-top: 1px solid var(--intelligence-border);
+  padding: 13px 0 0;
+  color: var(--intelligence-text);
+  background: transparent;
+  font-size: 0.67rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
 }
-.mood-card span {
-  display: block;
-  margin-bottom: 3.5rem;
-  font-size: 1.4rem;
+.station-play span {
+  color: var(--intelligence-gold);
 }
-.mood-card b {
-  display: block;
+.recommendation-strip {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  margin-top: 12px;
+  padding: 16px 18px;
+  border: 1px solid rgba(16, 185, 129, 0.2);
+  background: rgba(16, 185, 129, 0.055);
 }
-.mood-card small {
-  color: rgba(255, 255, 255, 0.66);
+.recommendation-code {
+  color: var(--intelligence-emerald);
+  font-size: 0.58rem;
+  font-weight: 900;
+  letter-spacing: 0.1em;
+}
+.recommendation-strip strong {
+  font-size: 0.78rem;
+}
+.recommendation-strip p {
+  margin: 3px 0 0;
+  color: var(--intelligence-muted);
+  font-size: 0.75rem;
+}
+
+.mood-filters {
+  margin-bottom: 16px;
+}
+.music-intelligence-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 300px;
+  gap: 12px;
 }
 .personalized-shelf,
-.recently-played {
-  display: grid;
-  grid-template-columns: 180px 1fr;
-  gap: 1rem;
-  margin-top: 1rem;
-  padding: 1.2rem;
+.recently-played,
+.profile-model {
+  padding: 20px;
+  border: 1px solid var(--intelligence-border);
+  background: var(--intelligence-surface);
 }
-.personalized-shelf h3,
-.recently-played h3 {
+.shelf-heading {
+  align-items: end;
+  margin-bottom: 16px;
+}
+.shelf-heading h3 {
   margin: 0;
+  font-size: 1.1rem;
+}
+.shelf-heading > span {
+  color: #64748b;
+  font-size: 0.58rem;
+  letter-spacing: 0.1em;
 }
 .track-card-row {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 0.7rem;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 10px;
 }
 .track-card {
-  display: grid;
-  grid-template-columns: 42px 1fr auto;
-  align-items: center;
-  gap: 0.65rem;
-  padding: 0.7rem;
-  border: 1px solid var(--companion-line);
-  border-radius: 12px;
-  background: rgba(255, 255, 255, 0.035);
-  color: white;
-  text-align: left;
-  cursor: pointer;
+  position: relative;
+  min-width: 0;
+  border: 1px solid var(--intelligence-border);
+  background: var(--intelligence-surface-2);
 }
 .track-card__art {
-  display: grid;
-  place-items: center;
-  aspect-ratio: 1;
-  border-radius: 8px;
-  background: var(--track-color, #375c45);
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  min-height: 100px;
+  padding: 12px;
+  border-bottom: 1px solid var(--intelligence-border);
+  background: linear-gradient(135deg, #192f47, #0b1727);
+}
+.track-card__art > span {
+  color: rgba(248, 250, 252, 0.12);
+  font-size: 2.4rem;
+  font-weight: 900;
+  letter-spacing: -0.08em;
+}
+.track-card__art button {
+  border: 0;
+  color: #64748b;
+  background: transparent;
+  font-size: 0.54rem;
+  font-weight: 800;
+}
+.track-card__art button[aria-pressed='true'] {
+  color: var(--intelligence-gold);
+}
+.track-card > div:nth-child(2) {
+  padding: 13px 12px 48px;
 }
 .track-card b,
-.track-card small {
+.track-card small,
+.track-card p {
   display: block;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+.track-card b {
+  color: var(--intelligence-text);
+  font-size: 0.78rem;
+}
 .track-card small {
-  margin-top: 0.2rem;
-  color: var(--companion-muted);
+  margin-top: 6px;
+  color: var(--intelligence-muted);
+  font-size: 0.62rem;
+}
+.track-card p {
+  margin: 8px 0 0;
+  color: #64748b;
+  font-size: 0.59rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+.track-play {
+  position: absolute;
+  right: 12px;
+  bottom: 12px;
+  left: 12px;
+  border: 0;
+  border-top: 1px solid var(--intelligence-border);
+  padding-top: 8px;
+  color: var(--intelligence-gold);
+  background: transparent;
+  font-size: 0.59rem;
+  font-weight: 900;
+  text-align: left;
+}
+.profile-model h3 {
+  margin: 0 0 12px;
+  font-size: 1.2rem;
+}
+.profile-model > p:last-of-type {
+  color: var(--intelligence-muted);
+  font-size: 0.78rem;
+  line-height: 1.6;
+}
+.profile-model dl {
+  margin-top: 28px;
+}
+.profile-model dl div {
+  padding: 11px 0;
+  border-top: 1px solid var(--intelligence-border);
+}
+.profile-model dt {
+  color: #64748b;
+  font-size: 0.6rem;
+  text-transform: uppercase;
+}
+.profile-model dd {
+  margin: 5px 0 0;
+  color: #cbd5e1;
+  font-size: 0.76rem;
+}
+.recently-played {
+  margin-top: 12px;
+}
+.empty-state {
+  grid-column: 1 / -1;
+  padding: 30px;
+  border: 1px dashed var(--intelligence-border);
+  color: var(--intelligence-muted);
+  font-size: 0.8rem;
+  text-align: center;
+}
+
+.briefing-date {
+  color: #64748b;
+  font-size: 0.62rem;
+  letter-spacing: 0.1em;
+}
+.briefing-grid {
+  display: grid;
+  grid-template-columns: 2fr 0.8fr 0.8fr;
+  gap: 12px;
+}
+.briefing-grid article {
+  border: 1px solid var(--intelligence-border);
+  background: var(--intelligence-surface);
+}
+.briefing-lead {
+  display: grid;
+  grid-template-columns: 90px 1fr;
+  gap: 24px;
+  min-height: 320px;
+  padding: 24px;
+}
+.brief-index {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  border-right: 1px solid var(--intelligence-border);
+}
+.brief-index span {
+  color: #64748b;
+  font-size: 0.55rem;
+  font-weight: 800;
+  letter-spacing: 0.1em;
+  writing-mode: vertical-rl;
+}
+.brief-index b {
+  color: rgba(212, 175, 55, 0.3);
+  font-size: 2.5rem;
+  font-weight: 400;
+}
+.content-label {
+  color: var(--intelligence-gold);
+  font-size: 0.59rem;
+  font-weight: 800;
+  letter-spacing: 0.11em;
+  text-transform: uppercase;
+}
+.briefing-lead h3,
+.briefing-pick h3 {
+  margin: 18px 0 12px;
+  color: var(--intelligence-text);
+  font-weight: 540;
+}
+.briefing-lead h3 {
+  max-width: 680px;
+  font-size: clamp(1.35rem, 2.4vw, 2.1rem);
+  line-height: 1.2;
+}
+.briefing-lead p,
+.briefing-pick p {
+  color: var(--intelligence-muted);
+  line-height: 1.65;
+}
+.briefing-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
+  margin-top: 24px;
+}
+.briefing-actions button,
+.language-actions button {
+  padding: 9px 11px;
+  font-size: 0.62rem;
+  font-weight: 700;
+}
+.briefing-pick {
+  display: flex;
+  flex-direction: column;
+  min-height: 320px;
+  padding: 20px;
+}
+.briefing-code {
+  margin-top: 40px;
+  color: #52657b;
+  font-size: 0.62rem;
+  letter-spacing: 0.1em;
+}
+.briefing-pick p {
+  font-size: 0.75rem;
+}
+.briefing-pick button {
+  margin-top: auto;
+  border: 0;
+  border-top: 1px solid var(--intelligence-border);
+  padding: 14px 0 0;
+  color: var(--intelligence-text);
+  background: transparent;
+  font-size: 0.65rem;
+  font-weight: 800;
+  text-align: left;
+}
+
+.ask-africa {
+  display: grid;
+  grid-template-columns: 0.8fr 1.2fr;
+  border: 1px solid rgba(212, 175, 55, 0.28);
+  background: #0b1727;
+}
+.ask-africa-copy,
+.intelligence-answer {
+  padding: clamp(24px, 4vw, 48px);
+}
+.ask-africa-copy {
+  border-right: 1px solid var(--intelligence-border);
+}
+.ask-africa h2 {
+  margin: 0;
+  font-size: clamp(3rem, 6vw, 5.5rem);
+  font-weight: 560;
+  letter-spacing: -0.06em;
+}
+.ask-africa-copy > p:not(.eyebrow) {
+  color: var(--intelligence-muted);
+  line-height: 1.7;
+}
+.ask-examples {
+  display: grid;
+  gap: 7px;
+  margin-top: 30px;
+}
+.ask-examples button {
+  padding: 13px 15px;
+  border: 1px solid var(--intelligence-border);
+  color: #cbd5e1;
+  background: var(--intelligence-surface);
+  font-size: 0.72rem;
+  text-align: left;
+}
+.ask-examples button:hover {
+  border-color: var(--intelligence-gold);
+}
+.answer-header {
+  padding-bottom: 14px;
+  border-bottom: 1px solid var(--intelligence-border);
+  color: #64748b;
+  font-size: 0.58rem;
+  letter-spacing: 0.1em;
+}
+.answer-header b {
+  color: var(--intelligence-emerald);
+}
+.intelligence-answer h3 {
+  margin: 44px 0 18px;
+  font-size: clamp(1.3rem, 2vw, 1.8rem);
+  font-weight: 550;
+}
+.intelligence-answer > p {
+  min-height: 100px;
+  color: var(--intelligence-muted);
+  line-height: 1.8;
+}
+.answer-citations {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  margin-top: 32px;
+  border-top: 1px solid var(--intelligence-border);
+  border-left: 1px solid var(--intelligence-border);
+}
+.answer-citations span {
+  padding: 12px;
+  border-right: 1px solid var(--intelligence-border);
+  border-bottom: 1px solid var(--intelligence-border);
+}
+.answer-citations b,
+.answer-citations i {
+  display: block;
+}
+.answer-citations b {
+  color: #64748b;
+  font-size: 0.56rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+.answer-citations i {
+  margin-top: 5px;
+  color: #cbd5e1;
+  font-size: 0.68rem;
+  font-style: normal;
+}
+
+.status-chip.active,
+.status-active {
+  color: var(--intelligence-emerald) !important;
+}
+.language-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  border-top: 1px solid var(--intelligence-border);
+  border-left: 1px solid var(--intelligence-border);
+}
+.language-grid article {
+  min-height: 190px;
+  padding: 22px;
+  border-right: 1px solid var(--intelligence-border);
+  border-bottom: 1px solid var(--intelligence-border);
+  background: var(--intelligence-surface);
+}
+.language-grid article > span,
+.creator-tools article > span,
+.architecture-grid article > span {
+  color: #52657b;
   font-size: 0.65rem;
 }
-.track-card > span:last-child {
-  color: var(--companion-lime);
+.language-grid h3 {
+  margin: 30px 0 10px;
+  font-size: 1rem;
+}
+.language-grid p {
+  color: var(--intelligence-muted);
+  font-size: 0.76rem;
+  line-height: 1.6;
+}
+.language-actions {
+  display: flex;
+  gap: 8px;
+  margin-top: 12px;
 }
 .culture-grid {
   display: grid;
-  grid-template-columns: 1.2fr 0.8fr;
-  gap: 1rem;
+  grid-template-columns: 0.8fr 1.2fr;
+  gap: 12px;
 }
 .story-feature,
-.personality-card {
-  min-height: 390px;
-  padding: clamp(1.4rem, 4vw, 2.4rem);
-  border: 1px solid var(--companion-line);
-  border-radius: 24px;
-  background: var(--companion-panel);
+.graph-preview {
+  min-height: 330px;
+  padding: 26px;
+  border: 1px solid var(--intelligence-border);
+  background: var(--intelligence-surface);
 }
 .story-feature {
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  background:
-    linear-gradient(0deg, rgba(6, 15, 9, 0.9), rgba(6, 15, 9, 0.1)),
-    radial-gradient(circle at 70% 20%, #5c7540, transparent 35%), linear-gradient(135deg, #aa6c43, #1e3c2a);
+}
+.story-feature h3 {
+  margin: 8px 0;
+  font-size: 1.6rem;
 }
 .story-feature p {
-  max-width: 520px;
-  color: #deded5;
-  line-height: 1.6;
-}
-.story-feature button {
-  width: max-content;
-}
-.personality-card {
-  text-align: center;
-  background: radial-gradient(circle at 50% 35%, rgba(243, 189, 78, 0.17), transparent 35%), #15140f;
-}
-.personality-symbol {
-  margin: 1.2rem 0;
-  color: var(--companion-gold);
-  font-size: 5rem;
-}
-.personality-card > p:not(.eyebrow):not(.share-status) {
-  max-width: 430px;
-  margin: 1rem auto;
-  color: var(--companion-muted);
-  line-height: 1.6;
-}
-.personality-actions {
-  display: flex;
-  justify-content: center;
-  gap: 0.6rem;
-  flex-wrap: wrap;
-}
-.personality-actions button,
-.ai-tool-row button {
-  padding: 0.65rem 0.85rem;
-  border: 1px solid var(--companion-line);
-  border-radius: 10px;
-  background: transparent;
-  color: white;
-  cursor: pointer;
-}
-.personality-actions button:first-child {
-  background: var(--companion-gold);
-  color: #201607;
-  border: 0;
-}
-.share-status {
-  min-height: 1em;
-  color: var(--companion-lime);
-  font-size: 0.75rem;
-}
-.creator-studio {
-  display: grid;
-  grid-template-columns: 1.2fr 1fr;
-  gap: 2rem;
-  padding: clamp(1.5rem, 5vw, 3.5rem);
-  border: 1px solid rgba(200, 240, 75, 0.22);
-  border-radius: 26px;
-  background: linear-gradient(145deg, #182118, #0b100c);
-}
-.creator-studio > div:first-child > p:last-child {
-  max-width: 640px;
-  color: var(--companion-muted);
+  color: var(--intelligence-muted);
   line-height: 1.7;
 }
-.coming-soon {
-  display: inline-block;
-  margin-bottom: 1.2rem;
-  padding: 0.4rem 0.65rem;
-  border-radius: 100px;
-  background: rgba(200, 240, 75, 0.13);
-  color: var(--companion-lime);
-  font-size: 0.68rem;
+.story-feature button {
+  border: 0;
+  padding: 0;
+  color: var(--intelligence-text);
+  background: transparent;
+  font-size: 0.7rem;
   font-weight: 800;
-  text-transform: uppercase;
+}
+.graph-head {
+  color: #64748b;
+  font-size: 0.58rem;
+  letter-spacing: 0.1em;
+}
+.graph-head b {
+  color: var(--intelligence-gold);
+}
+.graph-nodes {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 9px;
+  align-content: center;
+  min-height: 210px;
+  padding: 24px 10px;
+}
+.graph-nodes span {
+  padding: 9px 12px;
+  border: 1px solid rgba(16, 185, 129, calc(0.18 + var(--node-index) * 0.015));
+  color: #cbd5e1;
+  background: rgba(16, 185, 129, 0.035);
+  font-size: 0.67rem;
+}
+.graph-preview > p {
+  margin: 0;
+  color: var(--intelligence-muted);
+  font-size: 0.73rem;
+  line-height: 1.6;
 }
 .creator-tools {
   display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 0.7rem;
+  grid-template-columns: repeat(5, 1fr);
+  border-top: 1px solid var(--intelligence-border);
+  border-left: 1px solid var(--intelligence-border);
 }
-.creator-tools button {
-  display: flex;
-  align-items: center;
-  gap: 0.7rem;
-  padding: 1rem;
-  border: 1px dashed rgba(255, 255, 255, 0.18);
-  border-radius: 14px;
-  background: rgba(255, 255, 255, 0.035);
-  color: #acb1aa;
-  text-align: left;
+.creator-tools article {
+  min-height: 230px;
+  padding: 20px;
+  border-right: 1px solid var(--intelligence-border);
+  border-bottom: 1px solid var(--intelligence-border);
+  background: var(--intelligence-surface);
 }
-.creator-tools span {
-  font-size: 1.3rem;
+.creator-tools h3 {
+  margin: 40px 0 10px;
+  font-size: 0.95rem;
 }
-.ai-tool-row {
-  grid-column: 1/-1;
-  display: flex;
-  align-items: center;
-  gap: 0.55rem;
-  flex-wrap: wrap;
-  padding-top: 1rem;
-  border-top: 1px solid var(--companion-line);
+.creator-tools p {
+  min-height: 56px;
+  color: var(--intelligence-muted);
+  font-size: 0.72rem;
+  line-height: 1.5;
 }
-.ai-tool-row > span {
-  margin-right: auto;
-  color: var(--companion-muted);
-  font-size: 0.75rem;
+.creator-tools b {
+  display: inline-block;
+  margin-top: 14px;
+  color: var(--intelligence-gold);
+  font-size: 0.58rem;
+  letter-spacing: 0.08em;
   text-transform: uppercase;
 }
+.architecture-showcase {
+  padding: 28px;
+  border: 1px solid var(--intelligence-border);
+  background: #091525;
+}
+.architecture-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  border-top: 1px solid var(--intelligence-border);
+  border-left: 1px solid var(--intelligence-border);
+}
+.architecture-grid article {
+  display: grid;
+  grid-template-columns: 28px 1fr auto;
+  gap: 14px;
+  align-items: center;
+  min-height: 108px;
+  padding: 17px;
+  border-right: 1px solid var(--intelligence-border);
+  border-bottom: 1px solid var(--intelligence-border);
+}
+.architecture-grid h3 {
+  margin: 0;
+  font-size: 0.85rem;
+}
+.architecture-grid p {
+  margin: 6px 0 0;
+  color: var(--intelligence-muted);
+  font-size: 0.67rem;
+}
+.architecture-grid article > b {
+  color: var(--intelligence-gold);
+  font-size: 0.55rem;
+  text-align: right;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+}
+
 .mobile-companion-nav {
   position: fixed;
-  left: 50%;
-  bottom: 14px;
-  z-index: 95;
+  right: 12px;
+  bottom: 12px;
+  left: 12px;
+  z-index: 900;
   display: none;
-  gap: 0.15rem;
-  max-width: calc(100vw - 24px);
-  padding: 0.45rem;
-  border: 1px solid rgba(255, 255, 255, 0.14);
-  border-radius: 18px;
-  background: rgba(9, 13, 10, 0.9);
-  box-shadow: 0 12px 45px rgba(0, 0, 0, 0.45);
+  grid-template-columns: repeat(7, 1fr);
+  padding: 7px;
+  border: 1px solid var(--intelligence-border-strong);
+  background: rgba(7, 17, 31, 0.96);
   backdrop-filter: blur(18px);
-  transform: translateX(-50%);
 }
 .mobile-companion-nav a,
 .mobile-companion-nav button {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 0.2rem;
-  min-width: 54px;
-  padding: 0.5rem 0.6rem;
+  display: grid;
+  place-items: center;
+  gap: 2px;
+  min-height: 42px;
   border: 0;
-  border-radius: 12px;
+  color: var(--intelligence-muted);
   background: transparent;
-  color: #aeb3ad;
-  font-size: 0.59rem;
+  font-size: 0.55rem;
   text-decoration: none;
-  text-shadow: none;
-  cursor: pointer;
 }
 .mobile-companion-nav span {
-  font-size: 1rem;
+  font-size: 0.72rem;
 }
-.mobile-companion-nav .active,
-.mobile-companion-nav a:hover,
-.mobile-companion-nav button:hover {
-  background: rgba(200, 240, 75, 0.12);
-  color: var(--companion-lime);
+.mobile-companion-nav .active {
+  color: var(--intelligence-gold);
 }
-.smart-radio-tools {
-  margin-bottom: 1.5rem;
-  padding: 1rem;
-  border: 1px solid var(--companion-line);
-  border-radius: 16px;
-  background: #111712;
-}
-.smart-radio-tools label {
-  display: block;
-  margin-bottom: 0.55rem;
-  color: var(--companion-lime);
-  font-size: 0.75rem;
-  font-weight: 800;
-  text-transform: uppercase;
-}
-.smart-radio-search {
-  display: flex;
-  align-items: center;
-  gap: 0.6rem;
-  padding: 0.7rem 1rem;
-  border: 1px solid var(--companion-line);
-  border-radius: 12px;
-  background: #080b09;
-}
-.smart-radio-search input {
-  width: 100%;
-  border: 0;
-  outline: 0;
-  background: transparent;
-  color: white;
-}
-.smart-radio-suggestions {
-  display: flex;
-  gap: 0.45rem;
-  margin-top: 0.7rem;
-  overflow-x: auto;
-}
-.smart-radio-results {
-  display: grid;
-  gap: 0.4rem;
-  margin-top: 0.75rem;
-}
-.smart-radio-result {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
-  padding: 0.65rem 0.75rem;
-  border: 1px solid var(--companion-line);
-  border-radius: 10px;
-  background: rgba(255, 255, 255, 0.04);
-  color: white;
-  cursor: pointer;
-}
-.smart-radio-result small {
-  color: var(--companion-muted);
-}
-body[data-theme='light'] .companion-shell {
-  --companion-ink: #11170f;
-  --companion-muted: #5f695d;
-  --companion-panel: #f8f9f3;
-  --companion-panel-soft: #eff3e9;
-  --companion-line: rgba(20, 35, 20, 0.13);
-}
-body[data-theme='light'] .companion-hero {
-  color: #f7f4e8;
-}
-body[data-theme='light'] .quick-actions button,
-body[data-theme='light'] .track-card,
-body[data-theme='light'] .personality-actions button,
-body[data-theme='light'] .ai-tool-row button {
-  color: var(--companion-ink);
-}
-@media (max-width: 1050px) {
-  .briefing-grid {
-    grid-template-columns: 1fr 1fr;
+
+@keyframes signalShift {
+  from {
+    transform: scaleY(0.65);
+    transform-origin: bottom;
+    opacity: 0.65;
   }
-  .briefing-lead {
-    grid-column: 1/-1;
+  to {
+    transform: scaleY(1);
+    transform-origin: bottom;
+    opacity: 1;
+  }
+}
+@media (max-width: 1180px) {
+  .hero-layout {
+    grid-template-columns: 1fr;
+  }
+  .metrics-panel {
+    max-width: 760px;
+    box-shadow: none;
   }
   .radio-discovery-grid {
     grid-template-columns: repeat(2, 1fr);
   }
-  .mood-grid {
-    grid-template-columns: repeat(4, 1fr);
+  .briefing-grid {
+    grid-template-columns: 1.4fr 0.7fr;
+  }
+  .briefing-grid article:last-child {
+    grid-column: 1 / -1;
+    min-height: 220px;
   }
   .track-card-row {
-    grid-template-columns: 1fr 1fr;
+    grid-template-columns: repeat(2, 1fr);
   }
-  .mobile-companion-nav a,
-  .mobile-companion-nav button {
-    min-width: 46px;
-    padding: 0.45rem;
+  .creator-tools {
+    grid-template-columns: repeat(3, 1fr);
   }
 }
-@media (max-width: 720px) {
-  body {
-    padding-bottom: 82px;
-  }
+@media (max-width: 820px) {
   .companion-shell {
-    gap: 3.5rem;
+    padding: 14px 14px 90px;
   }
-  .companion-hero {
-    min-height: 620px;
-    padding: 1.2rem;
-    border-radius: 24px;
+  .intelligence-hero {
+    padding: 18px;
   }
-  .companion-hero__topline {
+  .hero-status-row {
     align-items: flex-start;
   }
-  .companion-kicker {
+  .language-control {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+  .hero-layout {
+    padding-top: 38px;
+  }
+  .hero-primary h1 {
+    font-size: clamp(2.8rem, 13vw, 4.6rem);
+  }
+  .filter-console {
+    align-items: stretch;
+    flex-direction: column;
+  }
+  .music-intelligence-layout,
+  .ask-africa,
+  .culture-grid {
+    grid-template-columns: 1fr;
+  }
+  .ask-africa-copy {
+    border-right: 0;
+    border-bottom: 1px solid var(--intelligence-border);
+  }
+  .language-grid {
+    grid-template-columns: 1fr;
+  }
+  .creator-tools {
+    grid-template-columns: repeat(2, 1fr);
+  }
+  .architecture-grid {
+    grid-template-columns: 1fr;
+  }
+  .mobile-companion-nav {
+    display: grid;
+  }
+}
+@media (max-width: 580px) {
+  .companion-shell {
+    padding-right: 8px;
+    padding-left: 8px;
+  }
+  .intelligence-hero {
+    min-height: auto;
+    padding: 15px;
+  }
+  .hero-status-row {
+    gap: 10px;
+  }
+  .system-status {
+    max-width: 160px;
+    font-size: 0.6rem;
+  }
+  .language-control span {
     display: none;
   }
-  .companion-hero__copy {
-    margin-top: 5.5rem;
+  .hero-primary h1 {
+    font-size: 2.85rem;
   }
-  .companion-hero h1 {
-    font-size: clamp(2.65rem, 14vw, 4.5rem);
-  }
-  .companion-hero__glow {
-    right: -110px;
-    top: 80px;
+  .hero-deck {
+    font-size: 0.95rem;
   }
   .ai-command {
     grid-template-columns: auto 1fr;
-    padding: 0.55rem 0.75rem;
   }
   .ai-command button {
-    grid-column: 1/-1;
-    justify-content: center;
+    grid-column: 1 / -1;
+    min-height: 48px;
   }
-  .quick-actions {
-    grid-template-columns: 1fr 1fr;
+  .command-prefix {
+    width: 42px;
+    margin-left: 4px;
   }
-  .briefing-grid,
-  .culture-grid,
-  .creator-studio {
-    grid-template-columns: 1fr;
+  .hero-actions {
+    align-items: stretch;
+    flex-direction: column;
   }
-  .briefing-lead {
-    grid-template-columns: 1fr;
+  .hero-actions button {
+    min-height: 48px;
   }
-  .briefing-lead__art {
-    min-height: 170px;
-  }
-  .radio-discovery-grid {
-    display: flex;
-    overflow-x: auto;
-    scroll-snap-type: x mandatory;
-  }
-  .station-card {
-    min-width: 78vw;
-    scroll-snap-align: start;
-  }
-  .mood-grid {
-    display: flex;
-    overflow-x: auto;
-  }
-  .mood-card {
-    min-width: 140px;
-  }
-  .personalized-shelf,
-  .recently-played {
-    grid-template-columns: 1fr;
-  }
-  .track-card-row {
-    display: flex;
-    overflow-x: auto;
-  }
-  .track-card {
-    min-width: 240px;
-  }
-  .creator-tools {
-    grid-template-columns: 1fr 1fr;
-  }
-  .mobile-companion-nav {
-    display: flex;
-    width: calc(100vw - 18px);
-    overflow-x: auto;
-    justify-content: flex-start;
-    scrollbar-width: none;
-  }
-  .mobile-companion-nav a,
-  .mobile-companion-nav button {
-    min-width: 54px;
+  .metric-grid article {
+    min-height: 98px;
   }
   .section-heading {
     align-items: flex-start;
+    flex-direction: column;
   }
-  .text-button {
-    white-space: nowrap;
+  .radio-discovery-grid,
+  .briefing-grid,
+  .track-card-row {
+    grid-template-columns: 1fr;
   }
-  .badge-spotlight.trust-layer {
-    margin-top: 2rem;
+  .briefing-grid article:last-child {
+    grid-column: auto;
+  }
+  .briefing-lead {
+    grid-template-columns: 48px 1fr;
+    gap: 14px;
+    padding: 18px;
+  }
+  .briefing-pick {
+    min-height: 240px;
+  }
+  .answer-citations {
+    grid-template-columns: 1fr;
+  }
+  .creator-tools {
+    grid-template-columns: 1fr;
+  }
+  .architecture-showcase {
+    padding: 16px;
+  }
+  .architecture-grid article {
+    grid-template-columns: 24px 1fr;
+  }
+  .architecture-grid article > b {
+    grid-column: 2;
+    text-align: left;
+  }
+  .recommendation-strip {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+  .mobile-companion-nav {
+    overflow-x: auto;
+    grid-template-columns: repeat(7, minmax(58px, 1fr));
+  }
+  .prompt-rail {
+    margin-right: -15px;
+  }
+  .graph-nodes {
+    padding: 12px 0;
   }
 }
 @media (prefers-reduced-motion: reduce) {
-  .station-wave i {
+  .signal-bars i {
     animation: none;
   }
-  .companion-shell * {
-    scroll-behavior: auto !important;
+  .station-card {
+    transition: none;
   }
-}
-
-@media (max-width: 768px) {
-  body[data-page='main'] .header {
-    min-height: 92px;
-    padding: 0.65rem 0.8rem;
-    align-items: center;
-    gap: 0.55rem;
-  }
-  body[data-page='main'] .header-logo {
-    width: 48px;
-    height: 48px;
-  }
-  body[data-page='main'] .header-title {
-    font-size: clamp(1rem, 5vw, 1.35rem);
-  }
-  body[data-page='main'] .header-actions {
-    margin-left: auto;
-    gap: 0.35rem;
-  }
-  body[data-page='main'] .theme-toggle-label,
-  body[data-page='main'] .language-switcher label,
-  body[data-page='main'] .share-button {
-    display: none;
-  }
-  body[data-page='main'] .language-switcher select {
-    max-width: 112px;
-    font-size: 0.72rem;
-  }
-  body[data-page='main'] .container {
-    display: flex;
-    flex-direction: column;
-    width: 100%;
-    padding: 0.65rem;
-  }
-  body[data-page='main'] .sidebar {
-    display: flex;
-    order: 2;
-    width: 100%;
-    margin: 1rem 0 5rem;
-    padding: 0.75rem;
-    gap: 0.5rem;
-    border-radius: 18px;
-  }
-  body[data-page='main'] .content {
-    order: 1;
-    width: 100%;
-    max-width: 100%;
-    margin: 0;
-    padding: 0;
-  }
-  body[data-page='main'] .edge-panel {
-    display: none;
-  }
-}
-
-.companion-shell,
-.companion-shell > *,
-.companion-section,
-.ai-command,
-.prompt-rail {
-  min-width: 0;
-  width: 100%;
-}
-.ai-command button,
-.ai-command button span,
-.ai-command button b {
-  color: #12180b;
-  opacity: 1;
-  visibility: visible;
 }

--- a/main.html
+++ b/main.html
@@ -13,30 +13,33 @@
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <meta name="apple-mobile-web-app-title" content="Àríyò AI" />
     <meta name="apple-touch-fullscreen" content="yes" />
-    <meta name="theme-color" content="#8E5BFF" />
+    <meta name="theme-color" content="#07111F" />
     <link rel="manifest" href="manifest.json" />
     <link rel="apple-touch-icon" href="icons/Ariyo.png" />
     <meta
       name="description"
-      content="Àríyò AI is a web-based music player that provides a unique and culturally-rich experience for users. It features a curated selection of Nigerian music and the Ariyo AI assistant."
+      content="Africa's AI Media Intelligence Engine for intelligent discovery across music, live radio, news, stories, culture, and language."
     />
-    <meta name="keywords" content="Paul Iyogun, Omoluabi, Àríyò AI, Ariyo, Naija AI, Nigerian music, AI chatbot, PWA" />
-    <meta property="og:title" content="Àríyò AI - Smart Naija AI" />
+    <meta
+      name="keywords"
+      content="Àríyò AI, African media intelligence, African radio, African music, multilingual AI, African news, cultural knowledge"
+    />
+    <meta property="og:title" content="Àríyò AI — Africa's AI Media Intelligence Engine" />
     <meta
       property="og:description"
-      content="Àríyò AI is a web-based music player that provides a unique and culturally-rich experience for users. It features a curated selection of Nigerian music and the Ariyo AI assistant."
+      content="Africa's AI Media Intelligence Engine for intelligent discovery across music, live radio, news, stories, culture, and language."
     />
     <meta property="og:image" content="https://raw.githubusercontent.com/Omoluabi1003/Ariyo-AI/main/icons/Ariyo.png" />
     <meta property="og:url" content="https://omoluabi1003.github.io/Ariyo-AI/" />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="Àríyò AI - Smart Naija AI" />
+    <meta name="twitter:title" content="Àríyò AI — Africa's AI Media Intelligence Engine" />
     <meta
       name="twitter:description"
-      content="Àríyò AI is a web-based music player that provides a unique and culturally-rich experience for users. It features a curated selection of Nigerian music and the Ariyo AI assistant."
+      content="Africa's AI Media Intelligence Engine for intelligent discovery across music, live radio, news, stories, culture, and language."
     />
     <meta name="twitter:image" content="https://raw.githubusercontent.com/Omoluabi1003/Ariyo-AI/main/icons/Ariyo.png" />
-    <title>Àríyò AI - Smart Naija AI</title>
+    <title>Àríyò AI — Africa's AI Media Intelligence Engine</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link rel="preconnect" href="https://cdnjs.cloudflare.com" crossorigin />
@@ -73,7 +76,7 @@
         "@type": "WebSite",
         "url": "https://omoluabi1003.github.io/Ariyo-AI/",
         "name": "Àríyò AI",
-        "description": "Àríyò AI is a web-based music player that provides a unique and culturally-rich experience for users. It features a curated selection of Nigerian music and the Ariyo AI assistant.",
+        "description": "Africa's AI Media Intelligence Engine for intelligent discovery across music, live radio, news, stories, culture, and language.",
         "potentialAction": {
           "@type": "SearchAction",
           "target": "https://omoluabi1003.github.io/Ariyo-AI/?s={search_term_string}",
@@ -1705,11 +1708,16 @@
       <div class="header-brand">
         <img src="Logo.jpg" alt="Ariyo AI Logo" class="header-logo" width="64" height="64" />
         <div class="header-titles">
-          <span class="header-title">Àríyò AI Studio</span>
+          <span class="header-title">Àríyò AI Intelligence</span>
         </div>
       </div>
       <div class="header-actions" data-language-switcher-host>
-        <button class="share-button" aria-label="Share this page" data-i18n-aria-label="ui.sharePage" onclick="openShareMenu()">
+        <button
+          class="share-button"
+          aria-label="Share this page"
+          data-i18n-aria-label="ui.sharePage"
+          onclick="openShareMenu()"
+        >
           <i class="fas fa-share-alt" aria-hidden="true"></i>
         </button>
         <button class="theme-toggle" type="button" data-theme-toggle aria-pressed="false">
@@ -1746,7 +1754,8 @@
           data-i18n-aria-label="ui.navChooseAlbumAria"
           class="ripple shockwave"
         >
-          <i class="fas fa-headphones" aria-hidden="true"></i> <span data-i18n="ui.navChooseAlbum">Choose An Album</span>
+          <i class="fas fa-headphones" aria-hidden="true"></i>
+          <span data-i18n="ui.navChooseAlbum">Choose An Album</span>
         </button>
         <button
           onclick="openTrackList()"
@@ -1770,7 +1779,8 @@
           data-i18n-aria-label="ui.navRadioStationsAria"
           class="ripple shockwave"
         >
-          <i class="fas fa-broadcast-tower" aria-hidden="true"></i> <span data-i18n="ui.navRadioStations">Radio Stations</span>
+          <i class="fas fa-broadcast-tower" aria-hidden="true"></i>
+          <span data-i18n="ui.navRadioStations">Radio Stations</span>
         </button>
         <button
           type="button"
@@ -1794,85 +1804,474 @@
       </div>
       <div class="content" id="main-content">
         <main class="companion-shell" id="home" aria-label="Ariyọ AI media companion">
-          <section class="companion-hero" aria-labelledby="companionTitle">
-            <div class="companion-hero__glow" aria-hidden="true"></div>
-            <div class="companion-hero__topline">
-              <span class="live-pill"><span></span> Africa is live</span>
-              <span class="companion-kicker">Your culture. Your sound. Your AI.</span>
+          <section class="intelligence-hero" aria-labelledby="companionTitle">
+            <div class="hero-grid" aria-hidden="true"></div>
+            <div class="hero-status-row">
+              <span class="system-status"><i></i> Intelligence network operational</span>
+              <label class="language-control" for="intelligenceLanguage"
+                ><span>Interface language</span
+                ><select id="intelligenceLanguage">
+                  <option>English</option>
+                  <option>Nigerian Pidgin</option>
+                  <option>French</option>
+                  <option>Yoruba</option>
+                  <option>Igbo</option>
+                  <option>Hausa</option>
+                  <option>Lingala</option>
+                </select></label
+              >
             </div>
-            <div class="companion-hero__copy">
-              <p class="eyebrow">Africa's AI Media Companion</p>
-              <h1 id="companionTitle">What do you want to <em>feel</em> today?</h1>
-              <p>Chat, play music, cross borders by radio, understand the news, and rediscover African stories—all from one intelligent companion.</p>
-            </div>
-            <form class="ai-command" id="aiCommandForm">
-              <span class="ai-command__mark" aria-hidden="true">✦</span>
-              <label class="sr-only" for="aiCommandInput">Ask Ariyọ AI</label>
-              <input id="aiCommandInput" type="text" autocomplete="off" placeholder="Ask Ariyọ to play, explain, translate, or discover…" />
-              <button type="submit" aria-label="Send command"><span>Ask Ariyọ</span><b aria-hidden="true">↗</b></button>
-            </form>
-            <div class="prompt-rail" aria-label="Suggested prompts">
-              <button type="button" data-ai-prompt="Play music">♫ Play music</button>
-              <button type="button" data-ai-prompt="Stream radio">◉ Stream radio</button>
-              <button type="button" data-ai-prompt="Summarize African news">◫ Summarize news</button>
-              <button type="button" data-ai-prompt="Tell me a story">✦ Tell me a story</button>
-              <button type="button" data-ai-prompt="Translate this">文 Translate this</button>
-              <button type="button" data-ai-prompt="Teach me Pidgin">Wá Teach me Pidgin</button>
-              <button type="button" data-ai-prompt="Play Congo radio">● Congo radio</button>
-            </div>
-            <div class="ai-response" id="aiCommandResponse" role="status" aria-live="polite" hidden></div>
-            <div class="returning-message" id="returningMessage" hidden></div>
-          </section>
-
-          <section class="quick-actions" aria-label="Explore Ariyọ">
-            <button type="button" data-companion-action="music"><span>♫</span><b>Music</b><small>Find your rhythm</small></button>
-            <button type="button" data-companion-action="radio"><span>◉</span><b>Radio</b><small>Cross every border</small></button>
-            <button type="button" data-companion-action="stories"><span>❧</span><b>Stories</b><small>Hear our memory</small></button>
-            <button type="button" data-companion-action="news"><span>◫</span><b>News</b><small>Know what matters</small></button>
-          </section>
-
-          <section class="companion-section daily-briefing" id="news" aria-labelledby="briefingTitle">
-            <div class="section-heading">
-              <div><p class="eyebrow">Curated for you · Today</p><h2 id="briefingTitle">Africa Daily Briefing</h2></div>
-              <button class="text-button" type="button" data-companion-action="news">Open all news <span>→</span></button>
-            </div>
-            <div class="briefing-grid">
-              <article class="briefing-lead">
-                <div class="briefing-lead__art" aria-hidden="true"><span>AFRICA<br />NOW</span></div>
-                <div><span class="content-label">The 3-minute brief</span><h3 id="briefingHeadline">Culture, sound, and ideas moving Africa forward</h3><p id="briefingSummary">A quick, calm view of the stories shaping the continent—paired with the sounds and voices worth hearing today.</p>
-                  <div class="briefing-actions"><button type="button" data-simplify="simple">Make it simple</button><button type="button" data-simplify="pidgin">Explain in Pidgin</button><button type="button" data-simplify="fr">Translate to French</button></div>
+            <div class="hero-layout">
+              <div class="hero-primary">
+                <p class="eyebrow">Media Intelligence Command Center</p>
+                <h1 id="companionTitle">Africa's AI Media <span>Intelligence Engine.</span></h1>
+                <p class="hero-deck">
+                  Intelligent African media discovery across music, radio, news, stories, and language—unified in one
+                  culturally aware system.
+                </p>
+                <form class="ai-command" id="aiCommandForm">
+                  <span class="command-prefix" aria-hidden="true">AI</span>
+                  <label class="sr-only" for="aiCommandInput">Ask Ariyọ AI</label>
+                  <input
+                    id="aiCommandInput"
+                    type="text"
+                    autocomplete="off"
+                    placeholder="Ask Ariyọ to analyze, find, summarize, recommend, or translate…"
+                  />
+                  <button type="submit">Ask Ariyọ <span aria-hidden="true">→</span></button>
+                </form>
+                <div class="command-categories" aria-label="Command categories">
+                  <span>Route intent:</span
+                  ><button type="button" data-ai-prompt="Find Congolese gospel radio">Radio</button
+                  ><button type="button" data-ai-prompt="Recommend focus music">Music</button
+                  ><button type="button" data-ai-prompt="Summarize African news">News</button
+                  ><button type="button" data-ai-prompt="Translate to French">Language</button
+                  ><button type="button" data-ai-prompt="Explore African cultural stories">Culture</button
+                  ><button type="button" data-ai-prompt="Open creator tools">Creator</button>
                 </div>
-              </article>
-              <article class="briefing-pick briefing-pick--music"><span class="content-label">Track of the day</span><div class="pick-icon">♫</div><h3 id="dailyTrackTitle">A Very Good Bad Guy</h3><p>Afro-conscious · Nigeria</p><button type="button" id="playDailyTrack">Play track <span>▶</span></button></article>
-              <article class="briefing-pick briefing-pick--radio"><span class="content-label">Station to know</span><div class="station-wave" aria-hidden="true"><i></i><i></i><i></i><i></i><i></i></div><h3 id="dailyStationTitle">Naija Hits Live</h3><p>Live from Nigeria</p><button type="button" id="playDailyStation">Tune in <span>◉</span></button></article>
+                <div class="prompt-rail" aria-label="Suggested prompts">
+                  <button type="button" data-ai-prompt="Analyze today's African media trends">
+                    Analyze today's African media trends</button
+                  ><button type="button" data-ai-prompt="Find Congolese gospel radio">
+                    Find Congolese gospel radio</button
+                  ><button type="button" data-ai-prompt="Recommend focus music">Recommend focus music</button
+                  ><button type="button" data-ai-prompt="Explain in simple English">Explain in simple English</button>
+                </div>
+                <div class="hero-actions">
+                  <button class="primary-action" type="button" data-companion-action="ai">Ask Ariyọ</button
+                  ><button class="secondary-action" type="button" data-scroll-target="radio">
+                    Explore Radio Intelligence
+                  </button>
+                </div>
+                <div class="ai-response" id="aiCommandResponse" role="status" aria-live="polite" hidden></div>
+                <div class="returning-message" id="returningMessage" hidden></div>
+              </div>
+              <aside class="metrics-panel" aria-label="Live intelligence metrics">
+                <div class="panel-heading">
+                  <div>
+                    <p class="eyebrow">Live intelligence</p>
+                    <h2>Network overview</h2>
+                  </div>
+                  <span class="demo-label">LOCAL DEMO</span>
+                </div>
+                <div class="metric-grid">
+                  <article>
+                    <span>Media entities</span><strong id="metricEntities">—</strong><small>Indexed locally</small>
+                  </article>
+                  <article>
+                    <span>Live stations</span><strong id="metricStations">—</strong><small>Available streams</small>
+                  </article>
+                  <article><span>Languages</span><strong>07</strong><small>Discovery layer</small></article>
+                  <article><span>System modules</span><strong>07</strong><small>Operational map</small></article>
+                </div>
+                <div class="signal-monitor">
+                  <div class="signal-heading"><span>Cross-media signal</span><b>ACTIVE</b></div>
+                  <div class="signal-bars" aria-hidden="true">
+                    <i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i>
+                  </div>
+                  <div class="signal-legend">
+                    <span>Nigeria</span><span>Congo</span><span>Ghana</span><span>Kenya</span>
+                  </div>
+                </div>
+                <div class="routing-log">
+                  <span>Latest routing decision</span>
+                  <p id="routingLog">Awaiting an intelligence query.</p>
+                </div>
+              </aside>
             </div>
           </section>
 
           <section class="companion-section" id="radio" aria-labelledby="radioDiscoveryTitle">
-            <div class="section-heading"><div><p class="eyebrow">Radio Map of Africa</p><h2 id="radioDiscoveryTitle">One continent. Thousands of voices.</h2></div><button class="text-button" type="button" data-companion-action="radio">Browse every station <span>→</span></button></div>
-            <div class="filter-row" id="countryFilters" aria-label="Filter stations by country"></div>
+            <div class="section-heading">
+              <div>
+                <p class="eyebrow">01 / Broadcast layer</p>
+                <h2 id="radioDiscoveryTitle">Live African Radio Intelligence</h2>
+                <p>
+                  Discover active African frequencies by region, language, format, mood, and intended listening context.
+                </p>
+              </div>
+              <button class="text-button" type="button" data-companion-action="radio">
+                Open complete station directory <span>→</span>
+              </button>
+            </div>
+            <div class="filter-console">
+              <div class="filter-group">
+                <span>Country</span>
+                <div class="filter-row" id="countryFilters"></div>
+              </div>
+              <div class="filter-group">
+                <label for="radioLanguageFilter">Language</label
+                ><select id="radioLanguageFilter">
+                  <option>All languages</option>
+                  <option>English</option>
+                  <option>French</option>
+                  <option>Lingala</option>
+                  <option>Yoruba</option>
+                  <option>Hausa</option>
+                </select>
+              </div>
+              <div class="filter-group">
+                <label for="radioTypeFilter">Content</label
+                ><select id="radioTypeFilter">
+                  <option>All content</option>
+                  <option>Music</option>
+                  <option>News</option>
+                  <option>Gospel</option>
+                  <option>Talk</option>
+                </select>
+              </div>
+            </div>
             <div class="radio-discovery-grid" id="radioDiscoveryGrid"></div>
+            <div class="recommendation-strip" id="radioRecommendation">
+              <span class="recommendation-code">GRAPH MATCH</span>
+              <div>
+                <strong>Cross-media recommendation</strong>
+                <p>Select a station to surface related tracks and cultural stories.</p>
+              </div>
+            </div>
           </section>
 
           <section class="companion-section" id="music" aria-labelledby="musicDiscoveryTitle">
-            <div class="section-heading"><div><p class="eyebrow">Made for your moment</p><h2 id="musicDiscoveryTitle">Music that understands the mood.</h2></div><button class="text-button" type="button" data-companion-action="music">Open full library <span>→</span></button></div>
-            <div class="mood-grid" id="moodGrid"></div>
-            <div class="personalized-shelf">
-              <div><p class="eyebrow">Because you listened</p><h3>Keep the feeling going</h3></div>
-              <div class="track-card-row" id="recommendedTracks"></div>
+            <div class="section-heading">
+              <div>
+                <p class="eyebrow">02 / Metadata engine</p>
+                <h2 id="musicDiscoveryTitle">Music Intelligence Layer</h2>
+                <p>Existing Ariyọ tracks, enriched with mood, region, language, genre, and use-case intelligence.</p>
+              </div>
+              <button class="text-button" type="button" data-companion-action="music">
+                Open complete music library <span>→</span>
+              </button>
             </div>
-            <div class="recently-played" id="recentlyPlayedSection" hidden><div><p class="eyebrow">Your listening memory</p><h3>Recently played</h3></div><div class="track-card-row" id="recentlyPlayed"></div></div>
+            <div class="filter-row mood-filters" id="moodGrid" aria-label="Filter music by mood"></div>
+            <div class="music-intelligence-layout">
+              <div class="personalized-shelf">
+                <div class="shelf-heading">
+                  <div>
+                    <p class="eyebrow">Listening profile</p>
+                    <h3>Recommended from your listening profile</h3>
+                  </div>
+                  <span>LOCAL PERSONALIZATION</span>
+                </div>
+                <div class="track-card-row" id="recommendedTracks"></div>
+              </div>
+              <aside class="profile-model">
+                <p class="eyebrow">Preference model</p>
+                <h3 id="profileSignal">Building your signal</h3>
+                <p>
+                  Every track and station interaction improves regional, language, mood, and format matching on this
+                  device.
+                </p>
+                <dl>
+                  <div>
+                    <dt>Primary mood</dt>
+                    <dd id="profileMood">Focus</dd>
+                  </div>
+                  <div>
+                    <dt>Region bias</dt>
+                    <dd id="profileRegion">All Africa</dd>
+                  </div>
+                  <div>
+                    <dt>Cache mode</dt>
+                    <dd>Private / local</dd>
+                  </div>
+                </dl>
+              </aside>
+            </div>
+            <div class="recently-played" id="recentlyPlayedSection" hidden>
+              <div class="shelf-heading">
+                <div>
+                  <p class="eyebrow">Listening memory</p>
+                  <h3>Recently played</h3>
+                </div>
+              </div>
+              <div class="track-card-row" id="recentlyPlayed"></div>
+            </div>
           </section>
 
-          <section class="companion-section culture-grid" id="stories">
-            <article class="story-feature"><span class="content-label">Story keeper</span><div><p class="eyebrow">Tonight's story</p><h2>The wisdom that travels home</h2><p>Spoken word, proverbs, and modern African stories for the road ahead.</p><button type="button" data-companion-action="stories">Open stories <span>→</span></button></div></article>
-            <article class="personality-card" id="profile"><p class="eyebrow">Your African Media Personality</p><div class="personality-symbol" aria-hidden="true">✺</div><h2 id="personalityName">Radio Explorer</h2><p id="personalityCopy">You cross borders through sound and always know which frequency carries home.</p><div class="personality-actions"><button type="button" id="generatePersonality">Reveal mine</button><button type="button" id="sharePersonality">Copy &amp; share</button></div><p class="share-status" id="personalityStatus" aria-live="polite"></p></article>
+          <section class="companion-section daily-briefing" id="news" aria-labelledby="briefingTitle">
+            <div class="section-heading">
+              <div>
+                <p class="eyebrow">03 / Intelligence brief</p>
+                <h2 id="briefingTitle">African Media Briefing</h2>
+                <p>A decision-ready view of stories, sound, and signals shaping African attention.</p>
+              </div>
+              <span class="briefing-date" id="briefingDate">CURATED FALLBACK BRIEF</span>
+            </div>
+            <div class="briefing-grid">
+              <article class="briefing-lead">
+                <div class="brief-index"><span>INTELLIGENCE NOTE</span><b>01</b></div>
+                <div>
+                  <span class="content-label">Continental media signal</span>
+                  <h3 id="briefingHeadline">Culture, sound, and ideas moving Africa forward</h3>
+                  <p id="briefingSummary">
+                    A concise view of the stories shaping the continent, paired with the sounds and voices worth hearing
+                    today.
+                  </p>
+                  <div class="briefing-actions">
+                    <button type="button" data-simplify="executive">Executive Summary</button
+                    ><button type="button" data-simplify="simple">Simple English</button
+                    ><button type="button" data-simplify="pidgin">Pidgin Summary</button
+                    ><button type="button" data-simplify="fr">French Translation</button>
+                  </div>
+                </div>
+              </article>
+              <article class="briefing-pick">
+                <span class="content-label">Featured track</span><span class="briefing-code">MUSIC / NG</span>
+                <h3 id="dailyTrackTitle">A Very Good Bad Guy</h3>
+                <p>Selected from the local catalogue</p>
+                <button type="button" id="playDailyTrack">Play intelligence pick <span>→</span></button>
+              </article>
+              <article class="briefing-pick">
+                <span class="content-label">Recommended radio</span><span class="briefing-code">RADIO / LIVE</span>
+                <h3 id="dailyStationTitle">Naija Hits Live</h3>
+                <p>Matched to today's media profile</p>
+                <button type="button" id="playDailyStation">Open live signal <span>→</span></button>
+              </article>
+            </div>
+          </section>
+
+          <section class="companion-section ask-africa" id="ask-africa" aria-labelledby="askAfricaTitle">
+            <div class="ask-africa-copy">
+              <p class="eyebrow">04 / Flagship intelligence</p>
+              <h2 id="askAfricaTitle">Ask Africa.</h2>
+              <p>
+                Query the relationships between African music, live radio, news, language, and culture—not just isolated
+                content.
+              </p>
+              <div class="ask-examples">
+                <button type="button" data-ask-africa="What is trending in Nigerian gospel today?">
+                  What is trending in Nigerian gospel today?</button
+                ><button type="button" data-ask-africa="What are Congolese listeners tuning into?">
+                  What are Congolese listeners tuning into?</button
+                ><button type="button" data-ask-africa="Explain today's top African media story.">
+                  Explain today's top African media story.
+                </button>
+              </div>
+            </div>
+            <div class="intelligence-answer">
+              <div class="answer-header"><span>ARIYỌ SYNTHESIS</span><b>LOCAL KNOWLEDGE GRAPH</b></div>
+              <h3 id="askAfricaQuestion">Select a question to interrogate the media graph.</h3>
+              <p id="askAfricaAnswer">
+                Ariyọ will return structured placeholder intelligence from the available music, radio, story, region,
+                and language data until live intelligence APIs are connected.
+              </p>
+              <div class="answer-citations">
+                <span><b>Category</b><i id="answerCategory">Cross-media</i></span
+                ><span><b>Region</b><i id="answerRegion">Africa</i></span
+                ><span><b>Language</b><i id="answerLanguage">English</i></span
+                ><span><b>Path</b><i id="answerPath">Query → Graph → Recommendation</i></span>
+              </div>
+            </div>
+          </section>
+
+          <section class="companion-section language-intelligence" id="language" aria-labelledby="languageTitle">
+            <div class="section-heading">
+              <div>
+                <p class="eyebrow">05 / Language processing</p>
+                <h2 id="languageTitle">Language Intelligence</h2>
+                <p>Move African media across language and comprehension levels without losing cultural context.</p>
+              </div>
+              <span class="status-chip active">Preference persisted locally</span>
+            </div>
+            <div class="language-grid">
+              <article>
+                <span>01</span>
+                <h3>Discover in your language</h3>
+                <p>Prioritize matching stations, tracks, stories, and summaries across seven language modes.</p>
+              </article>
+              <article>
+                <span>02</span>
+                <h3>Simplify complexity</h3>
+                <p>Turn dense briefing language into direct, accessible explanations.</p>
+              </article>
+              <article>
+                <span>03</span>
+                <h3>Preserve context</h3>
+                <p>Keep regional, cultural, and media metadata attached to every recommendation.</p>
+              </article>
+            </div>
+            <div class="language-actions">
+              <button type="button" data-simplify="simple">Make it simple</button
+              ><button type="button" data-simplify="pidgin">Explain in Pidgin</button
+              ><button type="button" data-simplify="fr">Translate to French</button>
+            </div>
+          </section>
+
+          <section class="companion-section culture-knowledge" id="stories" aria-labelledby="storiesTitle">
+            <div class="section-heading">
+              <div>
+                <p class="eyebrow">06 / Cultural memory</p>
+                <h2 id="storiesTitle">Stories &amp; Cultural Knowledge</h2>
+                <p>Connect spoken word, proverbs, music, and regional context into a living African knowledge layer.</p>
+              </div>
+              <button class="text-button" type="button" data-companion-action="stories">
+                Explore story library <span>→</span>
+              </button>
+            </div>
+            <div class="culture-grid">
+              <article class="story-feature">
+                <span class="content-label">Featured cultural path</span>
+                <div>
+                  <p class="eyebrow">Story → Language → Sound</p>
+                  <h3>The wisdom that travels home</h3>
+                  <p>
+                    Explore spoken word and cultural storytelling, then continue into related regional radio and
+                    reflective music.
+                  </p>
+                  <button type="button" data-companion-action="stories">Open cultural knowledge <span>→</span></button>
+                </div>
+              </article>
+              <article class="graph-preview">
+                <div class="graph-head"><span>MEDIA INTELLIGENCE GRAPH</span><b>10 ENTITY TYPES</b></div>
+                <div class="graph-nodes" id="graphNodes"></div>
+                <p>
+                  Reusable entity mappings connect artist, track, station, country, language, genre, mood, story, news
+                  topic, and user preference.
+                </p>
+              </article>
+            </div>
           </section>
 
           <section class="companion-section creator-studio" id="create" aria-labelledby="creatorTitle">
-            <div><span class="coming-soon">Creator Studio · Coming Soon</span><p class="eyebrow">Built for Africa's next voices</p><h2 id="creatorTitle">Create once. Travel everywhere.</h2><p>Prepare music, podcasts, spoken word, and stories with an AI co-creator—then publish when creator uploads launch.</p></div>
-            <div class="creator-tools"><button type="button" disabled><span>↑</span> Upload music</button><button type="button" disabled><span>◌</span> Upload podcast</button><button type="button" disabled><span>✦</span> Spoken word</button><button type="button" disabled><span>❧</span> Add a story</button></div>
-            <div class="ai-tool-row"><span>AI creator tools</span><button type="button" data-creator-tool="title">Generate title</button><button type="button" data-creator-tool="description">Write description</button><button type="button" data-creator-tool="cover">Imagine cover</button><button type="button" data-creator-tool="caption">Social caption</button></div>
+            <div class="section-heading">
+              <div>
+                <p class="eyebrow">07 / Creator infrastructure</p>
+                <h2 id="creatorTitle">Creator Studio Foundation</h2>
+                <p>
+                  Future publishing infrastructure for African creators, built on the same metadata and language
+                  intelligence layer.
+                </p>
+              </div>
+              <span class="status-chip">FOUNDATION READY</span>
+            </div>
+            <div class="creator-tools">
+              <article>
+                <span>01</span>
+                <h3>Metadata tagging</h3>
+                <p>Structure region, language, genre, mood, and use case.</p>
+                <b>Prototype</b>
+              </article>
+              <article>
+                <span>02</span>
+                <h3>AI title generation</h3>
+                <p>Generate culturally aware working titles.</p>
+                <b>Coming Soon</b>
+              </article>
+              <article>
+                <span>03</span>
+                <h3>AI description</h3>
+                <p>Prepare platform-ready release narratives.</p>
+                <b>Coming Soon</b>
+              </article>
+              <article>
+                <span>04</span>
+                <h3>Cover concept</h3>
+                <p>Develop executive creative direction.</p>
+                <b>Coming Soon</b>
+              </article>
+              <article>
+                <span>05</span>
+                <h3>Release summary</h3>
+                <p>Build concise media and partner briefs.</p>
+                <b>Coming Soon</b>
+              </article>
+            </div>
+          </section>
+
+          <section
+            class="companion-section architecture-showcase"
+            id="architecture"
+            aria-labelledby="architectureTitle"
+          >
+            <div class="section-heading">
+              <div>
+                <p class="eyebrow">08 / Platform architecture</p>
+                <h2 id="architectureTitle">Technical Architecture Showcase</h2>
+                <p>
+                  A modular foundation designed to graduate from local intelligence to production APIs without replacing
+                  the user experience.
+                </p>
+              </div>
+              <span class="demo-label">OPERATIONAL MODEL</span>
+            </div>
+            <div class="architecture-grid">
+              <article>
+                <span>01</span>
+                <div>
+                  <h3>AI Routing Engine</h3>
+                  <p>Intent classification across seven media actions.</p>
+                </div>
+                <b class="status-active">Active</b>
+              </article>
+              <article>
+                <span>02</span>
+                <div>
+                  <h3>Radio Intelligence Layer</h3>
+                  <p>Station metadata, filters, favorites, and recency.</p>
+                </div>
+                <b class="status-active">Active</b>
+              </article>
+              <article>
+                <span>03</span>
+                <div>
+                  <h3>Music Metadata Engine</h3>
+                  <p>Mood, region, language, and use-case enrichment.</p>
+                </div>
+                <b>Prototype</b>
+              </article>
+              <article>
+                <span>04</span>
+                <div>
+                  <h3>Media Knowledge Graph</h3>
+                  <p>Cross-entity mapping and recommendation paths.</p>
+                </div>
+                <b class="status-active">Active</b>
+              </article>
+              <article>
+                <span>05</span>
+                <div>
+                  <h3>Language Processing Layer</h3>
+                  <p>Preference routing and transformation actions.</p>
+                </div>
+                <b>Ready for API Integration</b>
+              </article>
+              <article>
+                <span>06</span>
+                <div>
+                  <h3>Local Personalization Cache</h3>
+                  <p>Private favorites, recents, language, and region state.</p>
+                </div>
+                <b class="status-active">Local Cache</b>
+              </article>
+              <article>
+                <span>07</span>
+                <div>
+                  <h3>Recommendation Engine</h3>
+                  <p>Cross-media ranking from local graph signals.</p>
+                </div>
+                <b>Prototype</b>
+              </article>
+            </div>
           </section>
         </main>
 
@@ -1888,11 +2287,13 @@
             <p class="badge-spotlight__eyebrow" data-i18n="trustLayer.globalRecognition.badge">
               2026 Tällberg-SNF-Eliasson Global Leadership Prize Nominee
             </p>
-            <p class="badge-spotlight__title" data-i18n="trustLayer.globalRecognition.title">Global Leadership Recognition</p>
+            <p class="badge-spotlight__title" data-i18n="trustLayer.globalRecognition.title">
+              Global Leadership Recognition
+            </p>
             <p class="badge-spotlight__description" data-i18n="trustLayer.globalRecognition.primaryCopy">
-              Paul A.K. Iyogun, Founder of ETL GIS Consulting LLC and creator of Àríyò AI under Omoluabi Productions, was
-              nominated for the 2026 Tällberg-SNF-Eliasson Global Leadership Prize, awarded by the Tällberg Foundation in
-              partnership with the Stavros Niarchos Foundation.
+              Paul A.K. Iyogun, Founder of ETL GIS Consulting LLC and creator of Àríyò AI under Omoluabi Productions,
+              was nominated for the 2026 Tällberg-SNF-Eliasson Global Leadership Prize, awarded by the Tällberg
+              Foundation in partnership with the Stavros Niarchos Foundation.
             </p>
             <p class="badge-spotlight__supporting" data-i18n="trustLayer.globalRecognition.supportingLine">
               A global initiative recognizing leaders advancing ethical, innovative, and impactful change.
@@ -1930,7 +2331,9 @@
         <div class="notification-card">
           <div>
             <h4 data-i18n="ui.stayInLoopTitle">Stay in the loop</h4>
-            <p data-i18n="ui.stayInLoopDesc">We will invite you to enable music alerts after you play or follow creators—no spammy popups.</p>
+            <p data-i18n="ui.stayInLoopDesc">
+              We will invite you to enable music alerts after you play or follow creators—no spammy popups.
+            </p>
           </div>
           <div class="notification-actions">
             <p class="notification-status" id="notificationStatus" aria-live="polite"></p>
@@ -2021,7 +2424,9 @@
                 <div class="buffering-ripple delayed" aria-hidden="true"></div>
                 <div class="buffering-content">
                   <div id="loadingSpinner" class="loading-spinner" role="status" aria-label="Loading audio"></div>
-                  <p id="bufferingMessage" class="buffering-message" data-i18n="ui.startingPlayback">Starting playback...</p>
+                  <p id="bufferingMessage" class="buffering-message" data-i18n="ui.startingPlayback">
+                    Starting playback...
+                  </p>
                 </div>
               </div>
             </div>
@@ -2041,7 +2446,9 @@
                   />
                 </div>
                 <div class="now-playing-text">
-                  <p class="track-info" id="trackInfo" data-i18n="ui.chooseTrackToStart">Choose a track to start playback.</p>
+                  <p class="track-info" id="trackInfo" data-i18n="ui.chooseTrackToStart">
+                    Choose a track to start playback.
+                  </p>
                   <p class="track-artist-inline" id="trackArtistInline"></p>
                 </div>
               </div>
@@ -2067,7 +2474,8 @@
                   id="playbackRetryButton"
                   type="button"
                   class="status-retry-button"
-                  aria-label="Retry playback" data-i18n-aria-label="ui.retryPlayback"
+                  aria-label="Retry playback"
+                  data-i18n-aria-label="ui.retryPlayback"
                   hidden
                 >
                   <span data-i18n="ui.retry">Retry</span>
@@ -2085,18 +2493,33 @@
                 aria-controls="audioPlayer"
               />
               <div class="player-utility">
-                <button id="retryButton" type="button" class="retry-button" aria-label="Retry loading track" data-i18n-aria-label="ui.retryLoadingTrack">
+                <button
+                  id="retryButton"
+                  type="button"
+                  class="retry-button"
+                  aria-label="Retry loading track"
+                  data-i18n-aria-label="ui.retryLoadingTrack"
+                >
                   <span data-i18n="ui.retry">Retry</span>
                 </button>
                 <button
                   id="addToPlaylistButton"
                   type="button"
                   class="retry-button"
-                  aria-label="Add current track to playlist" data-i18n-aria-label="ui.addToPlaylist"
+                  aria-label="Add current track to playlist"
+                  data-i18n-aria-label="ui.addToPlaylist"
                 >
                   <span data-i18n="ui.addToPlaylist">Add to Playlist</span>
                 </button>
-                <button id="lyricsToggle" type="button" class="retry-button" aria-label="Toggle lyrics" data-i18n-aria-label="ui.toggleLyrics"><span data-i18n="ui.lyrics">Lyrics</span></button>
+                <button
+                  id="lyricsToggle"
+                  type="button"
+                  class="retry-button"
+                  aria-label="Toggle lyrics"
+                  data-i18n-aria-label="ui.toggleLyrics"
+                >
+                  <span data-i18n="ui.lyrics">Lyrics</span>
+                </button>
               </div>
               <div id="lyrics"></div>
               <div class="music-controls icons-only">
@@ -2167,14 +2590,7 @@
                   🔀
                 </button>
               </div>
-              <audio
-                id="audioPlayer"
-                preload="auto"
-                playsinline
-                webkit-playsinline
-                hidden
-                aria-hidden="true"
-              ></audio>
+              <audio id="audioPlayer" preload="auto" playsinline webkit-playsinline hidden aria-hidden="true"></audio>
             </div>
           </div>
         </div>
@@ -2235,9 +2651,18 @@
         </div>
         <div class="smart-radio-tools">
           <label for="smartRadioSearch">Find your frequency</label>
-          <div class="smart-radio-search"><span aria-hidden="true">⌕</span><input id="smartRadioSearch" type="search" placeholder="Search country, language, genre, or mood" /></div>
+          <div class="smart-radio-search">
+            <span aria-hidden="true">⌕</span
+            ><input id="smartRadioSearch" type="search" placeholder="Search country, language, genre, or mood" />
+          </div>
           <div class="smart-radio-suggestions" aria-label="AI radio recommendations">
-            <button type="button" data-radio-query="Nigerian Gospel">Nigerian Gospel</button><button type="button" data-radio-query="Congolese Rumba">Congolese Rumba</button><button type="button" data-radio-query="Afrobeat">Afrobeat</button><button type="button" data-radio-query="Worship">Worship</button><button type="button" data-radio-query="News">News</button><button type="button" data-radio-query="Talk">Talk Radio</button><button type="button" data-radio-query="Focus">Coding Focus</button>
+            <button type="button" data-radio-query="Nigerian Gospel">Nigerian Gospel</button
+            ><button type="button" data-radio-query="Congolese Rumba">Congolese Rumba</button
+            ><button type="button" data-radio-query="Afrobeat">Afrobeat</button
+            ><button type="button" data-radio-query="Worship">Worship</button
+            ><button type="button" data-radio-query="News">News</button
+            ><button type="button" data-radio-query="Talk">Talk Radio</button
+            ><button type="button" data-radio-query="Focus">Coding Focus</button>
           </div>
           <div id="smartRadioResults" class="smart-radio-results"></div>
         </div>
@@ -2815,7 +3240,12 @@
       </div>
     </aside>
     <nav class="mobile-companion-nav" aria-label="Primary navigation">
-      <a href="#home" class="active"><span>⌂</span>Home</a><a href="#radio"><span>◉</span>Radio</a><a href="#music"><span>♫</span>Music</a><button type="button" data-companion-action="stories"><span>❧</span>Stories</button><button type="button" data-companion-action="news"><span>◫</span>News</button><button type="button" data-companion-action="ai"><span>✦</span>AI</button><a href="#create"><span>＋</span>Create</a><a href="#profile"><span>◎</span>Profile</a>
+      <a href="#home" class="active"><span>⌂</span>Home</a><a href="#radio"><span>◉</span>Radio</a
+      ><a href="#music"><span>♫</span>Music</a
+      ><button type="button" data-companion-action="stories"><span>❧</span>Stories</button
+      ><button type="button" data-companion-action="news"><span>◫</span>News</button
+      ><button type="button" data-companion-action="ai"><span>✦</span>AI</button
+      ><a href="#create"><span>＋</span>Create</a><a href="#profile"><span>◎</span>Profile</a>
     </nav>
 
     <aside class="email-gate" id="emailGate" role="dialog" aria-modal="true" aria-labelledby="emailGateTitle" hidden>
@@ -2866,6 +3296,7 @@
     <script src="scripts/track-catalog.js" defer></script>
     <script src="scripts/search-utils.js" defer></script>
     <script src="scripts/main.js" defer></script>
+    <script src="scripts/media-intelligence.js" defer></script>
     <script src="scripts/companion.js" defer></script>
     <script src="user-tracking.js" defer></script>
     <script src="prevent-zoom.js" defer></script>

--- a/scripts/companion.js
+++ b/scripts/companion.js
@@ -1,81 +1,38 @@
 (function () {
   'use strict';
 
-  const STORAGE = {
-    favorites: 'ariyo.favoriteStations',
-    recent: 'ariyo.recentTracks',
-    regions: 'ariyo.preferredRegions',
-    visits: 'ariyo.companionVisits',
-    personality: 'ariyo.mediaPersonality',
-  };
+  const engine = window.AriyoMediaIntelligence;
+  if (!engine) return;
 
-  const state = { country: 'All Africa', mood: 'Happy' };
+  const { STORAGE_KEYS } = engine;
+  const state = {
+    country: engine.safeRead(STORAGE_KEYS.preferredRegion, 'All Africa'),
+    mood: 'All moods',
+    language: engine.safeRead(STORAGE_KEYS.preferredLanguage, 'English'),
+    contentType: 'All content',
+  };
   const countries = ['All Africa', 'Nigeria', 'Congo', 'Ghana', 'Kenya', 'South Africa', 'Cameroon', 'Global Africa'];
   const moods = [
-    ['Happy', '☀', '#d66a43', 'Bright & joyful'],
-    ['Worship', '✦', '#73634a', 'Faith & gratitude'],
-    ['Focus', '◎', '#2c5c55', 'Deep work'],
-    ['Motivation', '↑', '#8a4b33', 'Move forward'],
-    ['Relaxation', '≈', '#315b70', 'Slow your mind'],
-    ['Celebration', '✺', '#8a3f5c', 'Big energy'],
-    ['Deep Thinking', '◌', '#443f65', 'Reflect & reset'],
+    'All moods',
+    'Focus',
+    'Worship',
+    'Reflection',
+    'Motivation',
+    'Celebration',
+    'Study',
+    'Evening Wind Down',
   ];
-  const personalities = [
-    ['Afrobeat Scholar', 'You hear the history inside every drum and always have a deeper cut ready.'],
-    ['Lagos Night Rider', 'Your soundtrack starts after sunset: bold rhythms, bright streets, zero dull moments.'],
-    ['Gospel Warrior', 'You carry hope loudly and choose sound that lifts the whole room.'],
-    ['Congo Rumba Soul', 'You move with elegance, guitar lines, and the warm patience of a timeless groove.'],
-    ['Story Keeper', 'You collect wisdom, proverbs, and voices so important memories keep travelling.'],
-    ['Radio Explorer', 'You cross borders through sound and always know which frequency carries home.'],
-  ];
+  const fallbackBriefing = {
+    headline: 'African audiences are moving fluidly between news, live radio, and culturally grounded sound.',
+    summary:
+      'Ariyọ’s local media graph shows the opportunity in connecting information with relevant music, regional radio, language support, and cultural context rather than treating each format as a separate destination.',
+  };
 
-  function read(key, fallback) {
-    try {
-      const value = JSON.parse(localStorage.getItem(key));
-      return value == null ? fallback : value;
-    } catch (_) {
-      return fallback;
-    }
-  }
-
-  function write(key, value) {
-    try {
-      localStorage.setItem(key, JSON.stringify(value));
-    } catch (_) {}
-  }
-
-  function getAlbums() {
-    return Array.isArray(window.albums)
-      ? window.albums
-      : Array.isArray(window.libraryState?.local)
-        ? window.libraryState.local
-        : [];
-  }
-
-  function getStations() {
-    const playerStations = Array.isArray(window.radioStations) ? window.radioStations : [];
-    const merged = Array.isArray(window.mergedRadioStations) ? window.mergedRadioStations : [];
-    return playerStations.length >= merged.length ? playerStations : merged;
-  }
-
-  function stationCountry(station) {
-    const text = `${station?.location || ''} ${station?.country || ''} ${station?.name || ''}`.toLowerCase();
-    if (/congo|kinshasa|lubumbashi|rdc/.test(text)) return 'Congo';
-    if (/ghana|accra|kumasi/.test(text)) return 'Ghana';
-    if (/kenya|nairobi|mombasa/.test(text)) return 'Kenya';
-    if (/south africa|johannesburg|cape town|durban/.test(text)) return 'South Africa';
-    if (/cameroon|douala|yaound/.test(text)) return 'Cameroon';
-    if (/nigeria|lagos|abuja|ibadan|port harcourt|enugu|kano|kaduna|ondo|benin/.test(text)) return 'Nigeria';
-    return 'Global Africa';
-  }
-
-  function stationMeta(station) {
-    const text = `${station?.name || ''} ${station?.genre || ''} ${station?.tags || ''}`.toLowerCase();
-    if (/gospel|worship|christian/.test(text)) return 'Gospel · Worship';
-    if (/news|talk|info/.test(text)) return 'News · Talk';
-    if (/rumba|congo/.test(text)) return 'Rumba · Lingala';
-    if (/afro|hits|music/.test(text)) return 'Afrobeats · Music';
-    return 'Music · Culture';
+  function escapeHtml(value) {
+    return String(value || '').replace(
+      /[&<>'"]/g,
+      (character) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', "'": '&#39;', '"': '&quot;' })[character],
+    );
   }
 
   function findLauncher(target) {
@@ -83,115 +40,139 @@
   }
 
   function openPanel(target) {
-    const launcher = findLauncher(target);
-    if (launcher) launcher.click();
+    findLauncher(target)?.click();
   }
 
   function performAction(action) {
-    if (action === 'music') {
-      if (typeof window.openTrackList === 'function') window.openTrackList();
-      else document.getElementById('music')?.scrollIntoView({ behavior: 'smooth' });
-    } else if (action === 'radio') {
-      if (typeof window.openRadioList === 'function') window.openRadioList();
-      else document.getElementById('radio')?.scrollIntoView({ behavior: 'smooth' });
-    } else if (action === 'news') openPanel('news-section');
+    if (action === 'music')
+      typeof window.openTrackList === 'function'
+        ? window.openTrackList()
+        : document.getElementById('music')?.scrollIntoView({ behavior: 'smooth' });
+    else if (action === 'radio')
+      typeof window.openRadioList === 'function'
+        ? window.openRadioList()
+        : document.getElementById('radio')?.scrollIntoView({ behavior: 'smooth' });
+    else if (action === 'news') openPanel('news-section');
     else if (action === 'stories') {
-      const albums = getAlbums();
-      const storyIndex = albums.findIndex((album) => /spoken|story|word/i.test(album.name || ''));
-      if (storyIndex >= 0 && typeof window.selectAlbum === 'function') window.selectAlbum(storyIndex);
+      const story = engine.getTracks().find((track) => /spoken|story|word/i.test(track.album?.name || track.title));
+      if (story && typeof window.selectTrack === 'function') playTrack(story);
       else openPanel('ariyoChatbotContainer');
-    } else if (action === 'ai') openPanel('ariyoChatbotContainer');
+    } else if (action === 'creator') document.getElementById('create')?.scrollIntoView({ behavior: 'smooth' });
+    else if (action === 'games') openPanel('gamesHubContainer');
+    else openPanel('ariyoChatbotContainer');
   }
 
   function routeCommand(command) {
     const text = command.trim();
+    if (!text) return;
     const query = text.toLowerCase();
-    let action = 'ai';
-    let response = `I’m opening the Ariyọ conversation so we can explore “${text}” together.`;
-    if (/congo|rumba|lingala/.test(query) && /radio|play|stream/.test(query)) {
-      action = 'radio';
+    let route = 'AI / GENERAL';
+    let response = 'Opening Ariyọ Chat with your query and the current media context.';
+    if (/game|puzzle|simulation/.test(query)) {
+      route = 'GAMES / INTERACTIVE';
+      response = 'Routing to the existing games and simulations hub.';
+      performAction('games');
+    } else if (/congo|lingala|rumba/.test(query) && /radio|station|stream|tuning/.test(query)) {
       state.country = 'Congo';
+      engine.safeWrite(STORAGE_KEYS.preferredRegion, state.country);
       renderCountryFilters();
       renderStations();
-      response = 'I found the Congo frequency for you—start with rumba and Lingala voices.';
-    } else if (/radio|station|stream/.test(query)) {
-      action = 'radio';
-      response = 'Opening intelligent radio. Search by country, language, genre, or mood.';
-    } else if (/music|song|track|playlist|afrobeat|worship|focus/.test(query)) {
-      action = 'music';
-      response = 'Opening your music library with mood-based discovery.';
-    } else if (/news|brief|headline|summar/.test(query)) {
-      action = 'news';
-      response = 'Here is today’s Africa briefing. You can simplify or translate every summary.';
-    } else if (/story|proverb|spoken/.test(query)) {
-      action = 'stories';
-      response = 'Opening African stories and spoken word from the existing library.';
-    } else if (/game|play a game|puzzle/.test(query)) {
-      openPanel('gamesHubContainer');
-      response = 'Opening the games hub—pick your challenge.';
-    } else if (/translate|pidgin|french|yoruba|igbo|hausa|lingala/.test(query)) {
-      action = 'ai';
-      response = 'Opening Ariyọ AI for language help. Your preferred language is remembered on this device.';
+      route = 'RADIO / CONGO / LINGALA';
+      response = 'Radio intelligence filtered to Congo. Stations are ranked with Lingala and rumba context first.';
+      document.getElementById('radio')?.scrollIntoView({ behavior: 'smooth' });
+    } else if (/radio|station|stream|broadcast/.test(query)) {
+      route = 'RADIO / DISCOVERY';
+      response = 'Opening live radio intelligence with country, language, content, and use-case metadata.';
+      document.getElementById('radio')?.scrollIntoView({ behavior: 'smooth' });
+    } else if (/music|song|track|focus|worship|celebration|study/.test(query)) {
+      const matchedMood = moods.find((mood) => query.includes(mood.toLowerCase()));
+      if (matchedMood) state.mood = matchedMood;
+      renderMoods();
+      renderRecommendations();
+      route = `MUSIC / ${state.mood.toUpperCase()}`;
+      response = `Music intelligence is prioritizing ${state.mood.toLowerCase()} recommendations from the existing catalogue.`;
+      document.getElementById('music')?.scrollIntoView({ behavior: 'smooth' });
+    } else if (/news|brief|headline|trend|summar|simple english/.test(query)) {
+      route = 'NEWS / SYNTHESIS';
+      response =
+        'Opening the African Media Briefing with executive, simple English, Pidgin, and French interpretation paths.';
+      document.getElementById('news')?.scrollIntoView({ behavior: 'smooth' });
+    } else if (/story|culture|proverb|spoken/.test(query)) {
+      route = 'CULTURE / KNOWLEDGE';
+      response =
+        'Opening the cultural knowledge layer with paths into spoken word, regional radio, and reflective music.';
+      document.getElementById('stories')?.scrollIntoView({ behavior: 'smooth' });
+    } else if (/translate|french|pidgin|yoruba|igbo|hausa|lingala|language/.test(query)) {
+      route = 'LANGUAGE / TRANSFORMATION';
+      response = 'Opening language intelligence. Your preferred language will be stored only on this device.';
+      document.getElementById('language')?.scrollIntoView({ behavior: 'smooth' });
+    } else if (/creator|metadata|title|description|cover|release/.test(query)) {
+      route = 'CREATOR / FOUNDATION';
+      response =
+        'Opening Creator Studio Foundation. Backend-dependent generation tools are clearly marked Coming Soon.';
+      document.getElementById('create')?.scrollIntoView({ behavior: 'smooth' });
+    } else if (/africa|trending|listeners|media/.test(query)) {
+      route = 'ASK AFRICA / GRAPH QUERY';
+      askAfrica(text);
+      response = 'The local media graph has synthesized a structured Ask Africa response.';
+      document.getElementById('ask-africa')?.scrollIntoView({ behavior: 'smooth' });
+    } else {
+      window.setTimeout(() => performAction('ai'), 550);
     }
     const output = document.getElementById('aiCommandResponse');
     if (output) {
-      output.textContent = response;
+      output.innerHTML = `<span>${escapeHtml(route)}</span><p>${escapeHtml(response)}</p>`;
       output.hidden = false;
     }
-    window.setTimeout(() => performAction(action), 300);
+    const log = document.getElementById('routingLog');
+    if (log) log.textContent = `${route}: ${text}`;
   }
 
-  function trackLabels(track, album, index) {
-    const title = `${track?.title || ''} ${album?.name || ''}`.toLowerCase();
-    const genre = /spoken|story|life|father|truth/.test(title)
-      ? 'Spoken word'
-      : /holy|lord|oluwa|worship/.test(title)
-        ? 'Gospel'
-        : 'Afro-fusion';
-    const language = / pidgin| no be| dey | wahala| na /.test(` ${title} `)
-      ? 'Pidgin'
-      : /yoruba|omoluabi|boda/.test(title)
-        ? 'Yorùbá'
-        : 'English';
-    const mood = moods[index % moods.length][0];
-    return `${genre} · ${language} · ${mood}`;
-  }
-
-  function flattenTracks() {
-    return getAlbums().flatMap((album, albumIndex) =>
-      (album.tracks || []).map((track, trackIndex) => ({ album, albumIndex, track, trackIndex })),
+  function playTrack(track) {
+    if (!track || typeof window.selectTrack !== 'function') return;
+    engine.remember(
+      STORAGE_KEYS.recentTracks,
+      { title: track.title, src: track.src, album: track.album?.name, metadata: track.metadata },
+      (item) => item.src || item.title,
     );
-  }
-
-  function rememberTrack(item) {
-    const recent = read(STORAGE.recent, []).filter((entry) => entry.src !== item.track.src);
-    recent.unshift({
-      title: item.track.title,
-      src: item.track.src,
-      album: item.album.name,
-      albumIndex: item.albumIndex,
-      trackIndex: item.trackIndex,
-      at: Date.now(),
-    });
-    write(STORAGE.recent, recent.slice(0, 8));
+    window.selectTrack(track.src, track.title, track.trackIndex, true, null, track.albumIndex);
     renderRecent();
-  }
-
-  function playTrackItem(item) {
-    if (!item?.track || typeof window.selectTrack !== 'function') return;
-    rememberTrack(item);
-    window.selectTrack(item.track.src, item.track.title, item.trackIndex, true, null, item.albumIndex);
+    updateTrackRecommendation(track);
   }
 
   function playStation(station) {
-    const stations = getStations();
-    const index = stations.indexOf(station);
-    const playerIndex = (window.radioStations || []).findIndex((item) => item.url === station.url);
-    const useIndex = playerIndex >= 0 ? playerIndex : index;
-    if (useIndex >= 0 && typeof window.selectRadio === 'function') {
-      window.selectRadio(station.url, station.name, useIndex, station.logo);
-      write(STORAGE.regions, [stationCountry(station)]);
+    if (!station?.url) {
+      performAction('radio');
+      const log = document.getElementById('routingLog');
+      if (log)
+        log.textContent = `${station?.name || 'Station'} is a directory preview; opening available live stations.`;
+      return;
     }
+    const stations = engine.getStations();
+    const index = (Array.isArray(window.radioStations) ? window.radioStations : []).findIndex(
+      (item) => item.url === station.url,
+    );
+    engine.remember(
+      STORAGE_KEYS.recentStations,
+      {
+        name: station.name,
+        url: station.url,
+        location: station.location,
+        logo: station.logo,
+        metadata: station.metadata,
+      },
+      (item) => item.url || item.name,
+    );
+    if (typeof window.selectRadio === 'function')
+      window.selectRadio(
+        station.url,
+        station.name,
+        Math.max(index, 0),
+        station.logo || station.thumbnail || 'Logo.jpg',
+      );
+    else if (stations.length) performAction('radio');
+    renderStations();
+    updateStationRecommendation(station);
   }
 
   function renderCountryFilters() {
@@ -205,227 +186,293 @@
       button.classList.toggle('active', state.country === country);
       button.addEventListener('click', () => {
         state.country = country;
-        write(STORAGE.regions, [country]);
+        engine.safeWrite(STORAGE_KEYS.preferredRegion, country);
         renderCountryFilters();
         renderStations();
+        updateProfile();
       });
       host.appendChild(button);
     });
   }
 
+  function stationMatches(station) {
+    const metadata = station.metadata;
+    const countryMatch = state.country === 'All Africa' || metadata.country === state.country;
+    const languageMatch =
+      state.language === 'English' ||
+      document.getElementById('radioLanguageFilter')?.value === 'All languages' ||
+      metadata.language === document.getElementById('radioLanguageFilter')?.value;
+    const type = document.getElementById('radioTypeFilter')?.value || 'All content';
+    const typeMatch = type === 'All content' || metadata.category === type;
+    return countryMatch && languageMatch && typeMatch;
+  }
+
   function renderStations() {
     const host = document.getElementById('radioDiscoveryGrid');
     if (!host) return;
-    const favorites = read(STORAGE.favorites, []);
-    let stations = getStations();
-    const selected = state.country;
-    if (selected !== 'All Africa') stations = stations.filter((station) => stationCountry(station) === selected);
-    if (!stations.length) stations = getStations();
+    const favorites = engine.safeRead(STORAGE_KEYS.favoriteStations, []);
+    const favoriteIds = new Set(favorites.map((item) => item.url || item.name));
+    let stations = engine.buildGraph().stations.filter(stationMatches);
+    if (!stations.length)
+      stations = engine
+        .buildGraph()
+        .stations.filter((station) => state.country === 'All Africa' || station.metadata.country === state.country);
     host.innerHTML = '';
-    stations.slice(0, 4).forEach((station, index) => {
+    stations.slice(0, 8).forEach((station, position) => {
       const card = document.createElement('article');
-      const country = stationCountry(station);
       card.className = 'station-card';
-      card.style.setProperty('--station-color', ['#254d38', '#553d28', '#3b315c', '#214c55'][index % 4]);
-      card.innerHTML = `<div class="station-card__top"><span class="station-card__live">● Live</span><button class="station-card__favorite" type="button" aria-label="Favorite ${station.name}">${favorites.includes(station.url) ? '♥' : '♡'}</button></div><div class="station-card__mark">◉</div><h3>${station.name}</h3><p>${country} · ${stationMeta(station)}</p>`;
-      card.addEventListener('click', (event) => {
-        if (!event.target.closest('.station-card__favorite')) playStation(station);
-      });
+      const id = station.url || station.name;
+      card.innerHTML = `<div class="station-card__top"><span class="station-index">${String(position + 1).padStart(2, '0')}</span><span class="station-card__live"><i></i>${station.metadata.streamStatus}</span><button class="station-card__favorite" type="button" aria-label="${favoriteIds.has(id) ? 'Remove from' : 'Add to'} station favorites" aria-pressed="${favoriteIds.has(id)}">${favoriteIds.has(id) ? 'SAVED' : 'SAVE'}</button></div><h3>${escapeHtml(station.name)}</h3><p>${escapeHtml(station.metadata.country)} · ${escapeHtml(station.metadata.language)}</p><dl><div><dt>Format</dt><dd>${escapeHtml(station.metadata.category)}</dd></div><div><dt>Genre</dt><dd>${escapeHtml(station.metadata.genre)}</dd></div><div><dt>Best for</dt><dd>${escapeHtml(station.metadata.useCase)}</dd></div></dl><button class="station-play" type="button">Open live signal <span>→</span></button>`;
+      card.querySelector('.station-play').addEventListener('click', () => playStation(station));
       card.querySelector('.station-card__favorite').addEventListener('click', () => {
-        const next = read(STORAGE.favorites, []);
-        const exists = next.includes(station.url);
-        write(STORAGE.favorites, exists ? next.filter((url) => url !== station.url) : [...next, station.url]);
+        engine.toggleFavorite(
+          STORAGE_KEYS.favoriteStations,
+          { name: station.name, url: station.url, location: station.location, metadata: station.metadata },
+          (item) => item.url || item.name,
+        );
         renderStations();
       });
       host.appendChild(card);
     });
+    if (!host.children.length)
+      host.innerHTML =
+        '<div class="empty-state">No exact station match is available. Change a filter to expand the intelligence view.</div>';
+    updateMetrics();
   }
 
   function renderMoods() {
     const host = document.getElementById('moodGrid');
     if (!host) return;
     host.innerHTML = '';
-    moods.forEach(([name, icon, color, copy]) => {
+    moods.forEach((mood) => {
       const button = document.createElement('button');
       button.type = 'button';
-      button.className = 'mood-card';
-      button.style.setProperty('--mood-bg', color);
-      button.innerHTML = `<span>${icon}</span><b>${name}</b><small>${copy}</small>`;
+      button.textContent = mood;
+      button.classList.toggle('active', state.mood === mood);
       button.addEventListener('click', () => {
-        state.mood = name;
+        state.mood = mood;
+        renderMoods();
         renderRecommendations();
-        document.getElementById('recommendedTracks')?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        updateProfile();
       });
       host.appendChild(button);
     });
   }
 
-  function trackCard(item, index) {
-    const button = document.createElement('button');
-    button.type = 'button';
-    button.className = 'track-card';
-    button.innerHTML = `<span class="track-card__art" style="--track-color:${['#446b51', '#6c4b36', '#384f6c'][index % 3]}">♫</span><span><b>${item.track.title}</b><small>${trackLabels(item.track, item.album, index)}</small></span><span>▶</span>`;
-    button.addEventListener('click', () => playTrackItem(item));
-    return button;
+  function renderTrackCards(host, tracks, emptyMessage) {
+    if (!host) return;
+    const favorites = engine.safeRead(STORAGE_KEYS.favoriteTracks, []);
+    const favoriteIds = new Set(favorites.map((item) => item.src || item.title));
+    host.innerHTML = '';
+    tracks.forEach((track) => {
+      const id = track.src || track.title;
+      const card = document.createElement('article');
+      card.className = 'track-card';
+      card.innerHTML = `<div class="track-card__art"><span>${escapeHtml((track.metadata?.mood || 'AI').slice(0, 2).toUpperCase())}</span><button type="button" aria-label="${favoriteIds.has(id) ? 'Remove from' : 'Add to'} track favorites" aria-pressed="${favoriteIds.has(id)}">${favoriteIds.has(id) ? 'SAVED' : 'SAVE'}</button></div><div><b>${escapeHtml(track.title)}</b><small>${escapeHtml(track.metadata?.genre || 'African media')} · ${escapeHtml(track.metadata?.language || 'English')}</small><p>${escapeHtml(track.metadata?.useCase || 'Daily listening')}</p></div><button class="track-play" type="button" aria-label="Play ${escapeHtml(track.title)}">PLAY</button>`;
+      card.querySelector('.track-play').addEventListener('click', () => playTrack(track));
+      card.querySelector('.track-card__art button').addEventListener('click', () => {
+        engine.toggleFavorite(
+          STORAGE_KEYS.favoriteTracks,
+          { title: track.title, src: track.src, album: track.album?.name, metadata: track.metadata },
+          (item) => item.src || item.title,
+        );
+        renderRecommendations();
+      });
+      host.appendChild(card);
+    });
+    if (!tracks.length) host.innerHTML = `<div class="empty-state">${escapeHtml(emptyMessage)}</div>`;
+  }
+
+  function hydrateStoredTrack(stored) {
+    return (
+      engine.getTracks().find((track) => track.src === stored.src || track.title === stored.title) || {
+        ...stored,
+        trackIndex: 0,
+        albumIndex: 0,
+        album: { name: stored.album || 'Ariyọ Catalogue' },
+        metadata: stored.metadata || engine.trackMetadata(stored),
+      }
+    );
   }
 
   function renderRecommendations() {
-    const host = document.getElementById('recommendedTracks');
-    if (!host) return;
-    const tracks = flattenTracks();
-    host.innerHTML = '';
-    const offset = moods.findIndex((mood) => mood[0] === state.mood);
-    tracks
-      .slice(Math.max(0, offset), Math.max(0, offset) + 3)
-      .forEach((item, index) => host.appendChild(trackCard(item, index)));
+    let tracks = engine.getTracks();
+    if (state.mood !== 'All moods') {
+      const matches = tracks.filter((track) => track.metadata.mood === state.mood);
+      tracks = matches.length ? matches : tracks;
+    }
+    const recent = engine.safeRead(STORAGE_KEYS.recentTracks, []);
+    if (recent.length) {
+      const source = hydrateStoredTrack(recent[0]);
+      tracks = engine.recommendRelated(source, 'track', 8);
+    }
+    renderTrackCards(
+      document.getElementById('recommendedTracks'),
+      tracks.slice(0, 8),
+      'The music catalogue is still loading. Existing tracks will appear here automatically.',
+    );
   }
 
   function renderRecent() {
+    const recent = engine.safeRead(STORAGE_KEYS.recentTracks, []).map(hydrateStoredTrack);
     const section = document.getElementById('recentlyPlayedSection');
-    const host = document.getElementById('recentlyPlayed');
-    if (!section || !host) return;
-    const albums = getAlbums();
-    const items = read(STORAGE.recent, [])
-      .map((entry) => ({
-        ...entry,
-        album: albums[entry.albumIndex],
-        track: albums[entry.albumIndex]?.tracks?.[entry.trackIndex],
-      }))
-      .filter((item) => item.album && item.track);
-    section.hidden = !items.length;
-    host.innerHTML = '';
-    items.slice(0, 3).forEach((item, index) => host.appendChild(trackCard(item, index)));
+    if (!section) return;
+    section.hidden = !recent.length;
+    renderTrackCards(
+      document.getElementById('recentlyPlayed'),
+      recent.slice(0, 6),
+      'Play a track to begin your private listening memory.',
+    );
+  }
+
+  function updateTrackRecommendation(track) {
+    const related = engine.recommendRelated(track, 'station', 2);
+    const host = document.getElementById('radioRecommendation');
+    if (!host || !related.length) return;
+    host.innerHTML = `<span class="recommendation-code">GRAPH MATCH</span><div><strong>Because you played ${escapeHtml(track.title)}</strong><p>Try ${related.map((station) => station.name).join(' or ')}—matched through region, language, genre, and mood.</p></div>`;
+  }
+
+  function updateStationRecommendation(station) {
+    const related = engine.recommendRelated(station, 'track', 3);
+    const host = document.getElementById('radioRecommendation');
+    if (!host || !related.length) return;
+    host.innerHTML = `<span class="recommendation-code">NEXT PATH</span><div><strong>Continue beyond ${escapeHtml(station.name)}</strong><p>Related tracks: ${related.map((track) => track.title).join(', ')}.</p></div>`;
   }
 
   function renderBriefing() {
-    fetch('data/news.json')
-      .then((response) => (response.ok ? response.json() : []))
-      .then((items) => {
-        const item = Array.isArray(items) ? items[0] : null;
-        if (!item) return;
-        const title = document.getElementById('briefingHeadline');
-        const summary = document.getElementById('briefingSummary');
-        if (title) title.textContent = item.title;
-        if (summary) summary.textContent = item.summary;
-      })
-      .catch(() => {});
-    const tracks = flattenTracks();
-    const stations = getStations();
-    if (tracks[0]) document.getElementById('dailyTrackTitle').textContent = tracks[0].track.title;
-    if (stations[0]) document.getElementById('dailyStationTitle').textContent = stations[0].name;
-    document.getElementById('playDailyTrack')?.addEventListener('click', () => playTrackItem(flattenTracks()[0]));
-    document.getElementById('playDailyStation')?.addEventListener('click', () => playStation(getStations()[0]));
-  }
-
-  function initSmartRadioSearch() {
-    const input = document.getElementById('smartRadioSearch');
-    const host = document.getElementById('smartRadioResults');
-    if (!input || !host) return;
-    const search = (query) => {
-      const words = query.toLowerCase().split(/\s+/).filter(Boolean);
-      const matches = getStations()
-        .filter((station) => {
-          const haystack =
-            `${station.name} ${station.location || ''} ${station.country || ''} ${station.genre || ''} ${stationMeta(station)} ${stationCountry(station)}`.toLowerCase();
-          return words.every(
-            (word) =>
-              haystack.includes(word) ||
-              (word === 'nigerian' && haystack.includes('nigeria')) ||
-              (word === 'congolese' && haystack.includes('congo')) ||
-              (word === 'focus' && /music|classic|jazz/.test(haystack)),
-          );
-        })
-        .slice(0, 8);
-      host.innerHTML = '';
-      matches.forEach((station) => {
-        const button = document.createElement('button');
-        button.type = 'button';
-        button.className = 'smart-radio-result';
-        button.innerHTML = `<span>${station.name}<br><small>${stationCountry(station)} · ${stationMeta(station)}</small></span><b>▶</b>`;
-        button.addEventListener('click', () => playStation(station));
-        host.appendChild(button);
-      });
-      if (query && !matches.length)
-        host.innerHTML = '<p>No exact match yet. Try a country, “news,” “gospel,” or “music.”</p>';
-    };
-    input.addEventListener('input', () => search(input.value));
-    document.querySelectorAll('[data-radio-query]').forEach((button) =>
-      button.addEventListener('click', () => {
-        input.value = button.dataset.radioQuery;
-        search(input.value);
-      }),
-    );
+    const headline = document.getElementById('briefingHeadline');
+    const summary = document.getElementById('briefingSummary');
+    if (headline && !headline.dataset.live) headline.textContent = fallbackBriefing.headline;
+    if (summary && !summary.dataset.live) summary.textContent = fallbackBriefing.summary;
+    const track = engine.getTracks()[0];
+    const station = engine.buildGraph().stations[0];
+    if (track) document.getElementById('dailyTrackTitle').textContent = track.title;
+    if (station) document.getElementById('dailyStationTitle').textContent = station.name;
+    document.getElementById('playDailyTrack')?.addEventListener('click', () => playTrack(track), { once: true });
+    document.getElementById('playDailyStation')?.addEventListener('click', () => playStation(station), { once: true });
   }
 
   function simplify(mode) {
     const summary = document.getElementById('briefingSummary');
     if (!summary) return;
     const versions = {
-      simple: 'Here is the main point: a new African culture and music update is available now. Open it to learn more.',
-      pidgin: 'See the main gist: new African culture and music update don land. Open am make you see everything.',
-      fr: 'Voici l’essentiel : une nouvelle actualité sur la culture et la musique africaines est disponible. Ouvrez-la pour en savoir plus.',
+      executive:
+        'Executive view: Ariyọ’s opportunity is the intelligence layer between fragmented African media formats—using language, region, and behavior to move audiences from information to relevant sound and culture.',
+      simple:
+        'Main point: African media works better when news, radio, music, language, and stories help people discover each other in one place.',
+      pidgin:
+        'Main gist be say African news, radio, music, language and stories go useful pass when one smart system connect all of dem for the listener.',
+      fr: 'Point essentiel : les médias africains deviennent plus utiles lorsqu’une intelligence commune relie actualités, radio, musique, langues et récits culturels.',
     };
-    summary.textContent = versions[mode] || summary.textContent;
+    summary.textContent = versions[mode] || fallbackBriefing.summary;
+    document.getElementById('news')?.scrollIntoView({ behavior: 'smooth', block: 'center' });
   }
 
-  function setPersonality(forceRandom) {
-    const saved = read(STORAGE.personality, null);
-    const activity = read(STORAGE.recent, []).length + read(STORAGE.favorites, []).length;
-    const index = forceRandom
-      ? Math.floor(Math.random() * personalities.length)
-      : (saved?.index ?? activity % personalities.length);
-    const [name, copy] = personalities[index];
-    write(STORAGE.personality, { index, name });
-    document.getElementById('personalityName').textContent = name;
-    document.getElementById('personalityCopy').textContent = copy;
+  function askAfrica(question) {
+    const query = question.toLowerCase();
+    const graph = engine.buildGraph();
+    let result = {
+      category: 'Cross-media',
+      region: 'Africa',
+      language: state.language,
+      path: 'Query → Graph → Recommendation',
+      answer: `The current local graph contains ${graph.tracks.length} tracks and ${graph.stations.length} stations. Ariyọ can connect these signals by region, language, genre, and mood while live trend APIs are integrated.`,
+    };
+    if (/nigerian gospel/.test(query))
+      result = {
+        category: 'Gospel / Radio / Music',
+        region: 'Nigeria',
+        language: 'English',
+        path: 'Nigeria → Gospel → Radio + Tracks',
+        answer:
+          'The available local signal points to faith-led listening as a strong cross-format path. Start with Nigerian gospel or worship stations, then continue into worship-tagged tracks from the existing catalogue. This is curated local intelligence, not a claim of live market ranking.',
+      };
+    else if (/congo|congolese/.test(query))
+      result = {
+        category: 'Radio / Rumba / Culture',
+        region: 'Congo',
+        language: 'Lingala',
+        path: 'Congo → Lingala → Rumba → Stories',
+        answer:
+          'Congolese discovery is best served through Lingala and rumba radio signals, followed by culturally adjacent evening listening and storytelling. Ariyọ will rank available Congo-tagged stations first.',
+      };
+    else if (/story|news|media story/.test(query))
+      result = {
+        category: 'News / Interpretation',
+        region: 'Pan-African',
+        language: state.language,
+        path: 'News → Summary → Translation → Audio',
+        answer:
+          'The key media story is not only the headline; it is how audiences interpret and continue from it. Ariyọ provides an executive summary, simple English, Pidgin, French, and a related radio or music path.',
+      };
+    document.getElementById('askAfricaQuestion').textContent = question;
+    document.getElementById('askAfricaAnswer').textContent = result.answer;
+    document.getElementById('answerCategory').textContent = result.category;
+    document.getElementById('answerRegion').textContent = result.region;
+    document.getElementById('answerLanguage').textContent = result.language;
+    document.getElementById('answerPath').textContent = result.path;
   }
 
-  function initPersonality() {
-    setPersonality(false);
-    document.getElementById('generatePersonality')?.addEventListener('click', () => setPersonality(true));
-    document.getElementById('sharePersonality')?.addEventListener('click', async () => {
-      const name = document.getElementById('personalityName')?.textContent || 'Radio Explorer';
-      const text = `My African Media Personality is “${name}” on Ariyọ AI — Africa's AI Media Companion. What’s yours?`;
-      try {
-        await navigator.clipboard.writeText(text);
-        document.getElementById('personalityStatus').textContent = 'Copied—share your cultural frequency.';
-      } catch (_) {
-        window.prompt('Copy your result:', text);
-      }
+  function updateMetrics() {
+    const graph = engine.buildGraph();
+    const entities = document.getElementById('metricEntities');
+    const stations = document.getElementById('metricStations');
+    if (entities) entities.textContent = String(graph.nodes.length).padStart(2, '0');
+    if (stations)
+      stations.textContent = String(graph.stations.filter((station) => station.url).length).padStart(2, '0');
+  }
+
+  function renderGraphPreview() {
+    const host = document.getElementById('graphNodes');
+    if (!host) return;
+    host.innerHTML = engine.ENTITY_TYPES.map(
+      (type, index) => `<span style="--node-index:${index}">${escapeHtml(type)}</span>`,
+    ).join('');
+  }
+
+  function updateProfile() {
+    const recent = engine.safeRead(STORAGE_KEYS.recentTracks, []);
+    document.getElementById('profileMood').textContent =
+      state.mood === 'All moods' ? recent[0]?.metadata?.mood || 'Focus' : state.mood;
+    document.getElementById('profileRegion').textContent = state.country;
+    document.getElementById('profileSignal').textContent = recent.length
+      ? 'Signal established'
+      : 'Building your signal';
+  }
+
+  function initLanguage() {
+    const select = document.getElementById('intelligenceLanguage');
+    if (!select) return;
+    select.value = state.language;
+    select.addEventListener('change', () => {
+      state.language = select.value;
+      engine.safeWrite(STORAGE_KEYS.preferredLanguage, state.language);
+      document.getElementById('answerLanguage').textContent = state.language;
+      renderStations();
     });
-  }
-
-  function initReturningUser() {
-    const visits = Number(read(STORAGE.visits, 0));
-    write(STORAGE.visits, visits + 1);
-    const host = document.getElementById('returningMessage');
-    if (!host || visits < 1) return;
-    const favorites = read(STORAGE.favorites, []);
-    const station = getStations().find((item) => favorites.includes(item.url));
-    host.textContent = station
-      ? `Welcome back—${station.name}, your favorite station, is ready.`
-      : 'Welcome back—your daily African soundtrack is ready.';
-    host.hidden = false;
-  }
-
-  function initLanguageMemory() {
     window.addEventListener('ariyo:languageChanged', (event) => {
-      try {
-        localStorage.setItem('ariyo.preferredLanguage', event.detail.language);
-      } catch (_) {}
+      const map = {
+        en: 'English',
+        'en-NG': 'Nigerian Pidgin',
+        fr: 'French',
+        yo: 'Yoruba',
+        ig: 'Igbo',
+        ha: 'Hausa',
+        ln: 'Lingala',
+      };
+      state.language = map[event.detail?.language] || event.detail?.language || state.language;
+      engine.safeWrite(STORAGE_KEYS.preferredLanguage, state.language);
     });
   }
 
   function bind() {
     document.getElementById('aiCommandForm')?.addEventListener('submit', (event) => {
       event.preventDefault();
-      const input = document.getElementById('aiCommandInput');
-      if (input?.value.trim()) routeCommand(input.value);
+      routeCommand(document.getElementById('aiCommandInput')?.value || '');
     });
     document.querySelectorAll('[data-ai-prompt]').forEach((button) =>
       button.addEventListener('click', () => {
-        const input = document.getElementById('aiCommandInput');
-        input.value = button.dataset.aiPrompt;
+        document.getElementById('aiCommandInput').value = button.dataset.aiPrompt;
         routeCommand(button.dataset.aiPrompt);
       }),
     );
@@ -433,42 +480,51 @@
       .querySelectorAll('[data-companion-action]')
       .forEach((button) => button.addEventListener('click', () => performAction(button.dataset.companionAction)));
     document
+      .querySelectorAll('[data-scroll-target]')
+      .forEach((button) =>
+        button.addEventListener('click', () =>
+          document.getElementById(button.dataset.scrollTarget)?.scrollIntoView({ behavior: 'smooth' }),
+        ),
+      );
+    document
       .querySelectorAll('[data-simplify]')
       .forEach((button) => button.addEventListener('click', () => simplify(button.dataset.simplify)));
-    document.addEventListener('click', (event) => {
-      if (!event.target.closest('.search-result[role="option"]')) return;
-      window.setTimeout(() => document.querySelector('.music-player')?.scrollIntoView({ block: 'center' }), 50);
-    });
-    document.querySelectorAll('[data-creator-tool]').forEach((button) =>
-      button.addEventListener('click', () => {
-        const output = document.getElementById('aiCommandResponse');
-        output.textContent = `${button.textContent} is queued for Creator Studio. AI publishing tools are coming soon.`;
-        output.hidden = false;
-        document.getElementById('home')?.scrollIntoView({ behavior: 'smooth' });
-      }),
-    );
+    document
+      .querySelectorAll('[data-ask-africa]')
+      .forEach((button) => button.addEventListener('click', () => askAfrica(button.dataset.askAfrica)));
+    document.getElementById('radioLanguageFilter')?.addEventListener('change', renderStations);
+    document.getElementById('radioTypeFilter')?.addEventListener('change', renderStations);
   }
 
-  function refreshLibraryUi() {
+  function refresh() {
     renderStations();
     renderRecommendations();
     renderRecent();
     renderBriefing();
-  }
-  function init() {
-    bind();
-    renderCountryFilters();
-    renderMoods();
-    refreshLibraryUi();
-    initSmartRadioSearch();
-    initPersonality();
-    initReturningUser();
-    initLanguageMemory();
+    updateMetrics();
+    updateProfile();
   }
 
-  window.AriyoCompanion = { routeCommand, stationCountry, stationMeta, read, write };
+  function init() {
+    bind();
+    initLanguage();
+    renderCountryFilters();
+    renderMoods();
+    renderGraphPreview();
+    refresh();
+    const visits = Number(engine.safeRead('ariyo_intelligence_visits', 0));
+    engine.safeWrite('ariyo_intelligence_visits', visits + 1);
+    if (visits > 0) {
+      const message = document.getElementById('returningMessage');
+      message.textContent =
+        'Personalization cache restored. Your language, region, favorites, and listening history remain on this device.';
+      message.hidden = false;
+    }
+  }
+
+  window.AriyoCompanion = { routeCommand, askAfrica, playTrack, playStation, refresh };
   if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', init, { once: true });
   else init();
-  window.addEventListener('ariyo:library-ready', refreshLibraryUi);
-  window.addEventListener('ariyo:library-updated', refreshLibraryUi);
+  window.addEventListener('ariyo:library-ready', refresh);
+  window.addEventListener('ariyo:library-updated', refresh);
 })();

--- a/scripts/media-intelligence.js
+++ b/scripts/media-intelligence.js
@@ -1,0 +1,368 @@
+/**
+ * Ariyọ Media Intelligence Graph
+ * A dependency-free entity and relationship layer for cross-media discovery.
+ */
+(function () {
+  'use strict';
+
+  const STORAGE_KEYS = Object.freeze({
+    preferredLanguage: 'ariyo_preferred_language',
+    preferredRegion: 'ariyo_preferred_region',
+    favoriteTracks: 'ariyo_favorite_tracks',
+    favoriteStations: 'ariyo_favorite_stations',
+    recentTracks: 'ariyo_recent_tracks',
+    recentStations: 'ariyo_recent_stations',
+  });
+
+  const ENTITY_TYPES = Object.freeze([
+    'Artist',
+    'Track',
+    'Radio Station',
+    'Country',
+    'Language',
+    'Genre',
+    'Mood',
+    'Story',
+    'News Topic',
+    'User Preference',
+  ]);
+
+  const TRACK_PROFILES = Object.freeze([
+    {
+      match: /holy|oluwa|hail mary|worship|pastor/i,
+      genre: 'Gospel',
+      language: 'English',
+      region: 'Nigeria',
+      mood: 'Worship',
+      useCase: 'Faith and reflection',
+    },
+    {
+      match: /algorithm|forex|oil money|efcc|election|freedom|truth/i,
+      genre: 'Afro-conscious',
+      language: 'Nigerian Pidgin',
+      region: 'Nigeria',
+      mood: 'Reflection',
+      useCase: 'Ideas and analysis',
+    },
+    {
+      match: /party|detty|gbedu|stir|abula/i,
+      genre: 'Afrobeats',
+      language: 'Nigerian Pidgin',
+      region: 'Nigeria',
+      mood: 'Celebration',
+      useCase: 'Social energy',
+    },
+    {
+      match: /wisdom|kindness|omoluabi|ubuntu|home|mummy/i,
+      genre: 'Spoken Soul',
+      language: 'English',
+      region: 'Global Africa',
+      mood: 'Reflection',
+      useCase: 'Cultural grounding',
+    },
+    {
+      match: /working|risk|destiny|forerunner|motivation/i,
+      genre: 'Afro-inspirational',
+      language: 'English',
+      region: 'Nigeria',
+      mood: 'Motivation',
+      useCase: 'Momentum',
+    },
+  ]);
+
+  const STATION_PROFILES = Object.freeze([
+    {
+      match: /congo|kinshasa|lubumbashi|rdc/i,
+      country: 'Congo',
+      language: 'Lingala',
+      category: 'Music',
+      genre: 'Rumba',
+      mood: 'Evening Wind Down',
+      useCase: 'Cultural discovery',
+    },
+    {
+      match: /ghana|accra|kumasi/i,
+      country: 'Ghana',
+      language: 'English',
+      category: 'Music',
+      genre: 'Highlife',
+      mood: 'Celebration',
+      useCase: 'Regional discovery',
+    },
+    {
+      match: /kenya|nairobi|mombasa/i,
+      country: 'Kenya',
+      language: 'English',
+      category: 'Music',
+      genre: 'East African',
+      mood: 'Focus',
+      useCase: 'Daily listening',
+    },
+    {
+      match: /south africa|johannesburg|cape town|durban/i,
+      country: 'South Africa',
+      language: 'English',
+      category: 'Music',
+      genre: 'Amapiano',
+      mood: 'Celebration',
+      useCase: 'New sound discovery',
+    },
+    {
+      match: /cameroon|douala|yaound/i,
+      country: 'Cameroon',
+      language: 'French',
+      category: 'Music',
+      genre: 'Makossa',
+      mood: 'Celebration',
+      useCase: 'Francophone discovery',
+    },
+    {
+      match: /gospel|worship|christian/i,
+      country: 'Nigeria',
+      language: 'English',
+      category: 'Gospel',
+      genre: 'Gospel',
+      mood: 'Worship',
+      useCase: 'Faith and reflection',
+    },
+    {
+      match: /news|talk|bbc|radio nigeria|info/i,
+      country: 'Global Africa',
+      language: 'English',
+      category: 'News',
+      genre: 'News and Talk',
+      mood: 'Focus',
+      useCase: 'Current affairs',
+    },
+    {
+      match: /nigeria|naija|lagos|abuja|ibadan|enugu|kano|kaduna/i,
+      country: 'Nigeria',
+      language: 'English',
+      category: 'Music',
+      genre: 'Afrobeats',
+      mood: 'Motivation',
+      useCase: 'Daily listening',
+    },
+  ]);
+
+  const FALLBACK_STATIONS = Object.freeze([
+    { name: 'Naija Hits (Live)', location: 'Nigeria', url: 'https://stream.zeno.fm/thbqnu2wvmzuv', logo: 'Logo.jpg' },
+    {
+      name: 'Radio Nigeria',
+      location: 'Abuja, Nigeria',
+      url: 'https://stream.radionigeria.gov.ng/live',
+      logo: 'Logo.jpg',
+    },
+    {
+      name: 'BBC World Service',
+      location: 'Global Africa',
+      url: 'https://utulsa.streamguys1.com/KWGSHD3-MP3',
+      logo: 'Logo.jpg',
+    },
+    { name: 'Kinshasa Rumba Directory Preview', location: 'Kinshasa, Congo', logo: 'Logo.jpg' },
+    { name: 'Accra Highlife Directory Preview', location: 'Accra, Ghana', logo: 'Logo.jpg' },
+    { name: 'Nairobi Culture Directory Preview', location: 'Nairobi, Kenya', logo: 'Logo.jpg' },
+    { name: 'Johannesburg Amapiano Directory Preview', location: 'Johannesburg, South Africa', logo: 'Logo.jpg' },
+    { name: 'Douala Makossa Directory Preview', location: 'Douala, Cameroon', logo: 'Logo.jpg' },
+  ]);
+
+  function safeRead(key, fallback) {
+    try {
+      const value = JSON.parse(localStorage.getItem(key));
+      return value == null ? fallback : value;
+    } catch (_) {
+      return fallback;
+    }
+  }
+
+  function safeWrite(key, value) {
+    try {
+      localStorage.setItem(key, JSON.stringify(value));
+      return true;
+    } catch (_) {
+      return false;
+    }
+  }
+
+  function normalize(value) {
+    return String(value || '')
+      .trim()
+      .toLowerCase();
+  }
+
+  function unique(items, identity) {
+    const seen = new Set();
+    return items.filter((item) => {
+      const key = identity(item);
+      if (!key || seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    });
+  }
+
+  function inferProfile(value, profiles, fallback) {
+    const text = [value?.name, value?.title, value?.location, value?.country, value?.genre, value?.tags]
+      .filter(Boolean)
+      .join(' ');
+    return { ...fallback, ...(profiles.find((profile) => profile.match.test(text)) || {}) };
+  }
+
+  function stationMetadata(station) {
+    const fallback = {
+      country: 'Global Africa',
+      language: 'English',
+      category: 'Music',
+      genre: 'African Media',
+      mood: 'Focus',
+      useCase: 'Open discovery',
+    };
+    const profile = inferProfile(station, STATION_PROFILES, fallback);
+    const explicitCountry = station?.country || station?.location;
+    if (explicitCountry && /nigeria/i.test(explicitCountry)) profile.country = 'Nigeria';
+    return { ...profile, streamStatus: station?.url ? 'Available' : 'Unavailable' };
+  }
+
+  function trackMetadata(track, album) {
+    const fallback = {
+      genre: 'African Contemporary',
+      language: 'English',
+      region: 'Nigeria',
+      mood: 'Focus',
+      useCase: 'Daily listening',
+      duration: track?.duration || '—',
+    };
+    const profile = inferProfile(track, TRACK_PROFILES, fallback);
+    return { ...profile, artist: track?.artist || 'Omoluabi Productions', album: album?.name || 'Ariyọ Catalogue' };
+  }
+
+  function getStations() {
+    const direct = Array.isArray(window.radioStations) ? window.radioStations : [];
+    const merged = Array.isArray(window.mergedRadioStations) ? window.mergedRadioStations : [];
+    return unique([...merged, ...direct, ...FALLBACK_STATIONS], (station) => normalize(station.url || station.name));
+  }
+
+  function getTracks() {
+    const albums = Array.isArray(window.albums)
+      ? window.albums
+      : Array.isArray(window.libraryState?.local)
+        ? window.libraryState.local
+        : [];
+    return albums.flatMap((album, albumIndex) =>
+      (album.tracks || []).map((track, trackIndex) => ({
+        ...track,
+        album,
+        albumIndex,
+        trackIndex,
+        metadata: trackMetadata(track, album),
+      })),
+    );
+  }
+
+  function buildGraph() {
+    const tracks = getTracks();
+    const stations = getStations().map((station, stationIndex) => ({
+      ...station,
+      stationIndex,
+      metadata: stationMetadata(station),
+    }));
+    const node = (type, id, label, metadata = {}) => ({ type, id, label, metadata });
+    const nodes = [
+      ...tracks.map((track) =>
+        node('Track', `track:${normalize(track.src || track.title)}`, track.title, track.metadata),
+      ),
+      ...stations.map((station) =>
+        node('Radio Station', `station:${normalize(station.url || station.name)}`, station.name, station.metadata),
+      ),
+    ];
+    const dimensions = [
+      ['Country', [...tracks.map((t) => t.metadata.region), ...stations.map((s) => s.metadata.country)]],
+      ['Language', [...tracks.map((t) => t.metadata.language), ...stations.map((s) => s.metadata.language)]],
+      ['Genre', [...tracks.map((t) => t.metadata.genre), ...stations.map((s) => s.metadata.genre)]],
+      ['Mood', [...tracks.map((t) => t.metadata.mood), ...stations.map((s) => s.metadata.mood)]],
+    ];
+    dimensions.forEach(([type, values]) =>
+      unique(
+        values.filter(Boolean).map((label) => ({ label })),
+        (item) => normalize(item.label),
+      ).forEach(({ label }) => nodes.push(node(type, `${normalize(type)}:${normalize(label)}`, label))),
+    );
+    const edges = [];
+    tracks.forEach((track) =>
+      ['region', 'language', 'genre', 'mood'].forEach((key) =>
+        edges.push({
+          from: `track:${normalize(track.src || track.title)}`,
+          to: `${key === 'region' ? 'country' : key}:${normalize(track.metadata[key])}`,
+          relation: `HAS_${key.toUpperCase()}`,
+        }),
+      ),
+    );
+    stations.forEach((station) =>
+      ['country', 'language', 'genre', 'mood'].forEach((key) =>
+        edges.push({
+          from: `station:${normalize(station.url || station.name)}`,
+          to: `${key}:${normalize(station.metadata[key])}`,
+          relation: `HAS_${key.toUpperCase()}`,
+        }),
+      ),
+    );
+    return { entityTypes: ENTITY_TYPES, nodes, edges, tracks, stations };
+  }
+
+  function scoreMatch(sourceMetadata, targetMetadata, preferredLanguage) {
+    let score = 0;
+    if (normalize(sourceMetadata.language) === normalize(targetMetadata.language)) score += 4;
+    if (
+      normalize(sourceMetadata.region || sourceMetadata.country) ===
+      normalize(targetMetadata.region || targetMetadata.country)
+    )
+      score += 4;
+    if (normalize(sourceMetadata.genre) === normalize(targetMetadata.genre)) score += 3;
+    if (normalize(sourceMetadata.mood) === normalize(targetMetadata.mood)) score += 2;
+    if (preferredLanguage && normalize(targetMetadata.language) === normalize(preferredLanguage)) score += 2;
+    return score;
+  }
+
+  function recommendRelated(source, targetType, limit = 3) {
+    const graph = buildGraph();
+    const sourceMetadata =
+      source?.metadata || (source?.url ? stationMetadata(source) : trackMetadata(source, source?.album));
+    const candidates = targetType === 'station' ? graph.stations : graph.tracks;
+    const preferredLanguage = safeRead(STORAGE_KEYS.preferredLanguage, 'English');
+    return candidates
+      .map((candidate) => ({
+        ...candidate,
+        intelligenceScore: scoreMatch(sourceMetadata, candidate.metadata, preferredLanguage),
+      }))
+      .sort((a, b) => b.intelligenceScore - a.intelligenceScore)
+      .slice(0, limit);
+  }
+
+  function remember(key, item, identity, limit = 8) {
+    const existing = safeRead(key, []);
+    safeWrite(key, [item, ...existing.filter((entry) => identity(entry) !== identity(item))].slice(0, limit));
+  }
+
+  function toggleFavorite(key, item, identity) {
+    const existing = safeRead(key, []);
+    const id = identity(item);
+    const isFavorite = existing.some((entry) => identity(entry) === id);
+    const next = isFavorite ? existing.filter((entry) => identity(entry) !== id) : [item, ...existing];
+    safeWrite(key, next);
+    return !isFavorite;
+  }
+
+  window.AriyoMediaIntelligence = Object.freeze({
+    STORAGE_KEYS,
+    ENTITY_TYPES,
+    safeRead,
+    safeWrite,
+    stationMetadata,
+    trackMetadata,
+    getStations,
+    getTracks,
+    buildGraph,
+    recommendRelated,
+    remember,
+    toggleFavorite,
+  });
+})();

--- a/scripts/player.js
+++ b/scripts/player.js
@@ -3105,6 +3105,30 @@ function persistLastPlayed(payload) {
   writeStorageItem(localStorage, LAST_PLAYED_STORAGE_KEY, JSON.stringify(payload));
 }
 
+function loadPlayerState() {
+  try {
+    const rawState = readStorageItem(localStorage, PLAYER_STATE_STORAGE_KEY);
+    if (!rawState) return null;
+    const state = JSON.parse(rawState);
+    if (!state || typeof state !== 'object') return null;
+    return {
+      albumIndex: Number.isInteger(state.albumIndex) ? state.albumIndex : 0,
+      trackIndex: Number.isInteger(state.trackIndex) ? state.trackIndex : 0,
+      radioIndex: Number.isInteger(state.radioIndex) ? state.radioIndex : -1,
+      playbackPosition: Number.isFinite(state.playbackPosition) ? state.playbackPosition : 0,
+      position: Number.isFinite(state.position) ? state.position : 0,
+      title: typeof state.title === 'string' ? state.title : '',
+      trackId: typeof state.trackId === 'string' ? state.trackId : '',
+      shuffleState: state.shuffleState,
+      radioShuffleMode: Boolean(state.radioShuffleMode),
+      timestamp: Number.isFinite(state.timestamp) ? state.timestamp : 0,
+    };
+  } catch (error) {
+    debugConsole('Unable to restore player state:', error);
+    return null;
+  }
+}
+
 function savePlayerState() {
   const trackInfo = getActiveTrackInfo();
   const track = trackInfo?.track || null;

--- a/scripts/radioStations.js
+++ b/scripts/radioStations.js
@@ -343,17 +343,17 @@ async function validateRadioStations(stations) {
   return results;
 }
 
-function refreshMergedRadioStations() {
+function computeMergedRadioStations() {
   const globalStations = (typeof window !== 'undefined' && window.radioStations) || [];
   return mergeRadioStations(globalStations, radioStationsNew);
 }
 
-const mergedRadioStations = refreshMergedRadioStations();
+const mergedRadioStations = computeMergedRadioStations();
 
 if (typeof window !== 'undefined') {
   window.mergedRadioStations = mergedRadioStations;
   window.refreshMergedRadioStations = () => {
-    const nextMerged = refreshMergedRadioStations();
+    const nextMerged = computeMergedRadioStations();
     window.mergedRadioStations = nextMerged;
     return nextMerged;
   };


### PR DESCRIPTION
### Motivation

- Reposition the homepage and discovery layer to present Àríyò as an executive-grade “Media Intelligence Command Center” that unifies music, radio, news, stories, language, and creator tooling. 
- Add a local, dependency-free intelligence layer to enable cross-media recommendations and language-aware routing while preserving existing playback and app routes. 
- Surface professional, production-ready UI and metadata (language, mood, region, use-case) without adding binary assets and while fixing runtime issues discovered during browser testing.

### Description

- Added a reusable media-graph and utilities in `scripts/media-intelligence.js` exposing `window.AriyoMediaIntelligence` with `buildGraph`, `recommendRelated`, metadata inference, favorites/recents storage keys, and helper APIs. 
- Replaced the hero and discovery UX in `main.html` with an executive `Media Intelligence Command Center` and new sections: Live African Radio Intelligence, Music Intelligence Layer, African Media Briefing, Ask Africa, Language Intelligence, Cultural Knowledge, Creator Studio Foundation, and Technical Architecture Showcase. 
- Introduced a premium design system and responsive styles in `companion.css` (navy/gold/emerald), and adapted layout/controls for desktop and mobile. 
- Reworked `scripts/companion.js` to integrate the intelligence engine: intent routing (`routeCommand`), richer `renderStations`/`renderRecommendations`, mood filters, language persistence, Ask Africa synthesis, and local favorites/recents using `AriyoMediaIntelligence` storage keys. 
- Fixed two runtime issues: added `loadPlayerState()` to `scripts/player.js` to safely restore persisted player state, and replaced recursive merged-radio refresh by renaming to `computeMergedRadioStations()` in `scripts/radioStations.js`. 
- Kept all existing audio/radio/player entry points and integrations intact (`selectTrack`, `selectRadio`, chatbot, games, modals), and added graceful fallback station/briefing data and directory preview handling for non-stream directory entries.

### Testing

- Formatting and tooling: ran `npx prettier --write` and `npm run lint` with no blocking errors. 
- Unit tests: `npm test -- --runInBand` — 16 suites, 42 tests passed. 
- Validation and build: `npm run validate:release-years` (completed; reported existing catalogue metadata warnings) and `npm run build` — static build completed successfully. 
- Browser smoke checks: Playwright desktop and mobile checks verified `routeCommand` behavior, station and track cards, Ask Africa responses, language persistence, preserved `#audioPlayer`/chatbot/games/radio modal entry points, and no horizontal overflow at 390×844. 
- Visual proof: full-page browser screenshot captured (not committed to repo to avoid binary assets).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2caec5d10c833286fd000132ff13cc)