### PR TITLE
docs: plug repository into GeoAware OS

### DIFF
--- a/.geoaware/constitution.json
+++ b/.geoaware/constitution.json
@@ -1,0 +1,52 @@
+{
+  "schemaVersion": "1.0.0",
+  "extends": {
+    "name": "GeoAware OS",
+    "version": "1.0.0",
+    "source": "https://github.com/Omoluabi1003/GeoAware-OS",
+    "inherits": ["GDL", "GEC", "GPC", "GAIC", "GDS"]
+  },
+  "founder": {
+    "name": "Paul Iyogun",
+    "title": "Founder and Chief Architect",
+    "organization": "ETL GIS Consulting LLC"
+  },
+  "localProductMission": "Àríyò AI delivers a calm, culturally rich Nigerian music and assistant experience that guides discovery through accessible playback, curated storytelling, and lightweight PWA interactions.",
+  "governanceMode": "documentation-only",
+  "applicationBehavior": {
+    "sourceCodeChangesRequired": false,
+    "dependenciesRequired": false,
+    "uiBehaviorChangesRequired": false
+  },
+  "designPrinciples": [
+    {
+      "name": "Geography-first context",
+      "description": "Design decisions should respect place, culture, and local meaning before adding technical complexity."
+    },
+    {
+      "name": "Calm guidance",
+      "description": "Technology should quietly guide discovery without overwhelming the user or competing with the content."
+    },
+    {
+      "name": "Cultural continuity",
+      "description": "Product experiences should preserve founder attribution, community memory, and culturally grounded storytelling."
+    },
+    {
+      "name": "Restraint by default",
+      "description": "Prefer focused, coherent interactions over unnecessary features, motion, or visual noise."
+    },
+    {
+      "name": "Accessible discovery",
+      "description": "Core journeys should remain inclusive, understandable, and navigable across devices and abilities."
+    }
+  ],
+  "qualityGate": {
+    "requires": [
+      "performance",
+      "accessibility",
+      "restraint",
+      "product coherence"
+    ],
+    "description": "Changes should preserve application performance, accessibility, restrained interaction design, and coherence with the Àríyò AI product mission."
+  }
+}

--- a/README.md
+++ b/README.md
@@ -87,6 +87,10 @@
   - Extend structured data with `MusicRecording` and `RadioStation` schema for SEO.
   - Maintain offline support while keeping audio network-first to prevent large cache bloat.
 
+## GeoAware OS Governance
+
+This repository follows GeoAware OS v1.0.0, a design and engineering philosophy founded by Paul Iyogun for calm, geography-first digital experiences where technology quietly guides discovery. Governance metadata is maintained in `.geoaware/constitution.json` and extends the GeoAware OS source at <https://github.com/Omoluabi1003/GeoAware-OS>.
+
 ## Technologies Used
 
 - HTML


### PR DESCRIPTION
### Motivation

- Add GeoAware OS governance metadata to the repository to record adherence to GeoAware OS v1.0.0 and preserve founder attribution without changing application behavior.
- Provide a lightweight, documentation-only constitution file that captures the local product mission, design principles, and a quality gate focused on performance, accessibility, restraint, and product coherence.

### Description

- Create `.geoaware/constitution.json` that extends GeoAware OS v1.0.0 and references `https://github.com/Omoluabi1003/GeoAware-OS` while preserving founder attribution to Paul Iyogun and including the local Àríyò AI mission.
- Include `governanceMode: "documentation-only"` and explicit flags indicating no source-code, dependency, or UI behavior changes are required.
- Add GeoAware design principles and a `qualityGate` requiring `performance`, `accessibility`, `restraint`, and `product coherence` in the constitution file.
- Update `README.md` with a short "GeoAware OS Governance" section that references the new `.geoaware/constitution.json` and preserves all existing README content.

### Testing

- Validate the constitution file is well-formed JSON with `python -m json.tool .geoaware/constitution.json`, which succeeded.
- Run the Jest suite with `npm test -- --runInBand`, which completed successfully with 16 test suites and 42 tests passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d52aa9d7c8332b2e8fdfedc6d1348)