### PR TITLE
Repair mobile AI panel and YC responsive experience

### DIFF
--- a/companion.css
+++ b/companion.css
@@ -1324,3 +1324,215 @@
     transition: none;
   }
 }
+
+/* YC mobile stability repair */
+.companion-shell,
+.companion-section,
+.intelligence-hero,
+.hero-layout,
+.hero-primary,
+.metrics-panel,
+.radio-discovery-grid,
+.track-card-row,
+.briefing-grid,
+.architecture-grid {
+  width: 100%;
+  max-width: 100%;
+  min-width: 0;
+}
+
+.hero-primary h1,
+.hero-deck,
+.section-heading h2,
+.station-card h3,
+.track-card h3 {
+  overflow-wrap: anywhere;
+}
+
+@media (min-width: 768px) {
+  .edge-panel {
+    position: fixed !important;
+    top: 96px !important;
+    right: -420px;
+    bottom: auto !important;
+    left: auto !important;
+    width: min(420px, calc(100vw - 48px)) !important;
+    min-height: 0 !important;
+    max-height: calc(100dvh - 120px) !important;
+    overflow: hidden !important;
+    transform: none !important;
+    border-radius: 20px 0 0 20px !important;
+  }
+
+  .edge-panel.visible:not([data-position='peek']) {
+    right: 24px !important;
+  }
+
+  .edge-panel-content {
+    max-height: calc(100dvh - 238px) !important;
+    overflow-x: hidden !important;
+    overflow-y: auto !important;
+  }
+}
+
+@media (max-width: 767px) {
+  .companion-shell {
+    padding: 8px 8px calc(88px + env(safe-area-inset-bottom));
+  }
+
+  .intelligence-hero {
+    padding: 16px;
+  }
+
+  .hero-layout {
+    gap: 28px;
+    padding-top: 30px;
+  }
+
+  .hero-primary h1 {
+    max-width: 100%;
+    font-size: clamp(2.45rem, 12.5vw, 3.75rem);
+    line-height: 1.02;
+  }
+
+  .hero-deck {
+    margin: 18px 0 22px;
+    font-size: clamp(0.92rem, 4vw, 1.05rem);
+    line-height: 1.58;
+  }
+
+  .ai-command {
+    width: 100%;
+    max-width: 100%;
+  }
+
+  .prompt-rail {
+    width: 100%;
+    margin-right: 0;
+    padding-bottom: 4px;
+  }
+
+  .edge-panel {
+    position: fixed !important;
+    top: auto !important;
+    right: 12px !important;
+    bottom: calc(env(safe-area-inset-bottom) + 16px) !important;
+    left: 12px !important;
+    z-index: 9999 !important;
+    display: flex !important;
+    width: auto !important;
+    max-width: calc(100vw - 24px) !important;
+    min-height: 0 !important;
+    max-height: calc(100dvh - 96px) !important;
+    overflow: hidden !important;
+    border-radius: 24px !important;
+    opacity: 0 !important;
+    visibility: hidden;
+    transform: translateY(calc(100% + 32px)) !important;
+    transition:
+      transform 220ms ease,
+      opacity 180ms ease,
+      visibility 220ms ease !important;
+    pointer-events: none;
+  }
+
+  .edge-panel.visible:not([data-position='peek']) {
+    right: 12px !important;
+    opacity: 1 !important;
+    visibility: visible;
+    transform: translateY(0) !important;
+    pointer-events: auto;
+  }
+
+  .edge-panel[data-position='collapsed'],
+  .edge-panel[data-position='peek'] {
+    right: 12px !important;
+    opacity: 0 !important;
+    visibility: hidden;
+    transform: translateY(calc(100% + 32px)) !important;
+    pointer-events: none;
+  }
+
+  .edge-panel-handle {
+    display: none !important;
+  }
+
+  .edge-panel-header {
+    padding: 16px 16px 8px;
+  }
+
+  .edge-panel-content {
+    flex: 1 1 auto;
+    max-height: none !important;
+    min-height: 0;
+    padding: 8px 16px 18px !important;
+    overflow-x: hidden !important;
+    overflow-y: auto !important;
+    overscroll-behavior: contain;
+    opacity: 1 !important;
+    filter: none !important;
+    pointer-events: auto !important;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .edge-panel-list {
+    padding-bottom: 0 !important;
+  }
+
+  .edge-panel-privacy {
+    position: static !important;
+    flex: 0 0 auto;
+    margin: 0;
+    padding: 10px 16px 16px;
+  }
+
+  .mobile-companion-nav {
+    right: 8px;
+    bottom: calc(env(safe-area-inset-bottom) + 8px);
+    left: 8px;
+    grid-template-columns: repeat(5, minmax(0, 1fr));
+    width: auto;
+    max-width: calc(100vw - 16px);
+    padding: 6px;
+    overflow: hidden;
+    border-radius: 16px;
+  }
+
+  .mobile-companion-nav a,
+  .mobile-companion-nav button {
+    min-width: 0;
+    min-height: 44px;
+    padding: 3px 1px;
+    overflow: hidden;
+    font-size: clamp(0.48rem, 2.15vw, 0.58rem);
+    line-height: 1.05;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+  }
+
+  .mobile-companion-nav span {
+    font-size: clamp(0.66rem, 3vw, 0.78rem);
+  }
+
+  .mobile-companion-nav > :nth-child(4),
+  .mobile-companion-nav > :nth-child(5),
+  .mobile-companion-nav > :nth-child(8) {
+    display: none;
+  }
+}
+
+@media (max-width: 380px) {
+  .intelligence-hero {
+    padding: 13px;
+  }
+
+  .hero-primary h1 {
+    font-size: clamp(2.2rem, 12vw, 2.75rem);
+  }
+
+  .mobile-companion-nav {
+    right: 6px;
+    left: 6px;
+    max-width: calc(100vw - 12px);
+  }
+}

--- a/main.html
+++ b/main.html
@@ -2686,7 +2686,16 @@
       </div>
     </div>
 
-    <div class="edge-panel" id="edgePanel" aria-expanded="false">
+    <div class="edge-panel-backdrop" id="edgePanelBackdrop" aria-hidden="true"></div>
+    <div
+      class="edge-panel"
+      id="edgePanel"
+      role="dialog"
+      aria-modal="false"
+      aria-labelledby="edgePanelTitle"
+      aria-expanded="false"
+      aria-hidden="true"
+    >
       <div
         class="edge-panel-handle"
         role="button"
@@ -2695,8 +2704,17 @@
         aria-expanded="false"
         aria-controls="edgePanel"
       ></div>
+      <div class="edge-panel-header">
+        <div>
+          <p class="edge-panel-kicker">Ariyọ intelligence</p>
+          <h2 id="edgePanelTitle">Ask Ariyọ</h2>
+        </div>
+        <button class="edge-panel-close" id="edgePanelClose" type="button" aria-label="Close Ask Ariyọ panel">
+          <span aria-hidden="true">×</span>
+        </button>
+      </div>
       <div class="edge-panel-content">
-        <p class="edge-panel-intro">Quick launch hub</p>
+        <p class="edge-panel-intro">Choose an intelligence tool</p>
         <div class="edge-panel-list" role="list">
           <button
             class="edge-panel-item edge-panel-launcher"

--- a/scripts/companion.js
+++ b/scripts/companion.js
@@ -59,6 +59,8 @@
       else openPanel('ariyoChatbotContainer');
     } else if (action === 'creator') document.getElementById('create')?.scrollIntoView({ behavior: 'smooth' });
     else if (action === 'games') openPanel('gamesHubContainer');
