### PR TITLE
Add Ask Ariyọ assistant edge panel UI, behaviors, and Playwright E2E tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ dist/
 coverage/
 playwright-report/
 test-results/
+
+# Generated visual verification artifacts
+artifacts/

--- a/companion.css
+++ b/companion.css
@@ -1536,3 +1536,269 @@
     max-width: calc(100vw - 12px);
   }
 }
+
+/* Assistant edge panel recovery: controlled sheet on mobile, drawer on desktop. */
+.edge-panel-backdrop.assistant-backdrop {
+  z-index: 90;
+  background: rgba(0, 0, 0, 0.55);
+}
+
+.edge-panel {
+  z-index: 100 !important;
+  box-sizing: border-box;
+}
+
+.floating-assistant-button {
+  position: fixed;
+  right: 24px;
+  bottom: 24px;
+  z-index: 70;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 48px;
+  padding: 0 18px;
+  border: 1px solid rgba(212, 175, 55, 0.58);
+  border-radius: 999px;
+  color: #07111f;
+  background: linear-gradient(135deg, #f4dc83, #d4af37);
+  box-shadow: 0 16px 40px rgba(0, 0, 0, 0.36);
+  font: inherit;
+  font-size: 0.8rem;
+  font-weight: 800;
+  cursor: pointer;
+}
+
+.floating-assistant-button:focus-visible {
+  outline: 3px solid #fff;
+  outline-offset: 3px;
+}
+
+.assistant-panel-body {
+  display: grid;
+  gap: 14px;
+  padding: 2px 0 18px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.assistant-status {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 0;
+  color: rgba(248, 250, 252, 0.68);
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.assistant-status span {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: #42d392;
+  box-shadow: 0 0 12px rgba(66, 211, 146, 0.8);
+}
+
+.assistant-panel-body h3 {
+  margin: 0;
+  color: #f8fafc;
+  font-size: clamp(1.15rem, 3vw, 1.35rem);
+  line-height: 1.25;
+  letter-spacing: -0.025em;
+}
+
+.assistant-greeting {
+  margin: 0;
+  color: rgba(226, 232, 240, 0.76);
+  font-size: 0.83rem;
+  line-height: 1.6;
+}
+
+.assistant-prompt-chips,
+.assistant-quick-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.assistant-prompt-chips button,
+.assistant-quick-actions button {
+  min-height: 36px;
+  padding: 7px 11px;
+  border: 1px solid rgba(212, 175, 55, 0.24);
+  border-radius: 999px;
+  color: #f8fafc;
+  background: rgba(255, 255, 255, 0.055);
+  font: inherit;
+  font-size: 0.7rem;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.assistant-prompt-chips button:hover,
+.assistant-quick-actions button:hover,
+.assistant-prompt-chips button:focus-visible,
+.assistant-quick-actions button:focus-visible {
+  border-color: rgba(212, 175, 55, 0.7);
+  background: rgba(212, 175, 55, 0.12);
+  outline: none;
+}
+
+.assistant-response {
+  min-height: 76px;
+  padding: 13px 14px;
+  border: 1px solid rgba(100, 181, 246, 0.18);
+  border-radius: 16px;
+  background: rgba(4, 12, 25, 0.68);
+}
+
+.assistant-response span {
+  color: #d4af37;
+  font-size: 0.62rem;
+  font-weight: 800;
+  letter-spacing: 0.1em;
+}
+
+.assistant-response p {
+  margin: 7px 0 0;
+  color: rgba(241, 245, 249, 0.86);
+  font-size: 0.78rem;
+  line-height: 1.5;
+}
+
+.assistant-command {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 44px;
+  gap: 8px;
+}
+
+.assistant-command input {
+  min-width: 0;
+  height: 44px;
+  padding: 0 14px;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 14px;
+  color: #fff;
+  background: rgba(255, 255, 255, 0.06);
+  font: inherit;
+  font-size: 0.78rem;
+}
+
+.assistant-command input:focus {
+  border-color: #d4af37;
+  outline: 2px solid rgba(212, 175, 55, 0.16);
+}
+
+.assistant-command button {
+  display: grid;
+  place-items: center;
+  width: 44px;
+  height: 44px;
+  padding: 0;
+  border: 0;
+  border-radius: 14px;
+  color: #07111f;
+  background: #d4af37;
+  font: inherit;
+  font-size: 1.25rem;
+  font-weight: 900;
+  cursor: pointer;
+}
+
+.mobile-companion-nav {
+  z-index: 60;
+}
+
+@media (max-width: 767px) {
+  .floating-assistant-button {
+    right: 16px;
+    bottom: calc(env(safe-area-inset-bottom) + 78px);
+    min-width: 48px;
+    padding: 0 14px;
+  }
+
+  .floating-assistant-button span:last-child {
+    display: none;
+  }
+
+  .edge-panel {
+    position: fixed !important;
+    right: 12px !important;
+    bottom: calc(env(safe-area-inset-bottom) + 16px) !important;
+    left: 12px !important;
+    width: auto !important;
+    max-width: calc(100vw - 24px) !important;
+    max-height: calc(100dvh - 96px) !important;
+    overflow: hidden !important;
+    border-radius: 24px !important;
+  }
+
+  .edge-panel-content {
+    overflow-y: auto !important;
+  }
+}
+
+@media (min-width: 768px) {
+  .edge-panel {
+    position: fixed !important;
+    top: 96px !important;
+    right: -420px;
+    width: 420px !important;
+    max-width: calc(100vw - 48px) !important;
+    max-height: calc(100dvh - 120px) !important;
+    overflow: hidden !important;
+    border-radius: 24px !important;
+  }
+
+  .edge-panel.visible:not([data-position='peek']) {
+    right: 24px !important;
+  }
+
+  .edge-panel-content {
+    overflow-y: auto !important;
+  }
+}
+
+/* Keep legacy high-z navigation/player surfaces beneath the assistant modal layer. */
+body.edge-panel-open .sidebar,
+body.edge-panel-open .music-player,
+body.edge-panel-open .header,
+body.edge-panel-open .floating-watermarks {
+  z-index: 50 !important;
+}
+
+body.edge-panel-open .mobile-companion-nav {
+  z-index: 60 !important;
+}
+
+.edge-panel,
+body[data-theme='light'] .edge-panel {
+  border: 1px solid rgba(212, 175, 55, 0.3) !important;
+  color: #f8fafc !important;
+  background: linear-gradient(165deg, #101d31 0%, #07111f 70%) !important;
+  box-shadow: 0 28px 80px rgba(0, 0, 0, 0.58) !important;
+}
+
+.edge-panel-content,
+body[data-theme='light'] .edge-panel-content {
+  color: #f8fafc;
+  background: transparent !important;
+}
+
+.app-update-banner[hidden],
+.notification-toast[hidden],
+.email-gate[hidden] {
+  display: none !important;
+  pointer-events: none !important;
+}
+
+@media (min-width: 768px) {
+  body.edge-panel-open #edgePanel {
+    right: 24px !important;
+    left: auto !important;
+    inset-inline-start: auto !important;
+    inset-inline-end: 24px !important;
+  }
+}

--- a/main.html
+++ b/main.html
@@ -2686,7 +2686,18 @@
       </div>
     </div>
 
-    <div class="edge-panel-backdrop" id="edgePanelBackdrop" aria-hidden="true"></div>
+    <button
+      class="floating-assistant-button"
+      id="floatingAssistantButton"
+      type="button"
+      data-companion-action="ai"
+      aria-controls="edgePanel"
+      aria-label="Open Ask Ariyọ assistant"
+    >
+      <span aria-hidden="true">✦</span>
+      <span>Ask Ariyọ</span>
+    </button>
+    <div class="edge-panel-backdrop assistant-backdrop" id="edgePanelBackdrop" aria-hidden="true"></div>
     <div
       class="edge-panel"
       id="edgePanel"
@@ -2714,7 +2725,41 @@
         </button>
       </div>
       <div class="edge-panel-content">
-        <p class="edge-panel-intro">Choose an intelligence tool</p>
+        <section class="assistant-panel-body" aria-labelledby="assistantGreeting">
+          <p class="assistant-status"><span aria-hidden="true"></span> Intelligence network ready</p>
+          <h3 id="assistantGreeting">Good to see you. What would you like to discover?</h3>
+          <p class="assistant-greeting">
+            I can help you move across African music, live radio, news, stories, language, and cultural knowledge.
+          </p>
+          <div class="assistant-prompt-chips" aria-label="Suggested questions">
+            <button type="button" data-panel-prompt="Recommend focus music">Focus music</button>
+            <button type="button" data-panel-prompt="Find live African radio">Live radio</button>
+            <button type="button" data-panel-prompt="Summarize African news">News briefing</button>
+            <button type="button" data-panel-prompt="Explore African cultural stories">Cultural stories</button>
+          </div>
+          <div class="assistant-response" id="assistantPanelResponse" role="status" aria-live="polite">
+            <span>ARIYỌ / READY</span>
+            <p>Choose a prompt or type a command. I’ll route you to the right intelligence experience.</p>
+          </div>
+          <form class="assistant-command" id="assistantPanelForm">
+            <label class="sr-only" for="assistantPanelInput">Ask Ariyọ AI</label>
+            <input
+              id="assistantPanelInput"
+              type="text"
+              autocomplete="off"
+              placeholder="Ask about African media, culture, or language…"
+            />
+            <button type="submit" aria-label="Send command"><span aria-hidden="true">→</span></button>
+          </form>
+          <div class="assistant-quick-actions" aria-label="Assistant destinations">
+            <button type="button" data-companion-action="radio">Radio</button>
+            <button type="button" data-companion-action="music">Music</button>
+            <button type="button" data-companion-action="news">News</button>
+            <button type="button" data-scroll-target="language">Language</button>
+            <button type="button" data-scroll-target="ask-africa">Ask Africa</button>
+          </div>
+        </section>
+        <p class="edge-panel-intro">More Ariyọ tools</p>
         <div class="edge-panel-list" role="list">
           <button
             class="edge-panel-item edge-panel-launcher"

--- a/scripts/companion.js
+++ b/scripts/companion.js
@@ -121,11 +121,12 @@
     } else {
       window.setTimeout(() => performAction('ai'), 550);
     }
-    const output = document.getElementById('aiCommandResponse');
-    if (output) {
+    const outputs = [document.getElementById('aiCommandResponse'), document.getElementById('assistantPanelResponse')];
+    outputs.forEach((output) => {
+      if (!output) return;
       output.innerHTML = `<span>${escapeHtml(route)}</span><p>${escapeHtml(response)}</p>`;
       output.hidden = false;
-    }
+    });
     const log = document.getElementById('routingLog');
     if (log) log.textContent = `${route}: ${text}`;
   }
@@ -470,12 +471,26 @@
   function bind() {
     document.getElementById('aiCommandForm')?.addEventListener('submit', (event) => {
       event.preventDefault();
+      performAction('ai');
       routeCommand(document.getElementById('aiCommandInput')?.value || '');
+    });
+    document.getElementById('assistantPanelForm')?.addEventListener('submit', (event) => {
+      event.preventDefault();
+      const input = document.getElementById('assistantPanelInput');
+      routeCommand(input?.value || '');
     });
     document.querySelectorAll('[data-ai-prompt]').forEach((button) =>
       button.addEventListener('click', () => {
         document.getElementById('aiCommandInput').value = button.dataset.aiPrompt;
+        performAction('ai');
         routeCommand(button.dataset.aiPrompt);
+      }),
+    );
+    document.querySelectorAll('[data-panel-prompt]').forEach((button) =>
+      button.addEventListener('click', () => {
+        const input = document.getElementById('assistantPanelInput');
+        if (input) input.value = button.dataset.panelPrompt;
+        routeCommand(button.dataset.panelPrompt);
       }),
     );
     document

--- a/scripts/ui.js
+++ b/scripts/ui.js
@@ -1195,6 +1195,7 @@ if (edgePanel && edgePanelHandle) {
   };
 
   window.openAriyoEdgePanel = openEdgePanel;
+  edgePanel.addEventListener('click', (event) => event.stopPropagation());
   edgePanelBackdrop?.addEventListener('click', () => applyEdgePanelPosition('collapsed', { userInitiated: true }));
   edgePanelClose?.addEventListener('click', () => applyEdgePanelPosition('collapsed', { userInitiated: true }));
   document.addEventListener('keydown', (event) => {

--- a/tests/assistant-panel.e2e.js
+++ b/tests/assistant-panel.e2e.js
@@ -1,0 +1,64 @@
+const { test, expect } = require('@playwright/test');
+
+test.describe('Ask Ariyọ assistant edge panel', () => {
+  test.use({ viewport: { width: 390, height: 844 } });
+
+  test('opens as a viewport-safe mobile sheet and closes from the backdrop', async ({ page }) => {
+    await page.goto('/main.html');
+
+    const panel = page.locator('#edgePanel');
+    const backdrop = page.locator('#edgePanelBackdrop');
+
+    await expect(panel).toHaveAttribute('aria-hidden', 'true');
+    await page.getByRole('button', { name: 'Ask Ariyọ', exact: true }).first().click();
+
+    await expect(panel).toHaveClass(/visible/);
+    await expect(panel).toHaveAttribute('aria-hidden', 'false');
+    await expect(
+      page.getByRole('heading', { name: 'Good to see you. What would you like to discover?' }),
+    ).toBeVisible();
+    await expect(page.locator('#assistantPanelInput')).toBeVisible();
+    await expect(backdrop).toHaveClass(/visible/);
+
+    const bounds = await panel.boundingBox();
+    expect(bounds).not.toBeNull();
+    expect(bounds.x).toBeGreaterThanOrEqual(11);
+    expect(bounds.x + bounds.width).toBeLessThanOrEqual(379);
+    expect(bounds.y).toBeGreaterThanOrEqual(0);
+    expect(bounds.y + bounds.height).toBeLessThanOrEqual(844);
+
+    await backdrop.click({ position: { x: 4, y: 4 } });
+    await expect(panel).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  test('opens from the floating trigger and keeps assistant commands functional', async ({ page }) => {
+    await page.goto('/main.html');
+
+    await page.getByRole('button', { name: 'Open Ask Ariyọ assistant' }).click();
+    await page.locator('#assistantPanelInput').fill('Recommend focus music');
+    await page.locator('#assistantPanelForm').getByRole('button', { name: 'Send command' }).click();
+
+    await expect(page.locator('#assistantPanelResponse')).toContainText('MUSIC / FOCUS');
+    await expect(page.locator('#edgePanelClose')).toBeVisible();
+    await page.locator('#edgePanelClose').click();
+    await expect(page.locator('#edgePanel')).toHaveAttribute('aria-hidden', 'true');
+  });
+});
+
+test('opens as a bounded desktop drawer above the backdrop', async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 900 });
+  await page.goto('/main.html');
+
+  await page.getByRole('button', { name: 'Open Ask Ariyọ assistant' }).click();
+  const panel = page.locator('#edgePanel');
+  await expect(panel).toHaveCSS('right', '24px');
+  const bounds = await panel.boundingBox();
+
+  expect(bounds).not.toBeNull();
+  expect(bounds.width).toBeLessThanOrEqual(420);
+  expect(bounds.x + bounds.width).toBeLessThanOrEqual(1280);
+  expect(bounds.y + bounds.height).toBeLessThanOrEqual(900);
+  await expect(panel).toHaveCSS('z-index', '100');
+  await expect(page.locator('#edgePanelBackdrop')).toHaveCSS('z-index', '90');
+  await expect(page.locator('#edgePanelClose')).toBeVisible();
+});


### PR DESCRIPTION
### Motivation

- Introduce a responsive, accessible assistant (Ask Ariyọ) panel with a floating trigger so users can discover AI-driven navigation for music, radio, news and cultural knowledge across mobile and desktop viewports.
- Ensure the assistant sits above legacy high-z surfaces, respects viewport safe-area insets, and provides quick prompts and command input for routing within the app.

### Description

- Added `artifacts/` to `.gitignore` to exclude generated visual verification artifacts.
- Implemented assistant styles in `companion.css` including a floating trigger, panel/backdrop styling, responsive mobile sheet and desktop drawer layout, z-index rules, and component tokens for prompts, responses and commands.
- Injected assistant markup and UI into `main.html` by adding the floating button and an `edge-panel` section with welcoming copy, prompt chips, quick actions and a command form.
- Extended `scripts/companion.js` to update command routing output to write to the new assistant panel, wire the `assistantPanelForm` submit handler, add prompt button bindings, and ensure `performAction('ai')` is invoked at appropriate trigger points.
- Tweaked `scripts/ui.js` to prevent clicks inside the `edge-panel` from propagating to the backdrop so the panel does not close unintentionally.
- Added Playwright end-to-end tests in `tests/assistant-panel.e2e.js` that validate mobile sheet behavior, floating-trigger command flow, and desktop drawer bounds and z-index layering.

### Testing

- Ran the new Playwright E2E spec `tests/assistant-panel.e2e.js` which covers mobile sheet open/close, command submission from the floating button, and desktop drawer layout and z-index checks, and the tests passed locally via `npx playwright test tests/assistant-panel.e2e.js`.
- Existing UI flows that interact with the edge panel were exercised by the E2E tests and showed expected routing output in the panel.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2cbae435fc833295621842fab6ecf5)