+    else if (typeof window.openAriyoEdgePanel === 'function')
+      window.openAriyoEdgePanel({ trigger: document.activeElement, focusLaunchers: true });
     else openPanel('ariyoChatbotContainer');
   }
 

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1563,6 +1563,19 @@ const EDGE_PANEL_MIN_HEIGHT = 480;
 const updateEdgePanelHeight = () => {
   if (!mainEdgePanel || !mainEdgePanelContent) return;
 
+  if (window.matchMedia('(max-width: 767px)').matches) {
+    mainEdgePanel.style.removeProperty('height');
+    mainEdgePanel.style.removeProperty('top');
+    mainEdgePanel.style.removeProperty('right');
+    mainEdgePanel.style.removeProperty('bottom');
+    mainEdgePanel.style.removeProperty('transform');
+    mainEdgePanelContent.style.removeProperty('max-height');
+    mainEdgePanelContent.style.removeProperty('padding-bottom');
+    mainEdgePanelContent.style.removeProperty('scroll-padding-bottom');
+    mainEdgePanelContent.style.overflowY = 'auto';
+    return;
+  }
+
   const viewportHeight = window.visualViewport ? window.visualViewport.height : window.innerHeight;
   const computedRoot = getComputedStyle(rootElement);
   const topOffset = parseFloat(computedRoot.getPropertyValue('--edge-panel-top-offset')) || 24;

--- a/scripts/ui.js
+++ b/scripts/ui.js
@@ -1028,6 +1028,10 @@ function resetInactivityTimer() {
 
 const edgePanel = document.getElementById('edgePanel');
 const edgePanelHandle = edgePanel ? edgePanel.querySelector('.edge-panel-handle') : null;
+const edgePanelBackdrop = document.getElementById('edgePanelBackdrop');
+const edgePanelClose = document.getElementById('edgePanelClose');
+let edgePanelReturnFocus = null;
+const isMobileEdgePanel = () => window.matchMedia('(max-width: 767px)').matches;
 const focusFirstEdgePanelItem = () => {
   const firstItem = edgePanel?.querySelector('.edge-panel-item');
   if (firstItem) {
@@ -1102,29 +1106,35 @@ const computeEdgePanelOffsets = () => {
 const applyEdgePanelPosition = (state, { userInitiated = false } = {}) => {
   if (!edgePanel) return;
 
-  edgePanelState = state;
+  const mobile = isMobileEdgePanel();
+  const normalizedState = mobile && state === 'peek' ? 'collapsed' : state;
+  edgePanelState = normalizedState;
 
-  const isVisible = state === 'visible';
-  const isPeek = state === 'peek';
+  const isVisible = normalizedState === 'visible';
+  const isPeek = normalizedState === 'peek';
   const ariaExpanded = isVisible ? 'true' : 'false';
 
   edgePanel.setAttribute('aria-expanded', ariaExpanded);
-  if (edgePanelHandle) {
-    edgePanelHandle.setAttribute('aria-expanded', ariaExpanded);
+  edgePanel.setAttribute('aria-hidden', isVisible || !mobile ? 'false' : 'true');
+  edgePanel.setAttribute('aria-modal', mobile && isVisible ? 'true' : 'false');
+  if (edgePanelHandle) edgePanelHandle.setAttribute('aria-expanded', ariaExpanded);
+  if (edgePanelBackdrop) {
+    edgePanelBackdrop.classList.toggle('visible', isVisible);
+    edgePanelBackdrop.setAttribute('aria-hidden', isVisible ? 'false' : 'true');
   }
+  document.body.classList.toggle('edge-panel-open', isVisible);
 
   if (edgePanelPeekTimeoutId) {
     clearTimeout(edgePanelPeekTimeoutId);
     edgePanelPeekTimeoutId = null;
   }
 
-  if (isVisible || isPeek) {
-    edgePanel.classList.add('visible');
-  } else {
-    edgePanel.classList.remove('visible');
-  }
+  edgePanel.classList.toggle('visible', isVisible || isPeek);
 
-  if (isPeek) {
+  if (mobile) {
+    edgePanel.style.removeProperty('right');
+    edgePanel.dataset.position = isVisible ? 'open' : 'collapsed';
+  } else if (isPeek) {
     edgePanel.dataset.position = 'peek';
     edgePanel.style.right = `${EDGE_PANEL_PEEK_X}px`;
   } else if (isVisible) {
@@ -1135,22 +1145,21 @@ const applyEdgePanelPosition = (state, { userInitiated = false } = {}) => {
     edgePanel.style.right = `${EDGE_PANEL_COLLAPSED_X}px`;
   }
 
-  if (state === 'peek') {
+  if (isPeek) {
     edgePanelPeekTimeoutId = window.setTimeout(() => {
-      if (edgePanelState === 'peek') {
-        applyEdgePanelPosition('collapsed');
-      }
+      if (edgePanelState === 'peek') applyEdgePanelPosition('collapsed');
     }, EDGE_PANEL_PEEK_DURATION);
   }
 
   if (userInitiated) {
-    if (state === 'collapsed') {
-      edgePanelUserCollapsed = true;
-    } else if (state === 'visible') {
-      edgePanelUserCollapsed = false;
-    }
-  } else if (state === 'visible') {
+    edgePanelUserCollapsed = normalizedState === 'collapsed';
+  } else if (isVisible) {
     edgePanelUserCollapsed = false;
+  }
+
+  if (!isVisible && edgePanelReturnFocus instanceof HTMLElement) {
+    edgePanelReturnFocus.focus({ preventScroll: true });
+    edgePanelReturnFocus = null;
   }
 };
 
@@ -1176,18 +1185,30 @@ if (edgePanel && edgePanelHandle) {
     edgePanel.setAttribute('aria-expanded', 'false');
   }
   window.setTimeout(() => {
-    if (!edgePanelUserCollapsed) {
-      showEdgePanelPeek();
-    }
+    if (!isMobileEdgePanel() && !edgePanelUserCollapsed) showEdgePanelPeek();
   }, 600);
+
+  const openEdgePanel = ({ trigger = document.activeElement, focusLaunchers = false } = {}) => {
+    if (trigger instanceof HTMLElement) edgePanelReturnFocus = trigger;
+    applyEdgePanelPosition('visible', { userInitiated: true });
+    if (focusLaunchers) window.requestAnimationFrame(focusFirstEdgePanelItem);
+  };
+
+  window.openAriyoEdgePanel = openEdgePanel;
+  edgePanelBackdrop?.addEventListener('click', () => applyEdgePanelPosition('collapsed', { userInitiated: true }));
+  edgePanelClose?.addEventListener('click', () => applyEdgePanelPosition('collapsed', { userInitiated: true }));
+  document.addEventListener('keydown', (event) => {
+    if (event.key === 'Escape' && edgePanelState === 'visible') {
+      event.preventDefault();
+      applyEdgePanelPosition('collapsed', { userInitiated: true });
+    }
+  });
+
   const toggleEdgePanelVisibility = ({ userInitiated = false, focusLaunchers = false } = {}) => {
     if (edgePanelState === 'visible') {
       applyEdgePanelPosition('collapsed', { userInitiated });
     } else {
-      applyEdgePanelPosition('visible', { userInitiated });
-      if (focusLaunchers) {
-        focusFirstEdgePanelItem();
-      }
+      openEdgePanel({ focusLaunchers });
     }
   };
 
@@ -1274,6 +1295,7 @@ if (edgePanel && edgePanelHandle) {
 
   window.addEventListener('resize', () => {
     computeEdgePanelOffsets();
+    if (isMobileEdgePanel() && edgePanelState === 'peek') edgePanelState = 'collapsed';
     if (edgePanelState === 'peek') {
       applyEdgePanelPosition('peek');
     } else if (edgePanelState === 'visible') {

--- a/style.css
+++ b/style.css
@@ -3163,3 +3163,111 @@ body[data-theme='light'] .edge-panel-privacy a {
     transition: none !important;
   }
 }
+
+/* Viewport integrity: every application surface must remain inside the device width. */
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  width: 100%;
+  max-width: 100vw;
+  overflow-x: hidden;
+}
+
+body {
+  min-height: 100vh;
+  min-height: 100dvh;
+}
+
+body.edge-panel-open {
+  overflow: hidden;
+  overscroll-behavior: none;
+}
+
+.container,
+.content,
+main,
+section,
+article,
+header,
+footer,
+nav,
+img,
+video,
+canvas,
+svg,
+iframe {
+  max-width: 100%;
+}
+
+.edge-panel-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 9998;
+  visibility: hidden;
+  background: rgba(2, 8, 18, 0.72);
+  opacity: 0;
+  transition:
+    opacity 180ms ease,
+    visibility 180ms ease;
+  backdrop-filter: blur(4px);
+}
+
+.edge-panel-backdrop.visible {
+  visibility: visible;
+  opacity: 1;
+}
+
+.edge-panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1rem 1rem 0;
+}
+
+.edge-panel-kicker,
+.edge-panel-header h2 {
+  margin: 0;
+}
+
+.edge-panel-kicker {
+  color: #d4af37;
+  font-size: 0.62rem;
+  font-weight: 800;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.edge-panel-header h2 {
+  margin-top: 0.25rem;
+  color: #f8fafc;
+  font-size: 1.2rem;
+  letter-spacing: -0.02em;
+}
+
+.edge-panel-close {
+  display: grid;
+  flex: 0 0 42px;
+  place-items: center;
+  width: 42px;
+  height: 42px;
+  padding: 0;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 50%;
+  color: #f8fafc;
+  background: rgba(255, 255, 255, 0.07);
+  font: inherit;
+  font-size: 1.5rem;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.edge-panel-close:focus-visible {
+  outline: 2px solid #d4af37;
+  outline-offset: 3px;
+}


### PR DESCRIPTION
### Motivation
- Fix a broken mobile AI edge panel that overflowed/clipped the hero and caused horizontal scroll while preserving the executive YC positioning and existing media/chat/game functionality. 
- Ensure the AI panel is closed by default on small viewports and becomes a safe, accessible bottom sheet with backdrop and explicit close behavior. 
- Prevent legacy desktop drawer logic from overriding mobile layout and guarantee no content is hidden outside the viewport. 

### Description
- Reworked panel markup to add a backdrop, header and visible close control, and to expose `window.openAriyoEdgePanel` for programmatic opening while keeping the desktop drawer intact (files changed: `main.html`, `scripts/companion.js`).
- Implemented responsive panel state and accessibility: body scroll locking, focus restoration, backdrop and Escape dismissal, and suppression of automatic mobile peek (file changed: `scripts/ui.js`).
- Prevented the legacy dynamic-height/position logic from overriding mobile sheet layout by skipping desktop-only height adjustments on small viewports (file changed: `scripts/main.js`).
- Added global viewport/box-sizing safeguards and mobile/desktop CSS rules that create a viewport-safe bottom sheet on <768px and a capped 420px right-hand drawer on desktop, plus tightened hero typography and a safe-area-aware bottom navigation grid (files changed: `style.css`, `companion.css`).

### Testing
- Build: ran `npm run build` and the static production build completed successfully. 
- Unit tests: ran `npm test -- --runInBand` and all test suites passed (`16` suites, `42` tests). 
- Quality checks: ran `npm run lint` and `npx prettier --check` and code style/lint checks passed after formatting. 
- Responsive validation: executed a custom Playwright viewport check across `360x800`, `390x844`, `430x932`, `768x1024`, and `1440x1000` verifying no horizontal overflow, panel initial state closed on mobile, open/close via backdrop/Escape, panel fits inside each viewport, bottom nav bounds, and media/chat/game wiring; checks completed successfully and a mobile screenshot was examined (temporary artifacts were not committed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2cb58ece448332b571d13cc226d0f9)